### PR TITLE
I've addressed the application startup and UI initialization issues.

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -35,7 +35,7 @@ class NmapPage(Adw.PreferencesPage):
     nmap_all_ports_switchrow = Gtk.Template.Child("nmap_all_ports_switchrow")
     nmap_scripts_dropdown = Gtk.Template.Child("nmap_scripts_dropdown")
     nmap_status_row = Gtk.Template.Child("nmap_status_row")
-    scan_spinner = Gtk.Template.Child("scan_spinner")
+    scan_spinner = Gtk.Template.Child("nmap_spinner")
 
     error_banner = Gtk.Template.Child("error_banner")
     nmap_warning_banner = Gtk.Template.Child("nmap_warning_banner")


### PR DESCRIPTION
- I corrected the Gtk.Template.Child ID for 'scan_spinner' in nmap_page.py to match 'nmap_spinner' ID in nmap_page.ui.
- I verified and ensured consistency of Gtk.Template.Child IDs and custom widget class names across all relevant Python page modules and their corresponding .ui files.
- I confirmed GType registration patterns and the overall application startup sequence in main.py and window.py.

These changes address potential AttributeErrors and ensure that UI elements are correctly referenced and initialized, allowing your application to start as expected.