### PR TITLE
I've addressed several issues observed during application startup and…

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -57,7 +57,7 @@
       <object class="AdwPreferencesGroup" id="dns_results_group">
         <property name="title" translatable="yes">Lookup Results</property>
         <child>
-          <object class="AdwScrolledWindow" id="dns_results_scrolled_window">
+          <object class="GtkScrolledWindow" id="dns_results_scrolled_window">
             <property name="halign">baseline-fill</property>
             <property name="hexpand">True</property>
             <property name="hexpand-set">True</property>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -97,7 +97,6 @@
           <object class="AdwActionRow" id="nmap_status_row">
             <property name="title" translatable="yes">Scan Status</property>
             <property name="subtitle" translatable="yes"></property>
-            <property name="subtitle-visible">False</property>
             <property name="margin-start">10</property>
             <property name="margin-end">10</property>
             <suffix>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -49,15 +49,9 @@
                     <property name="valign">start</property>
                     <child>
                       <object class="AdwClampScrollable" id="http_clamp_scrollable">
-                        <property name="hadjustment">
-                          <object class="GtkAdjustment"/>
-                        </property>
                         <property name="maximum-size">1400</property>
                         <property name="tightening-threshold">500</property>
                         <property name="unit">px</property>
-                        <property name="vadjustment">
-                          <object class="GtkAdjustment"/>
-                        </property>
                         <child>
                           <object class="HttpPage">
                             <property name="overflow">hidden</property>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -137,27 +137,35 @@ class HttpPage(Adw.PreferencesPage):
         logger.debug(f"HttpPage._on_entry_row_activated: task_specific_data: {task_specific_data}")
         cancellable = Gio.Cancellable.new()
         logger.debug(f"HttpPage._on_entry_row_activated: Created Gio.Cancellable: {cancellable}")
-        new_task = Gio.Task.new(self, cancellable, self._fetch_headers_task_done_cb, None)
-        logger.debug(f"HttpPage._on_entry_row_activated: Created Gio.Task: {new_task}")
+        new_task = Gio.Task.new(self, cancellable, self._fetch_headers_task_done_cb, task_specific_data)
+        logger.debug(f"HttpPage._on_entry_row_activated: Created Gio.Task: {new_task} with task_data")
         # self._http_task_data_for_thread assignment removed
         self.current_http_task = new_task
         logger.debug(f"HttpPage._on_entry_row_activated: self.current_http_task set to: {self.current_http_task}")
         logger.debug(f"HttpPage._on_entry_row_activated: Starting async task fetch-headers by calling new_task.run_in_thread()")
-        new_task.run_in_thread(self._fetch_headers_task_thread_func, task_data=task_specific_data)
+        new_task.run_in_thread(self._fetch_headers_task_thread_func) # task_data removed from here
         logger.debug(f"HttpPage._on_entry_row_activated: After new_task.run_in_thread()")
 
     def _fetch_headers_task_thread_func(
         self,
         task: Gio.Task,
         _source_object_do_not_use, # Renamed from source_object
-        task_data: dict, # Changed from _task_data_ignored
+        _task_data_from_run_in_thread, # This is the task_data from run_in_thread, now unused
         cancellable: Optional[Gio.Cancellable]
     ):
         logger.debug(
             f"HttpPage._fetch_headers_task_thread_func: Starting for task {task}, "
-            f"_source_object_do_not_use: {_source_object_do_not_use}, task_data: {task_data}, cancellable: {cancellable}"
+            f"_source_object_do_not_use: {_source_object_do_not_use}, "
+            f"_task_data_from_run_in_thread: {_task_data_from_run_in_thread}, cancellable: {cancellable}"
         )
-        current_task_data = task_data # Use passed task_data
+        current_task_data = task.get_task_data() # Retrieve data from the task object
+        if current_task_data is None:
+            logger.error("HttpPage._fetch_headers_task_thread_func: task.get_task_data() returned None. Cannot proceed.")
+            # Handle error: Maybe return an error on the task
+            g_error = GLib.Error("Task data missing.", Gio.io_error_quark(), Gio.IOErrorEnum.FAILED.value)
+            task.return_error(g_error)
+            return
+
         url = current_task_data["url"]
         use_akamai_pragma = current_task_data["use_akamai_pragma"]
         logger.debug(f"HttpPage._fetch_headers_task_thread_func: Parameters - url: '{url}', use_akamai_pragma: {use_akamai_pragma}")

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ import logging
 from . import constants
 
 # Logger setup
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(name)s:%(message)s')
+logging.basicConfig(level=logging.WARNING, format='%(asctime)s %(levelname)s:%(name)s:%(message)s')
 logger = logging.getLogger(__name__)
 logger.info("Script execution started (main.py top level).")
 
@@ -137,14 +137,9 @@ class WoesApplication(Adw.Application):
         logger.debug("Handling local options: %s", options)
         if options.contains('debug'):
             self.debug_enabled = True
-            logger.debug(f"Debug mode set to: {self.debug_enabled}")
-            # Ensure logging is forced if already configured by basicConfig
-            logging.basicConfig(
-                level=logging.DEBUG,
-                format='%(asctime)s %(levelname)s:%(name)s:%(message)s',
-                force=True
-            )
-            logger.debug("Debug mode enabled via command line. Logging reconfigured.")
+            # Get the root logger and set its level to DEBUG
+            logging.getLogger().setLevel(logging.DEBUG)
+            logger.debug("Debug mode enabled via command line. Logging level set to DEBUG.")
         return -1
 
     def do_command_line(self, command_line):


### PR DESCRIPTION
… operation, focusing on GTK warnings, logging, and a TypeError.

Here's a summary of the changes:

- Logging:
    - INFO level logs are now only shown when you pass the --debug flag.
    - The default logging level is now WARNING.
- GTK Warnings:
    - I removed invalid 'hadjustment' and 'vadjustment' properties from AdwClampScrollable elements in window.ui that were causing warnings for HttpPage.
    - I removed an invalid 'subtitle-visible' property from an AdwActionRow in nmap_page.ui.
    - I corrected 'AdwScrolledWindow' to 'GtkScrolledWindow' in dns_page.ui to fix an 'Invalid object type' error.
    - I verified that other reported adjustment/scroll-policy properties were not present on NmapPage and DNSPage container elements in window.ui.
- TypeError in http_page.py:
    - I corrected the way task_data is passed to Gio.Task.run_in_thread by associating it with the Task object at creation time and retrieving it via task.get_task_data() in the thread function.

I attempted to test these changes, but encountered some persistent build environment issues that prevented a full verification. The fixes are based on the error messages and standard GTK/Python practices.