### PR TITLE
I've made a couple of changes to address the Meson build errors and w…

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -20,7 +20,6 @@ gsettings_schemadir = join_paths(get_option('prefix'), 'share', 'glib-2.0', 'sch
 
 # Prepare configuration data
 conf = configuration_data()
-conf.set('PYTHON_SITE_PACKAGES_DIR', site_packages_dir)
 conf.set('PYTHON', python_bin.full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('LOCALEDIR', localedir)
@@ -105,7 +104,7 @@ gnome.compile_resources(
   gresource_bundle: true,
   install: true,
   install_dir: conf.get('PKGDATADIR'),
-  dependencies: compiled_ui_outputs
+  depends: compiled_ui_outputs
 )
 
 # List of source files


### PR DESCRIPTION
…arnings:

- In `src/meson.build`, I updated `dependencies:` to `depends:` in the `gnome.compile_resources` call. This should fix an error you were seeing with Meson 1.8.1, as it seems your specific version or environment prefers the older keyword.
- I also removed an unused configuration variable, `PYTHON_SITE_PACKAGES_DIR`, from `src/meson.build`. This variable was defined but not actually used in `src/woes.in` (it was commented out there), which was causing a Meson warning. The existing way `woes.in` manages its Python path using `WOESDIR` is still in place and working fine.