### PR TITLE
I've fixed the gi imports and UI file XML structures.

### DIFF
--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -9,24 +9,24 @@
         <property name="title" translatable="yes">Request Parameters</property>
         <child>
           <object class="AdwEntryRow" id="http_entry_row">
-                <property name="activates-default">True</property>
-                <property name="focusable">True</property>
-                <property name="input-purpose">url</property>
-                <property name="max-width-chars">250</property>
-                <property name="show-apply-button">True</property>
-                <property name="title" translatable="yes">URL to fetch HTTP headers from</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwSwitchRow" id="http_pragma_switch_row">
-                <property name="subtitle" translatable="yes">Enable this to send Akamai Pragma headers in your request</property>
-                <property name="title" translatable="yes">Akamai Debug Headers</property>
-              </object>
-            </child>
+            <property name="activates-default">True</property>
+            <property name="focusable">True</property>
+            <property name="input-purpose">url</property>
+            <property name="max-width-chars">250</property>
+            <property name="show-apply-button">True</property>
+            <property name="title" translatable="yes">URL to fetch HTTP headers from</property>
           </object>
         </child>
         <child>
-      <object class="AdwPreferencesGroup">
+          <object class="AdwSwitchRow" id="http_pragma_switch_row">
+            <property name="subtitle" translatable="yes">Enable this to send Akamai Pragma headers in your request</property>
+            <property name="title" translatable="yes">Akamai Debug Headers</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup"> <!-- Group for the error banner -->
         <child>
           <object class="AdwBanner" id="http_error_banner">
             <property name="button-label" translatable="yes">Dismiss</property>
@@ -35,51 +35,49 @@
             <property name="revealed">False</property>
           </object>
         </child>
-          </object>
-        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup" id="http_response_group">
+        <property name="title" translatable="yes">Response Headers</property>
+        <property name="visible">False</property>
         <child>
-          <object class="AdwPreferencesGroup" id="http_response_group">
-            <property name="title" translatable="yes">Response Headers</property>
-            <property name="visible">False</property>
+          <object class="GtkColumnView" id="http_column_view">
+            <property name="enable-rubberband">True</property>
+            <property name="margin-bottom">10</property>
+            <property name="margin-end">10</property>
+            <property name="margin-start">10</property>
+            <property name="margin-top">10</property>
+            <property name="model">
+              <object class="GtkMultiSelection"/>
+            </property>
+            <property name="overflow">hidden</property>
+            <property name="reorderable">False</property>
+            <property name="show-column-separators">true</property>
+            <property name="show-row-separators">true</property>
+            <property name="vexpand">True</property>
             <child>
-              <object class="GtkColumnView" id="http_column_view">
-                <property name="enable-rubberband">True</property>
-                <property name="margin-bottom">10</property>
-                <property name="margin-end">10</property>
-                <property name="margin-start">10</property>
-                <property name="margin-top">10</property>
-                <property name="model">
-                  <object class="GtkMultiSelection"/>
+              <object class="GtkColumnViewColumn" id="header_name_column">
+                <property name="factory">
+                  <object class="GtkSignalListItemFactory"/>
                 </property>
-                <property name="overflow">hidden</property>
-                <property name="reorderable">False</property>
-                <property name="show-column-separators">true</property>
-                <property name="show-row-separators">true</property>
-                <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkColumnViewColumn" id="header_name_column">
-                    <property name="factory">
-                      <object class="GtkSignalListItemFactory"/>
-                    </property>
-                    <property name="fixed-width">0</property>
-                    <property name="title" translatable="yes">Response Header</property>
-                    <property name="visible">False</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkColumnViewColumn" id="header_value_column">
-                    <property name="expand">True</property>
-                    <property name="factory">
-                      <object class="GtkSignalListItemFactory"/>
-                    </property>
-                    <property name="resizable">True</property>
-                    <property name="sorter">
-                      <object class="GtkColumnViewSorter"/>
-                    </property>
-                    <property name="title" translatable="yes">Response Header Value</property>
-                    <property name="visible">False</property>
-                  </object>
-                </child>
+                <property name="fixed-width">0</property>
+                <property name="title" translatable="yes">Response Header</property>
+                <property name="visible">False</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkColumnViewColumn" id="header_value_column">
+                <property name="expand">True</property>
+                <property name="factory">
+                  <object class="GtkSignalListItemFactory"/>
+                </property>
+                <property name="resizable">True</property>
+                <property name="sorter">
+                  <object class="GtkColumnViewSorter"/>
+                </property>
+                <property name="title" translatable="yes">Response Header Value</property>
+                <property name="visible">False</property>
               </object>
             </child>
           </object>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -5,10 +5,14 @@
   <template class="WebScanPage" parent="AdwPreferencesPage">
     <property name="title">Web Scan</property>
     <child>
-      <object class="AdwBanner" id="error_banner_webscan">
-        <property name="button-label" translatable="yes">Dismiss</property>
-        <property name="revealed">False</property>
-        <signal name="button-clicked" handler="on_error_banner_dismiss_clicked"/>
+      <object class="AdwPreferencesGroup"> <!-- Wrapper for the banner -->
+        <child>
+          <object class="AdwBanner" id="error_banner_webscan">
+            <property name="button-label" translatable="yes">Dismiss</property>
+            <property name="revealed">False</property>
+            <signal name="button-clicked" handler="on_error_banner_dismiss_clicked"/>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/src/main.py
+++ b/src/main.py
@@ -3,8 +3,8 @@ import os
 import sys
 
 import gi
-gi.require_version("Gtk", "4.0")
-gi.require_version("Adw", "1")
+gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Adw, Gio, GLib
 
 from .constants import APP_ID, VERSION, RESOURCE_PREFIX, PKGDATADIR

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,8 @@
 import logging
 import gi
 
-gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
+gi.require_version('Gtk', '4.0')
 gi.require_version('GtkSource', '5')
 
 from gi.repository import Gtk, GtkSource


### PR DESCRIPTION
- I ensured all Python files use standard gi import patterns.
- I corrected XML errors in src/gtk/http_page.ui by fixing the nesting of Adw.PreferencesGroup elements.
- I verified and ensured the correct XML structure for Adw.PreferencesPage in dns_page.ui, nmap_page.ui, and webscan_page.ui (I wrapped a banner in webscan_page.ui).

These changes should address the build failure caused by malformed UI XML and ensure consistent import patterns.