### PR TITLE
Fix: Ensure main window is added to the application

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -133,6 +133,7 @@ class WoesApplication(Adw.Application):
             sys.exit(1)
 
         self.win = win
+        self.add_window(self.win) # Add this line
         logger.debug("Presenting WoesWindow.")
         try:
             self.win.present()


### PR DESCRIPTION
I modified WoesApplication.do_activate in src/main.py to include self.add_window(self.win).

This is a crucial step for Adw.Application (and Gtk.Application) to correctly manage the lifecycle of its windows. Without it, the application may exit prematurely after presenting a window, as it doesn't recognize any windows that should keep it alive. This change addresses the issue of the application starting and then immediately exiting without the GUI remaining visible.

Note: I was unable to confirm the window appearance and app persistence at runtime due to a persistent GObject Introspection ImportError in the execution environment. The applied code change is the standard and correct Gtk practice for the diagnosed problem.