### PR TITLE
Attempt to fix UI loading issues

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,22 @@
+import os
+
 APP_ID = "com.github.mclellac.woes"
 RESOURCE_PREFIX = "/com/github/mclellac/woes/gtk"
 THEME_LIGHT = "style.css"
 THEME_DARK = "style-dark.css"
 VERSION = "0.2.0"
+
+# PKGDATADIR would typically be set by the build system (e.g., Meson, Autotools)
+# to the application's shared data directory (e.g., /usr/share/com.github.mclellac.woes/
+# or a path relative to the installation prefix).
+# For development and if running from the source tree without installation,
+# this might point to where the .gresource file is compiled.
+# Assuming woes.gresource will be compiled into a 'gtk' subdirectory within 'src'
+# or a similar location accessible from the source.
+# If installed, this would be different, e.g., os.path.join(sys.prefix, 'share', APP_ID)
+# For now, let's assume it's located in a 'gtk' subdirectory relative to the main 'src' package.
+# This path is for the DIRECTORY containing woes.gresource.
+_installed_pkgdatadir = os.path.join(os.path.dirname(__file__), "gtk") # e.g. src/gtk
+PKGDATADIR = os.environ.get("WOES_PKGDATADIR", _installed_pkgdatadir)
+# This allows overriding with an environment variable for installed scenarios if needed,
+# otherwise defaults to a path relative to this constants.py file (src/gtk).

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -1,11 +1,55 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<interface>
-  <requires lib="gtk" version="4.14"/>
-  <requires lib="libadwaita" version="1.5"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<interfaceنگارنده>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1"/>
   <template class="WoesWindow" parent="AdwApplicationWindow">
-    <property name="title" translatable="yes">WebOps Evaluation Suite (Simplified)</property>
-    <!-- Content removed for testing -->
+    <property name="title">Woes</property>
     <property name="default-width">600</property>
     <property name="default-height">400</property>
+    <property name="content">
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="AdwHeaderBar">
+            <property name="centering-policy">loose</property>
+            <child type="title">
+              <object class="AdwViewSwitcherTitle" id="switcher_title">
+                <property name="stack">stack</property>
+                <property name="title">Woes Application</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStack" id="stack">
+            <property name="vexpand">true</property>
+            <child>
+              <object class="HttpPage" id="http_page_content">
+                <property name="name">http_page</property>
+                <property name="title" translatable="yes">HTTP Details</property>
+              </object>
+            </child>
+            <child>
+              <object class="NmapPage" id="nmap_page_content">
+                <property name="name">nmap_page</property>
+                <property name="title" translatable="yes">Nmap Scan</property>
+              </object>
+            </child>
+            <child>
+              <object class="DNSPage" id="dns_page_content">
+                <property name="name">dns_page</property>
+                <property name="title" translatable="yes">DNS Lookup</property>
+              </object>
+            </child>
+            <child>
+              <object class="WebScanPage" id="webscan_page_content">
+                <property name="name">webscan_page</property>
+                <property name="title" translatable="yes">Web Scan</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </property>
   </template>
 </interface>

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import sys
+import os # Added for path manipulation
 import logging
 
 # Ultra-early logging setup
@@ -24,7 +25,7 @@ gi.require_version("Adw", "1")
 # Import GUI related modules here
 from gi.repository import Adw, Gio, GLib  # Added GLib for OptionArg/OptionFlags
 
-from .constants import APP_ID, VERSION
+from .constants import APP_ID, VERSION, RESOURCE_PREFIX, PKGDATADIR # Import PKGDATADIR
 from .preferences import Preferences  # Ensure Preferences is imported
 from .window import WoesWindow  # Changed from MinimalWoesWindow
 
@@ -192,6 +193,30 @@ def main(version=VERSION):
     # Or, it might be DEBUG if basicConfig in __init__ ran and then was overridden by do_handle_local_options
     # To be safe, application startup messages should follow do_handle_local_options if they depend on its logging level
     # However, WoesApplication __init__ runs before do_handle_local_options.
