### PR TITLE
Refactor and cleanup application code.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,6 @@ from .preferences import Preferences  # Ensure Preferences is imported
 from .window import WoesWindow  # Changed from MinimalWoesWindow
 
 
-
 class WoesApplication(Adw.Application):
     """The main application singleton class."""
 
@@ -54,7 +53,6 @@ class WoesApplication(Adw.Application):
         self.create_action("switch-to-dns", self.switch_to_dns, ["<primary>3"])  # Added
         self.create_action("switch-to-webscan", self.switch_to_webscan, ["<primary>4"])  # Added
 
-
     def do_handle_local_options(self, options):
         # This method is called after options are parsed
         if options.contains('debug'):
@@ -78,7 +76,6 @@ class WoesApplication(Adw.Application):
         win = self.props.active_window
         if not win:
             win = WoesWindow(application=self)  # Changed to WoesWindow
-
         win.present()
         self.win = win
 
@@ -106,7 +103,6 @@ class WoesApplication(Adw.Application):
         else:
             logging.warning("Cannot switch to webscan_page: window or stack not available.")
 
-
     def on_about_action(self, widget, _):
         """Callback for the app.about action."""
         about = Adw.AboutWindow(
@@ -126,7 +122,7 @@ class WoesApplication(Adw.Application):
             return
         preferences_dialog = Preferences(main_window=self.win)
         preferences_dialog.present()
-
+        # preferences_dialog.set_transient_for(self.win)  # Already set in Preferences.__init__
 
     def create_action(self, name, callback, shortcuts=None):
         """Add an application action."""

--- a/src/minimal_window.py
+++ b/src/minimal_window.py
@@ -1,0 +1,17 @@
+import gi
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
+from gi.repository import Adw, Gtk
+
+class MinimalWoesWindow(Adw.ApplicationWindow):
+    __gtype_name__ = "MinimalWoesWindow"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.set_default_size(600, 400)
+        self.set_title("Minimal Woes Test Window") # Added a title
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        self.set_content(content)
+        label = Gtk.Label(label="Minimal Window Test - If you see this, basic Adw.ApplicationWindow works.")
+        content.append(label)
+        # No GSettings, no complex UI loading, no custom child widgets from templates.

--- a/src/window.py
+++ b/src/window.py
@@ -30,12 +30,7 @@ class WoesWindow(Adw.ApplicationWindow):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        try:
-            self.settings = Gio.Settings(schema_id=APP_ID)
-            logging.debug("WoesWindow: GSettings loaded successfully.")
-        except Exception as e:
-            logging.error(f"WoesWindow: Failed to load GSettings: {e}")
-            self.settings = None
+        self.settings = Gio.Settings(schema_id=APP_ID)
         self.style_manager = Adw.StyleManager.get_default()
 
         # Connect settings listener
@@ -85,9 +80,6 @@ class WoesWindow(Adw.ApplicationWindow):
         self.load_css()
 
     def apply_preferences(self):
-        if not self.settings:
-            logging.warning("WoesWindow.apply_preferences: self.settings is None, skipping.")
-            return
         try:
             font_size = self.settings.get_int("font-size")
             dark_theme_enabled = self.settings.get_boolean("dark-theme")


### PR DESCRIPTION
This commit includes the following changes:

- Build System:
  - Removed redundant Python dependency checks from `meson.build`. Flatpak manifest is the source of truth.

- Main Application (`src/main.py`):
  - Switched from `MinimalWoesWindow` to the full `WoesWindow`.
  - Enabled and implemented actions for preferences and page switching (HTTP, Nmap, DNS, WebScan).

- UI Page Refactoring:
  - `HttpPage`: Optimized `GtkColumnView` model and column initialization. Removed invalid UI property.
  - `Preferences`: Decoupled theme and source style scheme updates. `WoesWindow` and relevant pages (`DNSPage`, `NmapPage`) now listen directly to `Gio.Settings` changes.

- Code Cleanup & Linter Fixes:
  - Addressed critical linter issues:
    - Fixed missing `ScanStatus.IDLE` member in `nmap_scanner.py`.
    - Added missing `subprocess` import in `src/tests/test_webscan_page.py`.
    - Resolved warnings for unused page imports in `window.py` needed for Gtk.Template.
    - Removed unused style utility imports in `preferences.py`.
  - Applied extensive styling fixes across the codebase:
    - Corrected whitespace, indentation, and line length issues.
    - Changed logging statements to use %-style formatting.
    - Removed some other minor unused variables and imports.

Further work is planned to address remaining linter warnings and perform thorough testing.