### PR TITLE
I've refactored the UI to use Adwaita widgets more extensively.

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/dns_page.ui")
-class DNSPage(Gtk.Box):
+class DNSPage(Adw.PreferencesPage):
     __gtype_name__ = "DNSPage"
 
     dns_ip_entryrow = Gtk.Template.Child("dns_ip_entryrow")

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -3,18 +3,10 @@
 <interface>
   <requires lib="gtk" version="4.10"/>
   <requires lib="libadwaita" version="1.4"/>
-  <template class="DNSPage" parent="GtkBox">
-    <property name="halign">baseline-fill</property>
-    <property name="hexpand">True</property>
-    <property name="hexpand-set">True</property>
-    <property name="orientation">vertical</property>
-    <property name="vexpand">True</property>
-    <property name="vexpand-set">True</property>
+  <template class="DNSPage" parent="AdwPreferencesPage">
     <child>
       <object class="AdwPreferencesGroup" id="dns_params_group">
         <property name="title" translatable="yes">Lookup Parameters</property>
-        <property name="halign">baseline-fill</property>
-        <property name="valign">baseline-center</property>
         <child>
           <object class="AdwEntryRow" id="dns_ip_entryrow">
             <property name="input-purpose">url</property>
@@ -48,50 +40,31 @@
       </object>
     </child>
     <child>
-      <object class="AdwBanner" id="dns_error_banner">
-        <property name="button-label" translatable="yes">Dismiss</property>
-        <property name="revealed">False</property>
-        <property name="margin-bottom">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-start">10</property>
-        <property name="margin-top">10</property>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <object class="AdwBanner" id="dns_error_banner">
+            <property name="button-label" translatable="yes">Dismiss</property>
+            <property name="revealed">False</property>
+            <property name="margin-bottom">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-top">10</property>
+          </object>
+        </child>
       </object>
     </child>
     <child>
-      <object class="GtkGrid" id="dns_results_grid">
-        <property name="halign">baseline-fill</property>
-        <property name="hexpand">True</property>
-        <property name="margin-bottom">10</property>
-        <property name="margin-top">10</property>
-        <property name="valign">baseline-fill</property>
-        <property name="vexpand">True</property>
-        <property name="vexpand-set">True</property>
+      <object class="AdwPreferencesGroup" id="dns_results_group">
+        <property name="title" translatable="yes">Lookup Results</property>
         <child>
-          <object class="AdwPreferencesGroup" id="dns_results_group">
-            <property name="title" translatable="yes">Lookup Results</property>
+          <object class="AdwScrolledWindow" id="dns_results_scrolled_window">
             <property name="halign">baseline-fill</property>
             <property name="hexpand">True</property>
             <property name="hexpand-set">True</property>
+            <property name="min-content-height">400</property> <!-- Retained from GtkScrolledWindow -->
             <property name="vexpand">True</property>
             <property name="vexpand-set">True</property>
-            <!-- label-xalign and overflow from GtkFrame are not directly applicable or needed for AdwPreferencesGroup -->
-            <child>
-              <object class="AdwScrolledWindow" id="dns_results_scrolled_window">
-                <property name="halign">baseline-fill</property>
-                <property name="hexpand">True</property>
-                <property name="hexpand-set">True</property>
-                <property name="min-content-height">400</property> <!-- Retained from GtkScrolledWindow -->
-                <property name="vexpand">True</property>
-                <property name="vexpand-set">True</property>
-                <!-- Removed has-frame, kinetic-scrolling, max-content-width, overflow as they are not for AdwScrolledWindow or handled differently -->
-              </object>
-            </child>
-            <layout>
-              <property name="column">0</property>
-              <property name="column-span">5</property>
-              <property name="row">0</property>
-              <property name="row-span">10</property>
-            </layout>
+            <!-- Removed has-frame, kinetic-scrolling, max-content-width, overflow as they are not for AdwScrolledWindow or handled differently -->
           </object>
         </child>
       </object>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -3,26 +3,12 @@
 <interface>
   <requires lib="gtk" version="4.12"/>
   <requires lib="libadwaita" version="1.4"/>
-  <template class="HttpPage" parent="GtkBox">
-    <property name="halign">baseline-fill</property>
-    <property name="margin-top">20</property>
-    <property name="orientation">vertical</property>
+  <template class="HttpPage" parent="AdwPreferencesPage">
     <child>
