### PR TITLE
Fix runtime NameError and meson post-install script.

### DIFF
--- a/meson-postinstall.py
+++ b/meson-postinstall.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python3
 
 import compileall
-from os import environ
+import sys # Import sys
+import os # os can still be used if DESTDIR logic is desired for other purposes, but not for compileall path here.
 
-destdir = environ.get("DESTDIR", "")
+# The directory to compile is passed by Meson as an argument.
+# sys.argv[0] is the script name
+# sys.argv[1] is the Meson build directory (relative to source root)
+# sys.argv[2] is the first custom argument ('modulesdir' from meson.build)
+if len(sys.argv) > 2:
+    target_compile_dir = sys.argv[2]
+    print(f"Pre-compiling Python files in: {target_compile_dir}")
+    # Use quiet=1 to suppress verbose "Listing..." messages unless errors occur.
+    # legacy=True might be needed if there are symlinks to directories, but try without first.
+    success = compileall.compile_dir(target_compile_dir, force=True, quiet=1)
+    if not success:
+        print(f"Warning: compileall reported some errors for {target_compile_dir}.")
+else:
+    print("Warning: meson-postinstall.py did not receive the target directory argument.")
 
-# Pre compile all .py files
-compileall.compile_dir(destdir, force=True)
+# The DESTDIR logic is generally for staged installs and might not be what's needed here
+# for specifying the actual Python module installation path for compilation.
+# If DESTDIR is part of the path construction for target_compile_dir by Meson itself,
+# then sys.argv[2] would already include it.
+# For now, directly use sys.argv[2] as passed by Meson.

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -6,8 +6,8 @@ from urllib.parse import urlparse
 import requests
 import gi
 
-require_version('Adw', '1')
-require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Adw, Gio, GObject, Gtk
 
 from .constants import RESOURCE_PREFIX


### PR DESCRIPTION
This commit addresses two issues identified from your feedback:

1.  **Fix `NameError: name 'require_version' is not defined`**: I ensured that all calls to `require_version` are correctly prefixed with `gi.` (e.g., `gi.require_version(...)`) in all relevant Python source files. This issue was found to be mostly addressed in prior refactoring but I re-verified it.

2.  **Correct `meson-postinstall.py` Behavior**: I modified `meson-postinstall.py` to use the correct directory argument passed by Meson for `compileall.compile_dir()`. Previously, it was incorrectly using `os.environ.get("DESTDIR", "")`, which could lead to errors like "Can't list ''" during installation. The script now uses `sys.argv[2]` (the `modulesdir` provided in `meson.build`) and runs `compileall` with `quiet=1` to reduce unnecessary verbosity.

These changes should resolve the application startup crash and improve the reliability of the post-install compilation step.