### PR TITLE
Fix: Chain up to parent in WoesApplication.do_command_line

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -112,12 +112,8 @@ class WoesApplication(Adw.Application):
         return -1
 
     def do_command_line(self, command_line):
-        """Overrides the do_command_line virtual method."""
-        options = command_line.get_options_dict()
-        logger.debug("Application started with command line options: %s", options)
-        # GApplication automatically calls handle_local_options before activate
-        self.activate()
-        return 0
+        logger.debug("WoesApplication.do_command_line: options = %s", command_line.get_options_dict().print(True))
+        return super().do_command_line(command_line)
 
     def do_activate(self):
         """Called when the application is activated."""


### PR DESCRIPTION
Modified WoesApplication.do_command_line in src/main.py to call super().do_command_line(command_line).

This is the standard way to ensure that GApplication's normal option handling (including do_handle_local_options) and application activation (do_activate) occur correctly. The previous implementation was manually calling self.activate() and returning 0, bypassing the parent's logic.

Note: I encountered an unrelated GObject introspection ImportError in the execution environment which prevented me from performing runtime testing. The applied code change is a standard Gtk practice for the described problem.