### PR TITLE
Configure application for minimal startup test.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,8 @@ from gi.repository import Adw, Gio, GLib # Added GLib for OptionArg/OptionFlags
 
 from .constants import APP_ID, VERSION
 from .preferences import Preferences
-from .window import WoesWindow
+# from .window import WoesWindow
+from .minimal_window import MinimalWoesWindow
 
 class WoesApplication(Adw.Application):
     """The main application singleton class."""
@@ -46,9 +47,9 @@ class WoesApplication(Adw.Application):
         # Create actions and set accelerators
         self.create_action("quit", lambda *_: self.quit(), ["<primary>q"])
         self.create_action("about", self.on_about_action)
-        self.create_action("preferences", self.on_preferences_action)
-        self.create_action("switch-to-http", self.switch_to_http, ["<primary>1"])
-        self.create_action("switch-to-nmap", self.switch_to_nmap, ["<primary>2"])
+        # self.create_action("preferences", self.on_preferences_action)
+        # self.create_action("switch-to-http", self.switch_to_http, ["<primary>1"])
+        # self.create_action("switch-to-nmap", self.switch_to_nmap, ["<primary>2"])
 
     def do_handle_local_options(self, options):
         # This method is called after options are parsed
@@ -72,17 +73,21 @@ class WoesApplication(Adw.Application):
         """
         win = self.props.active_window
         if not win:
-            win = WoesWindow(application=self)
+            win = MinimalWoesWindow(application=self)
         win.present()
         self.win = win
 
     def switch_to_http(self, *args):
-        if self.win:
-            self.win.stack.set_visible_child_name("http_page")
+        # if self.win:
+        #     self.win.stack.set_visible_child_name("http_page")
+        logging.debug("switch_to_http called, but is a stub for minimal test.")
+        pass
 
     def switch_to_nmap(self, *args):
-        if self.win:
-            self.win.stack.set_visible_child_name("nmap_page")
+        # if self.win:
+        #     self.win.stack.set_visible_child_name("nmap_page")
+        logging.debug("switch_to_nmap called, but is a stub for minimal test.")
+        pass
 
     def on_about_action(self, widget, _):
         """Callback for the app.about action."""
@@ -99,9 +104,11 @@ class WoesApplication(Adw.Application):
 
     def on_preferences_action(self, widget, _):
         """Callback for the app.preferences action."""
-        preferences = Preferences(main_window=self.win)
-        preferences.set_transient_for(self.win)
-        preferences.present()
+        # preferences = Preferences(main_window=self.win)
+        # preferences.set_transient_for(self.win)
+        # preferences.present()
+        logging.debug("on_preferences_action called, but is a stub for minimal test.")
+        pass
 
     def create_action(self, name, callback, shortcuts=None):
         """Add an application action."""

--- a/src/minimal_window.py
+++ b/src/minimal_window.py
@@ -1,0 +1,17 @@
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
+from gi.repository import Adw, Gtk
+
+class MinimalWoesWindow(Adw.ApplicationWindow):
+    __gtype_name__ = "MinimalWoesWindow"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.set_default_size(600, 400)
+        self.set_title("Minimal Woes Test Window") # Added a title
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        self.set_content(content)
+        label = Gtk.Label(label="Minimal Window Test - If you see this, basic Adw.ApplicationWindow works.")
+        content.append(label)
+        # No GSettings, no complex UI loading, no custom child widgets from templates.


### PR DESCRIPTION
Adds src/minimal_window.py with a very basic Adw.ApplicationWindow. Modifies src/main.py to use this MinimalWoesWindow, bypassing the original WoesWindow, its UI templates, and associated page widgets. Actions related to pages and preferences have been temporarily stubbed out.

This is for diagnosing an application startup failure by attempting to run the most basic version of the application.