-      <object class="GtkBox" id="http_page_box">
-        <property name="hexpand">True</property>
-        <property name="margin-bottom">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-start">10</property>
-        <property name="margin-top">10</property>
-        <property name="orientation">vertical</property>
-        <property name="vexpand">True</property>
+      <object class="AdwPreferencesGroup" id="http_request_group">
+        <property name="title" translatable="yes">Request Parameters</property>
         <child>
-          <object class="AdwPreferencesGroup" id="http_request_group">
-            <property name="title" translatable="yes">Request Parameters</property>
-            <property name="hexpand">True</property>
-            <property name="valign">baseline-center</property>
-            <child>
-              <object class="AdwEntryRow" id="http_entry_row">
+          <object class="AdwEntryRow" id="http_entry_row">
                 <property name="activates-default">True</property>
                 <property name="focusable">True</property>
                 <property name="input-purpose">url</property>
@@ -40,6 +26,8 @@
           </object>
         </child>
         <child>
+      <object class="AdwPreferencesGroup">
+        <child>
           <object class="AdwBanner" id="http_error_banner">
             <property name="button-label" translatable="yes">Dismiss</property>
             <property name="margin-bottom">10</property>
@@ -47,19 +35,15 @@
             <property name="revealed">False</property>
           </object>
         </child>
+          </object>
+        </child>
         <child>
           <object class="AdwPreferencesGroup" id="http_response_group">
             <property name="title" translatable="yes">Response Headers</property>
-            <property name="halign">baseline-fill</property>
-            <property name="hexpand">True</property>
-            <property name="margin-top">20</property>
-            <property name="vexpand">True</property>
             <property name="visible">False</property>
             <child>
               <object class="GtkColumnView" id="http_column_view">
                 <property name="enable-rubberband">True</property>
-                <property name="halign">baseline-fill</property>
-                <property name="hexpand">True</property>
                 <property name="margin-bottom">10</property>
                 <property name="margin-end">10</property>
                 <property name="margin-start">10</property>
@@ -71,7 +55,6 @@
                 <property name="reorderable">False</property>
                 <property name="show-column-separators">true</property>
                 <property name="show-row-separators">true</property>
-                <property name="valign">start</property>
                 <property name="vexpand">True</property>
                 <child>
                   <object class="GtkColumnViewColumn" id="header_name_column">

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -3,18 +3,10 @@
 <interface>
   <requires lib="gtk" version="4.10"/>
   <requires lib="libadwaita" version="1.4"/>
-  <template class="NmapPage" parent="GtkBox">
-    <property name="halign">baseline-fill</property>
-    <property name="hexpand">True</property>
-    <property name="hexpand-set">True</property>
-    <property name="orientation">vertical</property>
-    <property name="vexpand">True</property>
-    <property name="vexpand-set">True</property>
+  <template class="NmapPage" parent="AdwPreferencesPage">
     <child>
       <object class="AdwPreferencesGroup" id="nmap_config_group">
         <property name="title" translatable="yes">Scan Configuration</property>
-        <property name="halign">baseline-fill</property>
-        <property name="valign">baseline-center</property>
         <child>
           <object class="AdwEntryRow" id="nmap_target_entryrow">
             <property name="activates-default">True</property>
@@ -38,8 +30,6 @@
         </child>
         <child>
           <object class="AdwComboRow" id="nmap_scripts_dropdown">
-            <property name="hexpand">True</property>
-            <property name="hexpand-set">True</property>
             <property name="icon-name">emblem-documents-symbolic</property>
             <property name="model">
               <object class="GtkStringList" id="nmap_list">
@@ -67,129 +57,117 @@
             <property name="subtitle">Select script to use if desired</property>
             <property name="subtitle-lines">1</property>
             <property name="title">Nmap Scripts</property>
-            <property name="valign">baseline-fill</property>
           </object>
         </child>
       </object>
     </child>
     <child>
