### PR TITLE
I've made some adjustments to the `meson.build` file to address the `…

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ gsettings_schemadir = join_paths(get_option('prefix'), 'share', 'glib-2.0', 'sch
 
 # Prepare configuration data
 conf = configuration_data()
+conf.set('PYTHON_SITE_PACKAGES_DIR', site_packages_dir)
 conf.set('PYTHON', python_bin.full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('LOCALEDIR', localedir)
@@ -104,7 +105,7 @@ gnome.compile_resources(
   gresource_bundle: true,
   install: true,
   install_dir: conf.get('PKGDATADIR'),
-  depends: compiled_ui_outputs
+  dependencies: compiled_ui_outputs
 )
 
 # List of source files


### PR DESCRIPTION
…gnome.compile_resources` and configuration warning.

Specifically:
- I updated `depends` to `dependencies` in the `gnome.compile_resources` call.
- I added `PYTHON_SITE_PACKAGES_DIR` to the configuration data for `woes.in` to resolve a warning.

It's worth noting that there might still be some build issues related to your system's Python environment, particularly with the 'gi' module affecting 'blueprint-compiler'.