### PR TITLE
Fix Blueprint UI compilation and GResource packaging

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -43,6 +43,24 @@ endif
 
 conf.set('RESOURCE_PATH', resource_path)
 
+# Define Blueprint sources
+gtk_dir = 'gtk'
+blueprint_sources = files(
+  join_paths(gtk_dir, 'window.blp'),
+  join_paths(gtk_dir, 'http_page.blp'),
+  join_paths(gtk_dir, 'nmap_page.blp'),
+  join_paths(gtk_dir, 'dns_page.blp'),
+  join_paths(gtk_dir, 'preferences.blp'),
+  join_paths(gtk_dir, 'help-overlay.blp'),
+  join_paths(gtk_dir, 'webscan_page.blp')
+)
+
+# Compile Blueprint files
+compiled_blueprints = gnome.blueprint(
+  'woesgtk',
+  sources: blueprint_sources
+)
+
 # Configure the woes script file
 configure_file(
   input: 'woes.in',
@@ -62,6 +80,8 @@ gnome.compile_resources(
   gresource_bundle: true,
   install: true,
   install_dir: conf.get('PKGDATADIR'),
+  # Meson should automatically infer dependency on compiled_blueprints
+  # if woes.gresource.xml refers to the generated .ui files.
 )
 
 # List of source files

--- a/src/woes.gresource.xml
+++ b/src/woes.gresource.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/mclellac/woes">
-    <file>gtk/window.blp</file>
-    <file>gtk/http_page.blp</file>
-    <file>gtk/nmap_page.blp</file>
-    <file>gtk/dns_page.blp</file>
-    <file>gtk/preferences.blp</file>
-    <file>gtk/help-overlay.blp</file>
-    <file>gtk/webscan_page.blp</file>
+    <file>gtk/window.ui</file>
+    <file>gtk/http_page.ui</file>
+    <file>gtk/nmap_page.ui</file>
+    <file>gtk/dns_page.ui</file>
+    <file>gtk/preferences.ui</file>
+    <file>gtk/help-overlay.ui</file>
+    <file>gtk/webscan_page.ui</file>
     <file compressed="true">gtk/style.css</file>
     <file compressed="true">gtk/style-dark.css</file>
     <file preprocess="xml-stripblanks">../data/icons/hicolor/symbolic/emotes/face-angel-symbolic.svg</file>


### PR DESCRIPTION
The application was failing to load GTK UI templates because raw Blueprint (.blp) files were being included in the GResource bundle instead of their compiled XML (.ui) counterparts. This caused Gtk-WARNINGs about malformed XML and a critical error due to missing .ui resources.

This commit addresses the issue by:
1. Modifying `src/meson.build` to add a `gnome.blueprint()` step. This compiles all `.blp` files in `src/gtk/` into `.ui` files during the build process.
2. Updating `src/woes.gresource.xml` to reference the compiled `.ui` files (e.g., `gtk/window.ui`) instead of the source `.blp` files.

These changes ensure that GTK receives valid XML UI definitions, resolving the template precompilation warnings and the resource loading error.

Note: Full testing of the application post-fix was hindered by a persistent Python GObject Introspection (`python3-gi`) import error within the build environment, which prevented a successful build and run. The changes are based on established best practices for Meson and Blueprint integration.