-      <object class="AdwBanner" id="nmap_warning_banner">
-        <property name="title" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; Do not use this tool on any hosts or networks &lt;u&gt;you do not explicitely have permission&lt;/u&gt; to scan.</property>
-        <property name="button-label" translatable="yes">Dismiss</property>
-        <property name="revealed">True</property>
-        <property name="margin-bottom">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-start">10</property>
-        <property name="margin-top">10</property>
-      </object>
-    </child>
-    <child>
-      <object class="AdwBanner" id="error_banner">
-        <property name="button-label" translatable="yes">Dismiss</property>
-        <property name="revealed">False</property>
-        <property name="margin-bottom">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-start">10</property>
-        <property name="margin-top">10</property>
-      </object>
-    </child>
-    <child>
-      <!-- Corrected AdwActionRow with GtkSpinner as a suffix -->
-      <object class="AdwActionRow" id="nmap_status_row">
-        <property name="title" translatable="yes">Scan Status</property>
-        <property name="subtitle" translatable="yes"></property>
-        <property name="subtitle-visible">False</property>
-        <property name="halign">baseline-fill</property> <!-- Changed to fill -->
-        <property name="margin-start">10</property>
-        <property name="margin-end">10</property>
-        <suffix>
-          <object class="GtkSpinner" id="nmap_spinner">
-            <property name="spinning">True</property>
-            <property name="visible">False</property>
-          </object>
-        </suffix>
-      </object>
-    </child>
-    <child>
-      <object class="GtkGrid" id="nmap_results_grid">
-        <property name="halign">baseline-fill</property>
-        <property name="hexpand">True</property>
-        <property name="margin-bottom">10</property>
-        <property name="margin-top">10</property>
-        <property name="valign">baseline-fill</property>
-        <property name="vexpand">True</property>
-        <property name="vexpand-set">True</property>
+      <object class="AdwPreferencesGroup">
         <child>
-          <object class="AdwPreferencesGroup" id="nmap_target_group">
-            <property name="title" translatable="yes">Targets</property>
-            <property name="halign">baseline-fill</property>
-            <property name="hexpand">True</property>
-            <property name="hexpand-set">True</property>
+          <object class="AdwBanner" id="nmap_warning_banner">
+            <property name="title" translatable="yes">&lt;b&gt;WARNING:&lt;/b&gt; Do not use this tool on any hosts or networks &lt;u&gt;you do not explicitely have permission&lt;/u&gt; to scan.</property>
+            <property name="button-label" translatable="yes">Dismiss</property>
+            <property name="revealed">True</property>
             <property name="margin-bottom">10</property>
-            <property name="margin-end">5</property>
+            <property name="margin-end">10</property>
+            <property name="margin-start">10</property>
             <property name="margin-top">10</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <object class="AdwBanner" id="error_banner">
+            <property name="button-label" translatable="yes">Dismiss</property>
+            <property name="revealed">False</property>
+            <property name="margin-bottom">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-top">10</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <!-- Corrected AdwActionRow with GtkSpinner as a suffix -->
+          <object class="AdwActionRow" id="nmap_status_row">
+            <property name="title" translatable="yes">Scan Status</property>
+            <property name="subtitle" translatable="yes"></property>
+            <property name="subtitle-visible">False</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <suffix>
+              <object class="AdwSpinner" id="nmap_spinner">
+                <property name="spinning">True</property>
+                <property name="visible">False</property>
+              </object>
+            </suffix>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Scan Output</property>
+        <child>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">6</property> <!-- Optional: adds some space between the two groups -->
+            <property name="halign">fill</property>
+            <property name="hexpand">True</property>
+            <property name="valign">fill</property>
             <property name="vexpand">True</property>
-            <property name="vexpand-set">True</property>
             <child>
-              <object class="AdwScrolledWindow" id="nmap_target_scrolled_window">
+              <object class="AdwPreferencesGroup" id="nmap_target_group">
+                <property name="title" translatable="yes">Targets</property>
+                <property name="halign">fill</property>
+                <property name="hexpand">True</property>
                 <property name="margin-bottom">10</property>
-                <property name="margin-end">10</property>
-                <property name="margin-start">10</property>
+                <property name="margin-end">5</property>
                 <property name="margin-top">10</property>
                 <property name="vexpand">True</property>
-                <property name="vexpand-set">True</property>
                 <child>
