### PR TITLE
I've made some adjustments to ensure the Meson Python module installa…

### DIFF
--- a/meson-postinstall.py
+++ b/meson-postinstall.py
@@ -1,26 +1,22 @@
 #!/usr/bin/env python3
 
 import compileall
-import sys # Import sys
-import os # os can still be used if DESTDIR logic is desired for other purposes, but not for compileall path here.
+import sys
+import os
 
-# The directory to compile is passed by Meson as an argument.
-# sys.argv[0] is the script name
-# sys.argv[1] is the Meson build directory (relative to source root)
-# sys.argv[2] is the first custom argument ('modulesdir' from meson.build)
-if len(sys.argv) > 2:
-    target_compile_dir = sys.argv[2]
-    print(f"Pre-compiling Python files in: {target_compile_dir}")
-    # Use quiet=1 to suppress verbose "Listing..." messages unless errors occur.
-    # legacy=True might be needed if there are symlinks to directories, but try without first.
-    success = compileall.compile_dir(target_compile_dir, force=True, quiet=1)
-    if not success:
-        print(f"Warning: compileall reported some errors for {target_compile_dir}.")
+if len(sys.argv) > 1:
+    base_modules_dir = sys.argv[1]
+    # The 'woes' subdirectory is where our actual package files are installed.
+    target_compile_dir = os.path.join(base_modules_dir, 'woes')
+
+    if os.path.isdir(target_compile_dir): # Ensure it's a directory
+        print(f"Pre-compiling Python files in: {target_compile_dir}")
+        # Use quiet=1 to suppress verbose "Listing..." messages unless errors occur.
+        # legacy=True helps with symlinks and older .pyc formats if encountered.
+        success = compileall.compile_dir(target_compile_dir, force=True, quiet=1, legacy=True)
+        if not success:
+            print(f"Warning: compileall reported some errors for {target_compile_dir}.")
+    else:
+        print(f"Warning: Target directory for compilation '{target_compile_dir}' does not exist or is not a directory. Skipping compilation.")
 else:
-    print("Warning: meson-postinstall.py did not receive the target directory argument.")
-
-# The DESTDIR logic is generally for staged installs and might not be what's needed here
-# for specifying the actual Python module installation path for compilation.
-# If DESTDIR is part of the path construction for target_compile_dir by Meson itself,
-# then sys.argv[2] would already include it.
-# For now, directly use sys.argv[2] as passed by Meson.
+    print("Warning: meson-postinstall.py did not receive the base modules directory argument (sys.argv[1]). Skipping compilation.")

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ gnome = import('gnome')
 python = import('python')
 
 # Find Python installation
-python_bin = python.find_installation('python3')
+python_bin = python.find_installation('python3', install_dir_method: 'prefix')
 
 if not python_bin.found()
     error('No valid Python installation found!')

--- a/src/meson.build
+++ b/src/meson.build
@@ -87,4 +87,4 @@ woes_sources = files(
 )
 
 # Install the Python source files
-python_bin.install_sources(woes_sources, subdir: conf.get('WOESDIR'))
+python_bin.install_sources(woes_sources, subdir: 'woes')


### PR DESCRIPTION
…tion path respects the prefix.

Here's a summary of what I did:

- I updated the main `meson.build` file. Now, when it figures out where to install Python modules, it takes the prefix into account.
- In `src/meson.build`, I adjusted how Python sources are installed. It now places them in a 'woes' subdirectory, using the prefix-aware path I set up.
- I also corrected `meson-postinstall.py`. It now correctly uses the provided base directory for modules and specifically targets the 'woes' subdirectory for byte-compilation.

These changes mean that Python modules will now be installed in the right spot based on the Meson `--prefix` you specify (like `/usr/local`), instead of going to a general system-wide location.