### PR TITLE
I fixed application activation by returning -1 from do_handle_local_o…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -85,8 +85,8 @@ class WoesApplication(Adw.Application):
         # If not debug, the INFO level set in __init__ remains.
         # No need to explicitly set logging.INFO here unless changing format or other settings.
 
-        logging.debug("WoesApplication.do_handle_local_options: Returning 0")
-        return 0  # Indicate success
+        logging.debug("WoesApplication.do_handle_local_options: Returning -1")
+        return -1  # Indicate normal activation should proceed
 
     def do_activate(self):
         """Called when the application is activated.


### PR DESCRIPTION
…ptions.

I changed the return value of `WoesApplication.do_handle_local_options` from 0 to -1.

Returning 0 after processing command-line options (like --debug) was incorrectly signaling to GApplication that activation was fully handled and that `do_activate` should not be called. Returning -1 ensures that after local options are dealt with, the standard activation process (which calls `do_activate` to show the main window) proceeds.

This change should resolve the issue where the application would start, log initial messages, and then exit cleanly without displaying any UI.