### PR TITLE
Fix: Use correct UI definition for WoesWindow

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -1,52 +1,214 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Created with Cambalache 0.96.1 -->
 <interface>
-  <requires lib="gtk" version="4.0"/>
-  <requires lib="libadwaita" version="1.0"/>
+  <!-- interface-name window.ui -->
+  <!-- interface-copyright (c) 2025 -->
+  <!-- interface-authors Carey McLelland <careymclelland@gmail.com> -->
+  <requires lib="gio" version="2.44"/>
+  <requires lib="gtk" version="4.18"/>
+  <requires lib="libadwaita" version="1.7"/>
   <template class="WoesWindow" parent="AdwApplicationWindow">
-    <property name="title">Woes</property>
-    <property name="default-width">600</property>
-    <property name="default-height">400</property>
-    <child>
-      <object class="GtkBox">
+    <property name="content">
+      <object class="GtkBox" id="main_box">
+        <property name="halign">baseline-fill</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="AdwHeaderBar" id="header_bar">
-            <child type="title">
-              <object class="AdwViewSwitcherTitle" id="switcher_title">
+            <property name="title-widget">
+              <object class="AdwViewSwitcher" id="switcher_title">
+                <property name="halign">baseline-fill</property>
+                <property name="policy">wide</property>
                 <property name="stack">stack</property>
+              </object>
+            </property>
+            <child type="end">
+              <object class="GtkMenuButton" id="menu_button">
+                <property name="icon-name">open-menu-symbolic</property>
+                <property name="menu-model">primary_menu</property>
+                <property name="primary">True</property>
+                <property name="tooltip-text" translatable="yes">Menu</property>
+                <style>
+                  <class name="GtkMenuButton"/>
+                </style>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="GtkStack" id="stack">
+          <object class="AdwViewStack" id="stack">
             <property name="vexpand">True</property>
+            <property name="vexpand-set">True</property>
             <child>
-              <object class="HttpPage" id="http">
-                <property name="name">HTTP</property>
+              <object class="AdwViewStackPage" id="http_page">
+                <property name="child">
+                  <object class="AdwStatusPage" id="http_status_page">
+                    <property name="description">This tool is ideal for developers, as well as systems and network administrators, who need to inspect HTTP headers for debugging, troubleshooting, and security analysis.</property>
+                    <property name="icon-name" bind-source="http_page" bind-property="icon-name" bind-flags="sync-create"/>
+                    <property name="overflow">hidden</property>
+                    <property name="title" bind-source="http_page" bind-property="title" bind-flags="sync-create"/>
+                    <property name="valign">start</property>
+                    <child>
+                      <object class="AdwClampScrollable" id="http_clamp_scrollable">
+                        <property name="hadjustment">
+                          <object class="GtkAdjustment"/>
+                        </property>
+                        <property name="maximum-size">1400</property>
+                        <property name="tightening-threshold">500</property>
+                        <property name="unit">px</property>
+                        <property name="vadjustment">
+                          <object class="GtkAdjustment"/>
+                        </property>
+                        <child>
+                          <object class="GtkBox" id="HttpPage">
+                            <child>
+                              <object class="HttpPage">
+                                <property name="overflow">hidden</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+                <property name="icon-name">network-transmit-receive-symbolic</property>
+                <property name="name">http_page</property>
                 <property name="title">HTTP Headers</property>
+                <property name="use-underline">true</property>
               </object>
             </child>
             <child>
-              <object class="NmapPage" id="nmap">
-                <property name="name">Nmap</property>
-                <property name="title">Nmap Scan</property>
+              <object class="AdwViewStackPage" id="nmap_page">
+                <property name="child">
+                  <object class="AdwStatusPage" id="nmap_status_page">
+                    <property name="description">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
+                    <property name="icon-name" bind-source="nmap_page" bind-property="icon-name" bind-flags="sync-create"/>
+                    <property name="title" bind-source="nmap_page" bind-property="title" bind-flags="sync-create">Port Scanning</property>
+                    <property name="vexpand">True</property>
+                    <property name="vexpand-set">True</property>
+                    <child>
+                      <object class="AdwClampScrollable">
+                        <property name="maximum-size">1400</property>
+                        <property name="unit">px</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="GtkBox" id="NmapPage">
+                            <property name="height-request">1000</property>
+                            <property name="hexpand">True</property>
+                            <property name="hexpand-set">True</property>
+                            <property name="valign">center</property>
+                            <property name="vexpand">True</property>
+                            <property name="vexpand-set">True</property>
+                            <child>
+                              <object class="NmapPage">
+                                <property name="vexpand">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+                <property name="icon-name">face-devilish</property>
+                <property name="name">nmap_page</property>
+                <property name="title">Port Scan</property>
+                <property name="use-underline">true</property>
               </object>
             </child>
             <child>
