### PR TITLE
Fix various GTK warnings and runtime errors

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -29,7 +29,7 @@ class DNSPage(Adw.PreferencesPage):
         super().__init__(**kwargs)
         self.header_tag = None # Initialize W0201
         self._connect_signals()
-        self.source_view, self.source_buffer = create_source_view(language_name='txt')
+        self.source_view, self.source_buffer = create_source_view(language_name='text')
         self.dns_results_scrolled_window.set_child(self.source_view)
         self.settings = Gio.Settings.new(APP_ID)  # Ensure settings is initialized before use
         self._apply_source_view_style()  # Initial style application

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -93,7 +93,7 @@
       <object class="AdwPreferencesGroup" id="targets_group">
         <property name="title" translatable="yes">Scanned Targets</property>
         <property name="description" translatable="yes">Select a target to view its scan results.</property>
-        <property name="revealed">False</property> <!-- Initially hidden -->
+        <!-- <property name="revealed">False</property> --> <!-- Initially hidden -->
         <child>
           <object class="GtkScrolledWindow" id="nmap_target_scrolled_window">
             <property name="min-content-height">150</property>
@@ -113,7 +113,7 @@
       <object class="AdwPreferencesGroup" id="results_group">
         <property name="title" translatable="yes">Scan Results</property>
         <property name="description" translatable="yes">Results for the selected target.</property>
-        <property name="revealed">False</property> <!-- Initially hidden -->
+        <!-- <property name="revealed">False</property> --> <!-- Initially hidden -->
         <child>
           <object class="GtkScrolledWindow" id="nmap_results_scrolled_window">
             <property name="min-content-height">300</property>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -49,15 +49,9 @@
                     <property name="valign">start</property>
                     <child>
                       <object class="AdwClampScrollable" id="http_clamp_scrollable">
-                        <property name="hadjustment">
-                          <object class="GtkAdjustment"/>
-                        </property>
                         <property name="maximum-size">1400</property>
                         <property name="tightening-threshold">500</property>
                         <property name="unit">px</property>
-                        <property name="vadjustment">
-                          <object class="GtkAdjustment"/>
-                        </property>
                         <child>
                           <object class="GtkBox" id="HttpPage">
                             <child>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -92,16 +92,21 @@ class HttpPage(Adw.PreferencesPage):
         self.http_entry_row.set_sensitive(False)
         # You might want to add a spinner here, e.g., self.spinner.start()
 
-        task = Gio.Task.new(self, None, self._fetch_headers_task_done_cb, None)
-        task.set_task_data({
+        self._http_task_data_for_thread = {
             "url": url,
             "use_akamai_pragma": self.http_pragma_switch_row.get_active()
-        }, None) # No destroy notify needed for simple dict
+        }
+        task = Gio.Task.new(self, None, self._fetch_headers_task_done_cb, None)
+        # The problematic task.set_task_data line is now fully removed.
         task.run_in_thread(self._fetch_headers_task_thread_func)
 
     def _fetch_headers_task_thread_func(self, task: Gio.Task, source_object, task_data: dict, cancellable: Optional[Gio.Cancellable]):
-        url = task_data["url"]
-        use_akamai_pragma = task_data["use_akamai_pragma"]
+        # 'source_object' is the HttpPage instance (self).
+        # The 'task_data' argument in the function signature is likely None or unreliable now.
+        current_task_data = source_object._http_task_data_for_thread
+
+        url = current_task_data["url"]
+        use_akamai_pragma = current_task_data["use_akamai_pragma"]
         logger.debug("Task thread: Making GET request to %s with Akamai headers: %s", url, use_akamai_pragma)
 
         request_headers = {}


### PR DESCRIPTION
This commit addresses several issues identified from application debug output:

- UI Definition Warnings (GtkBox properties):
  - Removed erroneous `hadjustment` and `vadjustment` properties from an `AdwClampScrollable` in `window.ui`.
  - Ensured no `GtkBox` in `window.ui` incorrectly defines scroll-related properties.

- NmapPage Errors (AdwPreferencesGroup & AttributeError):
  - Removed `revealed` property from `AdwPreferencesGroup` in `nmap_page.ui` to prevent template instantiation failure.
  - Confirmed initial visibility is handled programmatically in `nmap_page.py`, fixing the `AttributeError` on `nmap_results_scrolled_window`.

- HttpPage Errors (ValueError & GTask finalization):
  - Removed the problematic `task.set_task_data()` call in `http_page.py` that was causing a `ValueError` due to incompatible Python dict type for a gpointer.
  - Data for the thread function is now passed by storing it on the `HttpPage` instance (source_object), making it accessible to the thread. This resolves the `ValueError` and the subsequent `GTask finalized without ever returning` critical errors.

- GtkSourceView Warning:
  - Changed language identifier from 'txt' to 'text' in `dns_page.py` for `GtkSourceView` to eliminate the "language 'txt' not found" warning.