### PR TITLE
I've made some updates to address a few issues you pointed out:

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -29,7 +29,7 @@ class DNSPage(Adw.PreferencesPage):
         super().__init__(**kwargs)
         self.header_tag = None # Initialize W0201
         self._connect_signals()
-        self.source_view, self.source_buffer = create_source_view(language_name='text')
+        self.source_view, self.source_buffer = create_source_view(language_name=None)
         self.dns_results_scrolled_window.set_child(self.source_view)
         self.settings = Gio.Settings.new(APP_ID)  # Ensure settings is initialized before use
         self._apply_source_view_style()  # Initial style application

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -93,7 +93,7 @@
       <object class="AdwPreferencesGroup" id="targets_group">
         <property name="title" translatable="yes">Scanned Targets</property>
         <property name="description" translatable="yes">Select a target to view its scan results.</property>
-        <!-- <property name="revealed">False</property> --> <!-- Initially hidden -->
+        <property name="revealed">False</property> <!-- Initially hidden -->
         <child>
           <object class="GtkScrolledWindow" id="nmap_target_scrolled_window">
             <property name="min-content-height">150</property>
@@ -113,7 +113,7 @@
       <object class="AdwPreferencesGroup" id="results_group">
         <property name="title" translatable="yes">Scan Results</property>
         <property name="description" translatable="yes">Results for the selected target.</property>
-        <!-- <property name="revealed">False</property> --> <!-- Initially hidden -->
+        <property name="revealed">False</property> <!-- Initially hidden -->
         <child>
           <object class="GtkScrolledWindow" id="nmap_results_scrolled_window">
             <property name="min-content-height">300</property>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -141,27 +141,37 @@ class HttpPage(Adw.PreferencesPage):
             # For simplicity, using a generic error domain and code
             # A more robust solution might define a custom error domain
             error_message = self._format_http_error(e)
-            task.return_new_error(Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, "%s", error_message)
+            safe_error_message = str(error_message)
+            g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
+            task.return_error(g_error)
             return
         except requests.exceptions.ConnectionError as e:
             logger.warning("Task thread: ConnectionError for %s: %s", url, e, exc_info=True)
             error_message = "Connection Error: Failed to establish a connection."
-            task.return_new_error(Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, "%s", error_message)
+            safe_error_message = str(error_message)
+            g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
+            task.return_error(g_error)
             return
         except requests.exceptions.Timeout as e:
             logger.warning("Task thread: Timeout for %s: %s", url, e, exc_info=True)
             error_message = "Timeout Error: The request timed out."
-            task.return_new_error(Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, "%s", error_message)
+            safe_error_message = str(error_message)
+            g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
+            task.return_error(g_error)
             return
         except requests.exceptions.RequestException as e:
             logger.error("Task thread: RequestException for %s: %s", url, e, exc_info=True)
             error_message = f"Request Error: {str(e)}"
-            task.return_new_error(Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, "%s", error_message)
+            safe_error_message = str(error_message)
+            g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
+            task.return_error(g_error)
             return
         except Exception as e: # Catch any other unexpected errors
             logger.error("Task thread: Unexpected error for %s: %s", url, e, exc_info=True)
             error_message = f"An unexpected error occurred: {str(e)}"
-            task.return_new_error(Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, "%s", error_message)
+            safe_error_message = str(error_message)
+            g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
+            task.return_error(g_error)
             return
 
 
@@ -173,7 +183,7 @@ class HttpPage(Adw.PreferencesPage):
             if local_task_ref:
                 # This call will raise a GLib.Error (caught as GObject.GError)
                 # if task.return_error() was called in the thread.
-                returned_value = local_task_ref.propagate_value(result)
+                returned_value = local_task_ref.propagate_value()
                 if returned_value: # Check if propagate_value didn't return None
                     headers = returned_value.get_boxed() # Assuming the returned value is a Python dict
                     logger.info("Successfully fetched headers (async)")

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -100,8 +100,8 @@ class NmapPage(Adw.PreferencesPage):
             self.nmap_target_listbox_store, self._create_target_listbox_row
         )
         # Initial visibility states
-        self.targets_group.set_revealed(False)
-        self.results_group.set_revealed(False)
+        # self.targets_group.set_revealed(False) # Handled by UI file
+        # self.results_group.set_revealed(False) # Handled by UI file
         self.error_banner.set_revealed(False)
         self.scan_spinner.set_spinning(False)
         self.scan_spinner.set_visible(False)


### PR DESCRIPTION
1.  Regarding the NmapPage `revealed` property:
    - I've restored the `revealed="False"` property for AdwPreferencesGroups in `nmap_page.ui`.
    - I also removed the corresponding programmatic `set_revealed(False)` calls from `nmap_page.py`. This should fix an `AttributeError` that was occurring when `set_revealed` was called, and now relies on the UI template for the initial state.

2.  For the HttpPage GIO.Task API:
    - I changed `task.propagate_value(result)` to `task.propagate_value()` in `_fetch_headers_task_done_cb` to resolve a `TypeError` related to argument count.
    - I reverted the error reporting in `_fetch_headers_task_thread_func` from the incorrect `task.return_new_error()` back to `task.return_error(g_error_instance)`.
    - I've made sure that the message passed to `GLib.Error()` is explicitly cast to `str()` to prevent a `TypeError` during error reporting. This should fix the `AttributeError` for `return_new_error` and aims to resolve the underlying `TypeError` with `return_error`.

3.  Concerning the GtkSourceView language warning:
    - I set `language_name=None` for `create_source_view` in `dns_page.py`. This should prevent warnings about missing 'text' or 'txt' language definitions, and the view will now use a plain buffer.

The GtkBox property warnings (`hadjustment`, etc.) are still something I'm looking into. I haven't found a direct cause in your application's UI files or Python code yet, despite thorough checks.