### PR TITLE
Input:

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -57,7 +57,7 @@ gnome = import('gnome')
 blueprint_compiler = find_program('blueprint-compiler', required: true)
 
 # Define Blueprint source files and prepare for custom targets
-gtk_dir_relative = 'gtk' // Relative path from current meson.build (src/) to gtk blueprint files
+gtk_dir_relative = 'gtk' # Relative path from current meson.build (src/) to gtk blueprint files
 blp_files = [
   'window.blp',
   'http_page.blp',


### PR DESCRIPTION
Fix comment syntax in src/meson.build

Changed '//' comment to '#' for compatibility with Meson 1.8.1. This addresses the "ERROR: Expecting eof got id" build failure.

Output:
I've fixed the comment syntax in `src/meson.build`.

I changed '//' comments to '#' for compatibility with Meson 1.8.1. This should address the "ERROR: Expecting eof got id" build failure you were seeing.