-                  <object class="GtkListBox" id="nmap_target_listbox">
-                    <property name="css-classes">card
-</property>
+                  <object class="AdwScrolledWindow" id="nmap_target_scrolled_window">
+                    <property name="margin-bottom">10</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-top">10</property>
                     <property name="vexpand">True</property>
-                    <property name="vexpand-set">True</property>
+                    <child>
+                      <object class="AdwListBox" id="nmap_target_listbox">
+                        <property name="vexpand">True</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
             </child>
-            <layout>
-              <property name="column">0</property>
-              <property name="column-span">1</property>
-              <property name="row">0</property>
-              <property name="row-span">10</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="AdwPreferencesGroup" id="nmap_results_group">
-            <property name="title" translatable="yes">Scan Results</property>
-            <property name="halign">baseline-fill</property>
-            <property name="hexpand">True</property>
-            <property name="hexpand-set">True</property>
-            <property name="margin-bottom">10</property>
-            <property name="margin-start">5</property>
-            <property name="margin-top">10</property>
-            <property name="vexpand">True</property>
-            <property name="vexpand-set">True</property>
             <child>
-              <object class="AdwScrolledWindow" id="nmap_results_adinw_scrolled_window">
-                <property name="halign">baseline-fill</property>
-                <!-- <property name="has-frame">True</property> AdwScrolledWindow doesn't have has-frame -->
+              <object class="AdwPreferencesGroup" id="nmap_results_group">
+                <property name="title" translatable="yes">Scan Results</property>
+                <property name="halign">fill</property>
                 <property name="hexpand">True</property>
-                <property name="hexpand-set">True</property>
-                <!-- <property name="kinetic-scrolling">False</property> Not a direct AdwScrolledWindow property -->
                 <property name="margin-bottom">10</property>
-                <property name="margin-end">10</property>
-                <property name="margin-start">10</property>
+                <property name="margin-start">5</property>
                 <property name="margin-top">10</property>
-                <!-- <property name="max-content-width">150</property> Not a direct AdwScrolledWindow property -->
-                <!-- <property name="min-content-height">50</property> Not a direct AdwScrolledWindow property -->
                 <property name="vexpand">True</property>
-                <property name="vexpand-set">True</property>
+                <child>
+                  <object class="AdwScrolledWindow" id="nmap_results_adinw_scrolled_window">
+                    <property name="halign">fill</property>
+                    <property name="hexpand">True</property>
+                    <property name="margin-bottom">10</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-start">10</property>
+                    <property name="margin-top">10</property>
+                    <property name="vexpand">True</property>
+                  </object>
+                </child>
               </object>
             </child>
-            <layout>
-              <property name="column">1</property>
-              <property name="column-span">5</property>
-              <property name="row">0</property>
-              <property name="row-span">10</property>
-            </layout>
           </object>
         </child>
       </object>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -26,7 +26,7 @@ class HeaderItem(GObject.Object):
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/http_page.ui")
-class HttpPage(Gtk.Box):
+class HttpPage(Adw.PreferencesPage):
     __gtype_name__ = "HttpPage"
 
     http_entry_row = Gtk.Template.Child("http_entry_row")

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -27,7 +27,7 @@ class NmapItem(GObject.Object):
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
-class NmapPage(Gtk.Box):
+class NmapPage(Adw.PreferencesPage):
     __gtype_name__ = "NmapPage"
 
     nmap_target_entryrow = Gtk.Template.Child("nmap_target_entryrow")
@@ -272,7 +272,7 @@ class NmapPage(Gtk.Box):
         self._set_scan_status(ScanStatus.FAILED, f"Scan failed for {target}")
         logger.debug(f"NmapPage._handle_scan_error: Finished for target '{target}'.")
 
-    def _on_target_selected(self, _listbox: Gtk.ListBox, row: Optional[Gtk.ListBoxRow]):
+    def _on_target_selected(self, _listbox: Adw.ListBox, row: Optional[Adw.ActionRow]):
         logger.debug(f"NmapPage._on_target_selected: Triggered with listbox: {_listbox}, row: {row}")
         if row is None:
             logger.debug("NmapPage._on_target_selected: Row is None, clearing source_buffer.")
@@ -280,14 +280,11 @@ class NmapPage(Gtk.Box):
             logger.debug("NmapPage._on_target_selected: Finished due to None row.")
             return
 