-              <object class="DNSPage" id="dns">
-                <property name="name">DNS</property>
-                <property name="title">DNS Lookup</property>
+              <object class="AdwViewStackPage" id="dns_page">
+                <property name="badge-number">0</property>
+                <property name="child">
+                  <object class="AdwStatusPage" id="dns_status_page">
+                    <property name="description">The DNS tool allows users to perform DNS queries for various record types, including &lt;b&gt;A&lt;/b&gt;, &lt;b&gt;TXT&lt;/b&gt;, &lt;b&gt;CNAME&lt;/b&gt; and others. By entering an IP address, users can perform reverse DNS lookups.</property>
+                    <property name="icon-name">org.gnome.Epiphany-symbolic</property>
+                    <property name="margin-end">15</property>
+                    <property name="margin-start">15</property>
+                    <property name="title" bind-source="dns_page" bind-property="title" bind-flags="sync-create">Domain Name Lookup</property>
+                    <property name="valign">start</property>
+                    <child>
+                      <object class="AdwClampScrollable">
+                        <property name="maximum-size">1400</property>
+                        <property name="unit">px</property>
+                        <property name="vexpand">True</property>
+                        <child>
+                          <object class="GtkBox" id="DnsPageBox">
+                            <child>
+                              <object class="DNSPage" id="DNSPage"/>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+                <property name="icon-name">org.gnome.Epiphany-symbolic</property>
+                <property name="title">DNS</property>
+                <property name="use-underline">true</property>
               </object>
             </child>
             <child>
-              <object class="WebScanPage" id="webscan">
-                <property name="name">WebScan</property>
-                <property name="title">Web Scanner</property>
+              <object class="AdwViewStackPage" id="webscan_page">
+                <property name="child">
+                  <object class="AdwStatusPage" id="webscan_status_page">
+                    <property name="child">
+                      <object class="GtkBox" id="webscan_box">
+                        <property name="orientation">vertical</property>
+                        <property name="valign">center</property>
+                      </object>
+                    </property>
+                    <property name="description">TODO</property>
+                    <property name="icon-name" bind-source="webscan_page" bind-property="icon-name" bind-flags="sync-create">org.gnome.Loupe-symbolic</property>
+                    <property name="title" bind-source="webscan_page" bind-property="title" bind-flags="sync-create">Web Scanner</property>
+                    <property name="valign">start</property>
+                  </object>
+                </property>
+                <property name="icon-name">face-cool</property>
+                <property name="name">webscan_page</property>
+                <property name="title">Web Scan</property>
+                <property name="use-underline">true</property>
               </object>
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwViewSwitcherBar" id="switcher_bar">
+            <property name="halign">baseline-fill</property>
+            <property name="stack">stack</property>
+          </object>
+        </child>
+      </object>
+    </property>
+    <property name="default-height">1000</property>
+    <property name="default-width">1000</property>
+    <property name="height-request">500</property>
+    <property name="overflow">hidden</property>
+    <property name="title" translatable="yes">WebOps Evaluation Suite</property>
+    <property name="width-request">800</property>
+    <child>
+      <object class="AdwBreakpoint">
+        <!-- Custom object fragments -->
+        <condition>max-width: 550sp</condition>
+        <setter object="header_bar" property="title-widget"/>
+        <setter object="switcher_bar" property="reveal">true</setter>
       </object>
     </child>
   </template>
+  <menu id="primary_menu">
+    <section>
+      <item>
+        <attribute name="action">app.preferences</attribute>
+        <attribute name="label" translatable="yes">_Preferences</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.show-help-overlay</attribute>
+        <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.about</attribute>
+        <attribute name="label" translatable="yes">_About WebOps Evaluation Suite</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>


### PR DESCRIPTION
This commit replaces the content of src/gtk/window.ui with the correct XML structure you provided. The previous commit had an oversimplified and incorrect UI definition for the main WoesWindow, which this change rectifies.

The corrected window.ui file properly defines WoesWindow as a child of AdwApplicationWindow and includes the necessary AdwHeaderBar, AdwViewSwitcher, AdwViewStack, and AdwViewStackPage elements for all application pages.

Testing confirms that with this corrected UI definition, the application initializes without template parsing errors and resolves the previously reported Gtk-CRITICAL issues.