### PR TITLE
Here's my progress on converting .ui files to .blp format.

### DIFF
--- a/src/woes.gresource.xml
+++ b/src/woes.gresource.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/mclellac/woes">
-    <file content-type="text/blueprint">gtk/window.blp</file>
-    <file content-type="text/blueprint">gtk/http_page.blp</file>
-    <file content-type="text/blueprint">gtk/nmap_page.blp</file>
-    <file content-type="text/blueprint">gtk/dns_page.blp</file>
-    <file content-type="text/blueprint">gtk/preferences.blp</file>
-    <file content-type="text/blueprint">gtk/help-overlay.blp</file>
-    <file content-type="text/blueprint">gtk/webscan_page.blp</file>
+    <file>gtk/window.blp</file>
+    <file>gtk/http_page.blp</file>
+    <file>gtk/nmap_page.blp</file>
+    <file>gtk/dns_page.blp</file>
+    <file>gtk/preferences.blp</file>
+    <file>gtk/help-overlay.blp</file>
+    <file>gtk/webscan_page.blp</file>
     <file compressed="true">gtk/style.css</file>
     <file compressed="true">gtk/style-dark.css</file>
     <file preprocess="xml-stripblanks">../data/icons/hicolor/symbolic/emotes/face-angel-symbolic.svg</file>


### PR DESCRIPTION
I've updated all explicit code and resource references to use .blp and corrected the gresource.xml file to avoid a build failure.

However, I'm currently blocked by a persistent issue with the Python/PyGObject environment. The build configuration consistently fails during a check for PyGObject importability with the error:

"ImportError: cannot import name '_gi' from partially initialized module 'gi' (most likely due to a circular import)"

This environment error is preventing the application from being built, so I can't test or verify the Blueprint conversion. The application cannot proceed past the initial setup phase.

In this iteration, I removed the `content-type` attribute from .blp file entries in `src/woes.gresource.xml`.

Without a resolution to the underlying Python environment / PyGObject import error, I can't successfully complete this.