### PR TITLE
Fix: Resolve ModuleNotFoundError on startup

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -11,6 +11,9 @@ message('Python install dir: ' + python_install_dir)
 site_packages_dir = python_bin.get_install_dir(subdir: 'woes')
 message('Site packages dir: ' + site_packages_dir)
 
+# Create a new configuration variable for the site-packages directory
+python_site_packages_dir = python_bin.get_install_dir()
+
 # Define paths
 localedir = join_paths(get_option('prefix'), 'share', 'locale')
 pkgdatadir = join_paths(get_option('prefix'), 'share', 'woes')
@@ -24,6 +27,7 @@ conf.set('PYTHON', python_bin.full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('LOCALEDIR', localedir)
 conf.set('WOESDIR', site_packages_dir)
+conf.set('PYTHON_SITE_PACKAGES_DIR', python_site_packages_dir)
 conf.set('APPID', meson.project_name())
 conf.set('GSETTINGSSCHEMADIR', gsettings_schemadir) # Add this line
 

--- a/src/woes.in
+++ b/src/woes.in
@@ -35,6 +35,7 @@ VERSION = "@VERSION@"
 DATA_DIR = "@DATADIR@"
 APP_ID = "@APPID@"
 PKG_DATA_DIR = "@PKGDATADIR@"
+PYTHON_SITE_PACKAGES_DIR = "@PYTHON_SITE_PACKAGES_DIR@"
 GSETTINGS_SCHEMA_DIR = "@GSETTINGSSCHEMADIR@"
 LOCALE_DIR = "@LOCALEDIR@"
 
@@ -42,7 +43,7 @@ print("APP_ID: ", APP_ID)
 print("VERSION: ", VERSION)
 print("GSETTINGS_SCHEMA_DIR: ", GSETTINGS_SCHEMA_DIR)
 
-sys.path.insert(1, PKG_DATA_DIR)
+sys.path.insert(1, PYTHON_SITE_PACKAGES_DIR)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 # Use gettext on macOS, otherwise bindtext


### PR DESCRIPTION
The application was failing to start due to a ModuleNotFoundError. This was caused by an incorrect path being added to sys.path for locating the 'woes' Python module.

This commit modifies:
- src/meson.build: To pass the correct Python site-packages directory (where the module is installed) to the main script.
- src/woes.in: To use this correct site-packages directory in sys.path, allowing the 'woes' module to be found.

Note: Full build and test verification of this fix was prevented by issues encountered in the build environment related to the pygobject-3.0 dependency. You will need to pull and test these changes in your own environment.