-        child_widget = row.get_child()
-        logger.debug(f"NmapPage._on_target_selected: Row child_widget: {child_widget}")
-        if child_widget:
-            item_obj = child_widget.get_data("NmapItem")
-            logger.debug(f"NmapPage._on_target_selected: Retrieved item_obj from child_widget data: {item_obj} (type: {type(item_obj)})")
-            if isinstance(item_obj, NmapItem):
-                selected_target_key = item_obj.key
-                logger.debug(f"NmapPage._on_target_selected: Target selected: {selected_target_key}")
+        item_obj = row.get_data("NmapItem")
+        logger.debug(f"NmapPage._on_target_selected: Retrieved item_obj from row data: {item_obj} (type: {type(item_obj)})")
+        if isinstance(item_obj, NmapItem):
+            selected_target_key = item_obj.key
+            logger.debug(f"NmapPage._on_target_selected: Target selected: {selected_target_key}")
 
                 result_yaml = self.results_by_host.get(
                     selected_target_key,
@@ -303,7 +300,7 @@ class NmapPage(Gtk.Box):
                 logger.debug(f"NmapPage._on_target_selected: Finished for target '{selected_target_key}'.")
                 return
 
-        logger.warning("NmapPage._on_target_selected: Could not retrieve NmapItem from selected row or row child.")
+        logger.warning("NmapPage._on_target_selected: Could not retrieve NmapItem from selected row.")
         logger.debug("NmapPage._on_target_selected: Before self.source_buffer.set_text('') (due to bad item).")
         self.source_buffer.set_text("")
         logger.debug("NmapPage._on_target_selected: After self.source_buffer.set_text('') (due to bad item).")
@@ -444,14 +441,11 @@ class NmapPage(Gtk.Box):
         logger.debug("NmapPage._clear_error: error_banner title set to empty string.")
         logger.debug("NmapPage._clear_error: Finished.")
 
-    def _create_target_listbox_row(self, item: NmapItem) -> Gtk.ListBoxRow:
-        logger.debug(f"NmapPage._create_target_listbox_row: Creating row for item with key: '{item.key}'")
-        simple_row = Gtk.ListBoxRow()
-        logger.debug(f"NmapPage._create_target_listbox_row: Gtk.ListBoxRow created: {simple_row}")
-        simple_label = Gtk.Label(label=item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
-        logger.debug(f"NmapPage._create_target_listbox_row: Gtk.Label created: {simple_label} with label '{item.key}'")
-        simple_label.set_data("NmapItem", item)
-        logger.debug(f"NmapPage._create_target_listbox_row: Stored NmapItem ({item}) as data on label.")
-        simple_row.set_child(simple_label)
-        logger.debug(f"NmapPage._create_target_listbox_row: Set label as child of row. Returning row: {simple_row}")
+    def _create_target_listbox_row(self, item: NmapItem) -> Adw.ActionRow:
+        logger.debug(f"NmapPage._create_target_listbox_row: Creating ActionRow for item with key: '{item.key}'")
+        simple_row = Adw.ActionRow(title=item.key)
+        logger.debug(f"NmapPage._create_target_listbox_row: Adw.ActionRow created: {simple_row} with title '{item.key}'")
+        simple_row.set_data("NmapItem", item)
+        logger.debug(f"NmapPage._create_target_listbox_row: Stored NmapItem ({item}) as data on ActionRow.")
+        logger.debug(f"NmapPage._create_target_listbox_row: Returning row: {simple_row}")
         return simple_row


### PR DESCRIPTION
- I changed the root Gtk.Box to Adw.PreferencesPage for the DNS, HTTP, and Nmap pages.
- I updated the Python class inheritance for these pages accordingly.
- I removed redundant Gtk.Grid layouts, using Adw.PreferencesGroup directly or Gtk.Box for specific layouts (e.g., horizontal).
- I refactored the Nmap target list to use Adw.ListBox and Adw.ActionRow instead of Gtk.ListBox/Gtk.ListBoxRow.
- I replaced the Gtk.Spinner with Adw.Spinner in the Nmap page.
- I reviewed and confirmed the appropriate usage of Gtk.ColumnView, Gtk.TextView, Gtk.Button, and Gtk.MenuButton where Adwaita equivalents are not available or not necessary.