### PR TITLE
I fixed an AttributeError for Adw.ListBox in NmapPage.

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -138,7 +138,7 @@
                     <property name="margin-top">10</property>
                     <property name="vexpand">True</property>
                     <child>
-                      <object class="AdwListBox" id="nmap_target_listbox">
+                      <object class="GtkListBox" id="nmap_target_listbox">
                         <property name="vexpand">True</property>
                       </object>
                     </child>

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -272,7 +272,7 @@ class NmapPage(Adw.PreferencesPage):
         self._set_scan_status(ScanStatus.FAILED, f"Scan failed for {target}")
         logger.debug(f"NmapPage._handle_scan_error: Finished for target '{target}'.")
 
-    def _on_target_selected(self, _listbox: Adw.ListBox, row: Optional[Adw.ActionRow]):
+    def _on_target_selected(self, _listbox: Gtk.ListBox, row: Optional[Adw.ActionRow]):
         logger.debug(f"NmapPage._on_target_selected: Triggered with listbox: {_listbox}, row: {row}")
         if row is None:
             logger.debug("NmapPage._on_target_selected: Row is None, clearing source_buffer.")


### PR DESCRIPTION
I corrected the type hint in `src/nmap_page.py`'s `_on_target_selected` method from `Adw.ListBox` to `Gtk.ListBox`. I also reverted the class of `nmap_target_listbox` in `src/gtk/nmap_page.ui` from `Adw.ListBox` back to `Gtk.ListBox`.

Libadwaita uses `Gtk.ListBox` as the container for boxed lists, often populated with Adwaita rows like `Adw.ActionRow`. `Adw.ListBox` is not a valid class.