### PR TITLE
Fix: Resolve UI page loading and switcher issues

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -10,7 +10,6 @@
       <object class="AdwBanner" id="warning_banner">
         <property name="title" translatable="yes">WARNING: Do not use this tool on any hosts or networks you do not have explicit permission to scan.</property>
         <property name="revealed">True</property>
-        <property name="type">warning</property> <!-- Adw.BannerType.WARNING -->
       </object>
     </child>
     <child>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -21,7 +21,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkStack" id="stack">
+          <object class="AdwViewStack" id="stack">
             <property name="vexpand">true</property>
             <child>
               <object class="HttpPage" id="http_page_content">


### PR DESCRIPTION
Addresses critical errors and warnings that prevented the UI from fully initializing and displaying all pages correctly.

Key changes:
- Corrected `src/gtk/nmap_page.ui`: Removed an invalid 'type' property from an AdwBanner widget. This was causing a Gtk-CRITICAL error during NmapPage template building and preventing its proper initialization.
- Changed `GtkStack` to `AdwViewStack` in `src/gtk/window.ui`: The main page container is now an AdwViewStack. This resolves type mismatch warnings with AdwViewSwitcherTitle, which expects an AdwViewStack, ensuring better integration.

These changes should allow all pages (HTTP, Nmap, DNS, WebScan) to load correctly and be navigable via the AdwViewSwitcherTitle, resolving the issue where only the HTTP page was accessible.