### PR TITLE
Fix: Ensure AdwViewSwitcherTitle correctly displays all pages

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -66,6 +66,10 @@ class WoesWindow(Adw.ApplicationWindow):
             logging.exception("WoesWindow.setup_ui: Error during self.apply_preferences()")
         logging.debug("WoesWindow.setup_ui: apply_preferences finished.")
 
+        logging.debug("WoesWindow.setup_ui: Attempting to explicitly set switcher_title.stack")
+        self.switcher_title.props.stack = self.stack
+        logging.debug(f"WoesWindow.setup_ui: switcher_title.stack explicitly set to {self.switcher_title.props.stack}")
+
         if self.switcher_title and self.stack:
             logging.debug("WoesWindow.setup_ui: Connecting switcher_title signal...")
             try:


### PR DESCRIPTION
The UI was previously only showing the HTTP page, and the AdwViewSwitcherTitle was not allowing navigation to other pages (Nmap, DNS, WebScan).

This was likely due to a subtle initialization issue where the AdwViewSwitcherTitle, despite being linked to the GtkStack in the UI definition, was not correctly recognizing all of its children.

The fix involves explicitly re-assigning the `props.stack` of the AdwViewSwitcherTitle instance in the `WoesWindow.setup_ui` method. This ensures that the switcher re-evaluates the GtkStack's children after the main window components are initialized, thereby correctly populating its list of navigable pages.