+
+    # Load GResources
+    # Construct the full path to woes.gresource using PKGDATADIR
+    resource_file_path = os.path.join(PKGDATADIR, "woes.gresource")
+    logging.info(f"Attempting to load GResource file from: {resource_file_path} (derived from PKGDATADIR: {PKGDATADIR})")
+    try:
+        if os.path.exists(resource_file_path):
+            resource = Gio.Resource.load(resource_file_path)
+            Gio.Resource.register(resource)
+            logging.info(f"Successfully loaded and registered GResource: {resource_file_path}")
+            # Log available resources under the application's prefix for verification
+            # This uses RESOURCE_PREFIX from constants.py
+            available_resources = resource.enumerate_children(RESOURCE_PREFIX, Gio.ResourceLookupFlags.NONE)
+            if not available_resources: # Check if list is empty
+                logging.warning(f"No resources found under prefix {RESOURCE_PREFIX} after loading {resource_file_path}. This might be expected if all resources are at the root or a different prefix, or if PKGDATADIR is incorrect.")
+            else:
+                logging.debug(f"Available resources under {RESOURCE_PREFIX}: {available_resources}")
+        else:
+            logging.error(f"GResource file not found at {resource_file_path} (derived from PKGDATADIR: {PKGDATADIR}). UI elements may be missing. Check PKGDATADIR and ensure woes.gresource is in that directory.")
+    except GLib.Error as e:
+        logging.error(f"Error loading or registering GResource {resource_file_path}: {e}. Check if the file is a valid GResource bundle.")
+    except Exception as e: # Catch any other unexpected errors
+        logging.error(f"An unexpected error occurred during GResource loading: {e}")
+
 
     print("src/main.py: main() - Creating WoesApplication instance (print)")
     logging.info("src/main.py: main() - Creating WoesApplication instance (logging)")


### PR DESCRIPTION
This commit includes several changes made in an attempt to resolve UI loading problems:

1.  **Command Line Handling:**
    - Modified `src/main.py` to correctly handle command line arguments by removing the `Gio.ApplicationFlags.HANDLES_COMMAND_LINE` flag and implementing the `do_command_line` virtual method. This resolved an initial GLib-GIO-WARNING.

2.  **UI Definition Reconstruction:**
    - Reconstructed the content of `src/gtk/window.ui`, which was found to be mostly empty. The reconstructed file now defines the main window layout, including an `AdwHeaderBar`, `AdwViewSwitcherTitle` (ID: `switcher_title`), and a `GtkStack` (ID: `stack`) to hold the application's different pages.

3.  **GResource Loading (In Progress):**
    - Modified `src/main.py` to load and register `woes.gresource`. This is crucial for the application to access its compiled UI files, icons, and stylesheets.
    - Identified that the path to `woes.gresource` needs to be provided by the build system (Meson) to `src/main.py`, likely via a generated `src/constants.py` file.
    - Current efforts were focused on ensuring `src/main.py` uses the correct path (expected to be stored in a variable like `PKGDATADIR` in `src/constants.py`).

**Current State and Next Steps (if work were to continue):**

The primary remaining task is to ensure that `src/constants.py` is correctly generated by Meson with the `PKGDATADIR` variable pointing to the installation directory of `woes.gresource`.

Currently, `src/meson.build` defines `PKGDATADIR` but doesn't appear to use it to generate `src/constants.py`. The `constants.py` file is treated as a static source file.

My plan was to:
1.  Modify `src/meson.build` to configure a `src/constants.py.in` template file, injecting the correct `PKGDATADIR` value into the generated `src/constants.py`.
2.  Ensure `src/main.py` uses this `PKGDATADIR` from the generated `constants.py` to load `woes.gresource`.
3.  Test thoroughly to confirm that all UI elements load correctly and the application is fully functional.

I was stuck on the final step of correctly configuring Meson to generate `constants.py` and ensuring that the `PKGDATADIR` path was correctly passed and utilized.