### PR TITLE
Fix: Resolve NmapPage template error and simplify window setup

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -70,7 +70,7 @@
             <property name="title" translatable="yes">Scan Status</property>
             <property name="subtitle" translatable="yes">Idle</property> <!-- Initial status message -->
             <property name="activatable">False</property>
-            <property name="revealed">True</property> <!-- Always visible, content changes -->
+            <property name="visible">true</property> <!-- Always visible, content changes -->
             <child>
               <object class="GtkSpinner" id="scan_spinner">
                 <property name="spinning">False</property>

--- a/src/window.py
+++ b/src/window.py
@@ -66,9 +66,9 @@ class WoesWindow(Adw.ApplicationWindow):
             logging.exception("WoesWindow.setup_ui: Error during self.apply_preferences()")
         logging.debug("WoesWindow.setup_ui: apply_preferences finished.")
 
-        logging.debug("WoesWindow.setup_ui: Attempting to explicitly set switcher_title.stack")
-        self.switcher_title.props.stack = self.stack
-        logging.debug(f"WoesWindow.setup_ui: switcher_title.stack explicitly set to {self.switcher_title.props.stack}")
+        # logging.debug("WoesWindow.setup_ui: Attempting to explicitly set switcher_title.stack")
+        # self.switcher_title.props.stack = self.stack
+        # logging.debug(f"WoesWindow.setup_ui: switcher_title.stack explicitly set to {self.switcher_title.props.stack}")
 
         if self.switcher_title and self.stack:
             logging.debug("WoesWindow.setup_ui: Connecting switcher_title signal...")


### PR DESCRIPTION
This commit addresses critical issues that prevented the NmapPage from loading and likely caused the main application window to not render correctly.

Key changes:
- Corrected `src/gtk/nmap_page.ui`: An AdwActionRow with id `status_row` had an invalid `revealed="True"` property. This was replaced with `visible="true"`, fixing a Gtk-CRITICAL error during NmapPage template building. This allows NmapPage and its components to initialize correctly.
- Simplified `src/window.py`: Temporarily commented out the explicit programmatic assignment of `self.switcher_title.props.stack`. The UI definition (`window.ui`), which now uses AdwViewStack, is expected to correctly link the AdwViewSwitcherTitle to the stack.

These changes should ensure that all pages load without critical errors, allowing the main WoesWindow (including its AdwHeaderBar and AdwViewSwitcherTitle) to be visible and fully functional. This resolves the issue where only the HTTP page's widgets were visible without the main application frame.