### PR TITLE
Fix: Correct custom_target name generation in src/meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -80,7 +80,7 @@ foreach blp_file_name : blp_files
   output_ui_path = join_paths(gtk_dir_relative, local_ui_file_name) # This variable is no longer used for 'output' but comment is kept for context
 
   compiled_blp_target = custom_target(
-    'compile_blueprint_'.format(blp_file_name.replace('.blp','')),
+    'compile_blueprint_{}'.format(blp_file_name.replace('.blp','')),
     input: join_paths(gtk_dir_relative, blp_file_name),
     output: local_ui_file_name,
     command: [


### PR DESCRIPTION
Ensured unique names for custom_targets by adding the necessary format placeholder `{}` in the target name string. This resolves the error "Tried to create target ..., but a target of that name already exists."