### PR TITLE
Fix: Resolve UI errors in WebScanPage and its integration

### DIFF
--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -10,7 +10,6 @@
         <child>
           <object class="AdwEntryRow" id="url_entry">
             <property name="title">Target URL</property>
-            <property name="placeholder-text">e.g., http://example.com</property>
           </object>
         </child>
         <child>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -119,21 +119,7 @@
                 <property name="child">
                   <object class="AdwClampScrollable" id="webscan_clamp_scrollable">
                     <child>
-                      <object class="AdwStatusPage" id="webscan_status_page">
-                        <property name="icon-name" bind-source="webscan_page" bind-property="icon-name" bind-flags="sync-create">org.gnome.Loupe-symbolic</property>
-                        <property name="title" bind-source="webscan_page" bind-property="title" bind-flags="sync-create">Web Scanner</property>
-                        <property name="child">
-                          <object class="GtkBox" id="webscan_box">
-                            <property name="orientation">vertical</property>
-                            <property name="valign">fill</property> <!-- Changed from center to fill -->
-                            <property name="halign">fill</property> <!-- Added halign fill -->
-                            <property name="vexpand">True</property> <!-- Added vexpand -->
-                            <child>
-                              <object class="WebScanPage"/>
-                            </child>
-                          </object>
-                        </property>
-                      </object>
+      <object class="WebScanPage"/>
                     </child>
                   </object>
                 </property>

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk, Adw, Gio, GLib
 
 import subprocess
 
-@Gtk.Template(filename='src/gtk/webscan_page.ui')
+@Gtk.Template(filename='/com/github/mclellac/WebOpsEvaluationSuite/gtk/webscan_page.ui')
 class WebScanPage(Adw.PreferencesPage):
     __gtype_name__ = 'WebScanPage'
 

--- a/src/woes.gresource.xml
+++ b/src/woes.gresource.xml
@@ -7,6 +7,7 @@
     <file preprocess="xml-stripblanks">gtk/dns_page.ui</file>
     <file preprocess="xml-stripblanks">gtk/preferences.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
+    <file preprocess="xml-stripblanks">gtk/webscan_page.ui</file>
     <file compressed="true">gtk/style.css</file>
     <file compressed="true">gtk/style-dark.css</file>
     <file preprocess="xml-stripblanks">../data/icons/hicolor/symbolic/emotes/face-angel-symbolic.svg</file>


### PR DESCRIPTION
This commit addresses several UI-related issues for WebScanPage:

1.  Fix AdwStatusPage warnings: The `WebScanPage` (an AdwPreferencesPage) was incorrectly nested within an AdwStatusPage and GtkBox inside an AdwClampScrollable in `window.ui`. This caused warnings as AdwClampScrollable attempted to apply scroll properties to the AdwStatusPage. The hierarchy has been simplified by making WebScanPage the direct child of AdwClampScrollable.

2.  Fix AdwEntryRow.placeholder-text error: Removed the invalid `placeholder-text` property from the `AdwEntryRow` in `webscan_page.ui` as it's not a valid property, fixing a Gtk-CRITICAL error during template parsing.

3.  Fix RuntimeError for on_scan_button_clicked handler: The `webscan_page.ui` file was not included in the GResource bundle (`woes.gresource.xml`), and `webscan_page.py` was referencing it using a relative file path. This caused the template not to load correctly, leading to a RuntimeError because the `on_scan_button_clicked` handler couldn't be found in the template.
    - `gtk/webscan_page.ui` has been added to `woes.gresource.xml`.
    - `webscan_page.py` now uses the correct GResource path for the template filename.