### PR TITLE
Fix: Correct application ID, paths, and PyGI warnings

### DIFF
--- a/com.github.mclellac.woes.json
+++ b/com.github.mclellac.woes.json
@@ -1,5 +1,5 @@
 {
-  "app-id": "com.github.mclellac.WebOpsEvaluationSuite",
+  "app-id": "com.github.mclellac.woes",
   "runtime": "org.gnome.Platform",
   "runtime-version": "master",
   "sdk": "org.gnome.Sdk",

--- a/data/com.github.mclellac.woes.desktop.in
+++ b/data/com.github.mclellac.woes.desktop.in
@@ -1,7 +1,8 @@
 [Desktop Entry]
-Name=woes
+Name=Woes
+Comment=Web Operations Evaluation Suite
 Exec=woes
-Icon=com.github.mclellac.WebOpsEvaluationSuite
+Icon=com.github.mclellac.woes
 Terminal=false
 Type=Application
 Categories=Network;

--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="woes">
-  <schema id="com.github.mclellac.WebOpsEvaluationSuite"
-    path="/com/github/mclellac/WebOpsEvaluationSuite/">
+  <schema id="com.github.mclellac.woes"
+    path="/com/github/mclellac/woes/">
     <key name="font-size" type="i">
       <default>12</default>
       <range min="8" max="24" />
@@ -26,4 +26,3 @@
     </key>
   </schema>
 </schemalist>
-

--- a/data/com.github.mclellac.woes.metainfo.xml.in
+++ b/data/com.github.mclellac.woes.metainfo.xml.in
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>com.github.mclellac.WebOpsEvaluationSuite.desktop</id>
+  <id>com.github.mclellac.woes.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
-  <name>WebOps Evaluation Suite</name>
+  <name>Woes</name>
   <summary>Web server and HTTP request analysis tools</summary>
   <description>
     <p>
-      WebOps Evaluation Suite is a collection of utilities for testing and analyzing web servers, including HTTP request and response analysis, performance benchmarking, and security auditing.
+      Woes is a collection of utilities for testing and analyzing web servers, including HTTP request and response analysis, performance benchmarking, and security auditing.
     </p>
     <p>
       The suite provides a comprehensive set of tools for web developers and administrators to evaluate and improve their web servers' performance and security.
@@ -16,4 +16,3 @@
   <url type="homepage">https://github.com/mclellac/woes</url>
   <update_contact>careymclelland_at_gmail.com</update_contact>
 </component>
-

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,4 +1,4 @@
-application_id = 'com.github.mclellac.WebOpsEvaluationSuite'
+application_id = 'com.github.mclellac.woes'
 
 # Install the scalable application icon
 scalable_dir = 'hicolor' / 'scalable' / 'apps'

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,6 @@
 desktop_file = i18n.merge_file(
-    input: 'com.github.mclellac.WebOpsEvaluationSuite.desktop.in',
-    output: 'com.github.mclellac.WebOpsEvaluationSuite.desktop',
+    input: 'com.github.mclellac.woes.desktop.in',
+    output: 'com.github.mclellac.woes.desktop',
     type: 'desktop',
     po_dir: '../po',
     install: true,
@@ -13,8 +13,8 @@ if desktop_utils.found()
 endif
 
 appstream_file = i18n.merge_file(
-    input: 'com.github.mclellac.WebOpsEvaluationSuite.metainfo.xml.in',
-    output: 'com.github.mclellac.WebOpsEvaluationSuite.metainfo.xml',
+    input: 'com.github.mclellac.woes.metainfo.xml.in',
+    output: 'com.github.mclellac.woes.metainfo.xml',
     po_dir: '../po',
     install: true,
     install_dir: get_option('datadir') / 'metainfo'
@@ -26,7 +26,7 @@ test('Validate appstream file', appstreamcli,
 
 # Install the schema file
 install_data(
-    'com.github.mclellac.WebOpsEvaluationSuite.gschema.xml',
+    'com.github.mclellac.woes.gschema.xml',
     install_dir: get_option('datadir') / 'glib-2.0' / 'schemas'
 )
 

--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@ icondir = join_paths(datadir, 'icons', 'hicolor')
 schemadir = join_paths(datadir, 'glib-2.0', 'schemas')
 
 # Application metadata and directories
-default_pkgappid = 'com.github.mclellac.WebOpsEvaluationSuite'
+default_pkgappid = 'com.github.mclellac.woes'
 pkgappid = default_pkgappid
 appdatadir = join_paths(datadir, 'metainfo')
 desktopdir = join_paths(datadir, 'applications')

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,6 +1,6 @@
-data/com.github.mclellac.WebOpsEvaluationSuite.desktop.in
-data/com.github.mclellac.WebOpsEvaluationSuite.metainfo.xml.in
-data/com.github.mclellac.WebOpsEvaluationSuite.gschema.xml
+data/com.github.mclellac.woes.desktop.in
+data/com.github.mclellac.woes.metainfo.xml.in
+data/com.github.mclellac.woes.gschema.xml
 src/main.py
 src/window.py
 src/window.ui

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,5 @@
-APP_ID = "com.github.mclellac.WebOpsEvaluationSuite"
-RESOURCE_PREFIX = "/com/github/mclellac/WebOpsEvaluationSuite/gtk"
+APP_ID = "com.github.mclellac.woes"
+RESOURCE_PREFIX = "/com/github/mclellac/woes/gtk"
 THEME_LIGHT = "style.css"
 THEME_DARK = "style-dark.css"
 VERSION = "0.2.0"

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -4,6 +4,11 @@ from datetime import datetime
 
 import dns.resolver
 import dns.reversename
+
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
+gi.require_version('GtkSource', '5')
 from gi.repository import Adw, Gio, Gtk, GtkSource, Pango
 
 from .constants import RESOURCE_PREFIX, APP_ID

--- a/src/helper.py
+++ b/src/helper.py
@@ -1,3 +1,5 @@
+import gi
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gdk, Gtk
 
 

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -3,6 +3,10 @@ from typing import Dict, Optional
 from urllib.parse import urlparse
 
 import requests
+
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Adw, Gio, GObject, Gtk
 
 from .constants import RESOURCE_PREFIX

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -2,6 +2,11 @@ import logging
 import functools # For functools.partial with GLib.idle_add
 
 import nmap
+
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
+gi.require_version('GtkSource', '5')
 from gi.repository import Adw, Gio, GLib, GObject, Gtk, GtkSource
 
 from .constants import RESOURCE_PREFIX, APP_ID # Import APP_ID

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -1,5 +1,9 @@
 import logging
 import re
+
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Adw, Gio, Gtk, GLib
 
 from .constants import APP_ID, RESOURCE_PREFIX

--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -1,5 +1,9 @@
 import logging
 
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
+gi.require_version('GtkSource', '5')
 from gi.repository import Adw, Gdk, Gio, Gtk, GtkSource
 
 

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -6,7 +6,9 @@ from gi.repository import Gtk, Adw, Gio, GLib
 import subprocess
 import logging
 
-@Gtk.Template(filename='/com/github/mclellac/WebOpsEvaluationSuite/gtk/webscan_page.ui')
+from .constants import RESOURCE_PREFIX # Import RESOURCE_PREFIX
+
+@Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/webscan_page.ui") # Use resource_path and constant
 class WebScanPage(Adw.PreferencesPage):
     __gtype_name__ = 'WebScanPage'
 

--- a/src/window.py
+++ b/src/window.py
@@ -1,5 +1,8 @@
 import logging
 
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Adw, Gdk, Gio, Gtk
 
 from . import DNSPage, HttpPage, NmapPage, WebScanPage

--- a/src/woes.gresource.xml
+++ b/src/woes.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/com/github/mclellac/WebOpsEvaluationSuite">
+  <gresource prefix="/com/github/mclellac/woes">
     <file preprocess="xml-stripblanks">gtk/window.ui</file>
     <file preprocess="xml-stripblanks">gtk/http_page.ui</file>
     <file preprocess="xml-stripblanks">gtk/nmap_page.ui</file>
@@ -26,4 +26,3 @@
     <file preprocess="xml-stripblanks">../data/icons/hicolor/symbolic/actions/globe-alt-symbolic.svg</file>
   </gresource>
 </gresources>
-


### PR DESCRIPTION
This commit addresses feedback regarding the application's identity and resource handling:

1.  **Application ID and Naming:**
    *   Renamed all instances of `com.github.mclellac.WebOpsEvaluationSuite` to `com.github.mclellac.woes`.
    *   Updated user-visible names from "WebOpsEvaluationSuite" to "Woes".
    *   This includes changes to:
        - `APP_ID` in `src/constants.py`.
        - GResource XML paths in `src/woes.gresource.xml`.
        - `@Gtk.Template` decorator paths in Python source files (via `RESOURCE_PREFIX` update).
        - Build system files (`meson.build`, `data/meson.build`).
        - Packaging files (`.desktop.in`, `.gschema.xml`, `.metainfo.xml.in`, Flatpak JSON).
        - `po/POTFILES`.

2.  **Resource Path Consistency:**
    *   Ensured `RESOURCE_PREFIX` in `src/constants.py` (`/com/github/mclellac/woes/gtk`) aligns with the GResource structure (`/com/github/mclellac/woes/` prefix with `gtk/...` paths inside).

3.  **PyGI Warnings:**
    *   Added or ensured correct placement of `gi.require_version()` calls in all relevant Python files within `src/` (e.g., `http_page.py`, `dns_page.py`, `nmap_page.py`, `window.py`, etc.) before `gi.repository` imports. This resolves warnings about modules like Adw and GtkSource being imported without a version specified.

**Build Environment Note:**
During the testing phase, I encountered issues building the application due to a missing `pygobject-3.0.pc` file in the provided build environment. This prevented a full `meson build` and runtime test cycle. The code changes have been made based on static analysis and adherence to your requirements, but a successful build in a correctly configured environment will be necessary to fully verify.