### PR TITLE
Fix: Add webscan_page.py to meson build sources

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -81,6 +81,7 @@ woes_sources = files(
   'preferences.py',
   'style_utils.py',
   'window.py',
+  'webscan_page.py',
 )
 
 # Install the Python source files


### PR DESCRIPTION
The file `webscan_page.py` was missing from the `woes_sources` list in `src/meson.build`. This caused the file to not be installed with the rest of the package, leading to a `ModuleNotFoundError` when `woes/__init__.py` tried to import it using `from .webscan_page import WebScanPage`.

This change adds `webscan_page.py` to the list, ensuring it is installed and resolving the import error.