### PR TITLE
Fix: Correct paths for blueprint-compiler in meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -88,10 +88,10 @@ foreach blp_file_name : blp_files
       'batch-compile',
       # Output directory for blueprint-compiler: <build_dir>/src/
       meson.current_build_dir(),
-      # Input directory for blueprint-compiler: <source_dir>/src/gtk/
-      join_paths(meson.current_source_dir(), gtk_dir_relative),
+      # Input directory for blueprint-compiler: <source_dir>/src/
+      meson.current_source_dir(),
       # File to compile, relative to the input directory specified above
-      blp_file_name
+      join_paths(gtk_dir_relative, blp_file_name)
     ]
   )
   compiled_ui_outputs += compiled_blp_target


### PR DESCRIPTION
The build was failing because blueprint-compiler could not find the .blp files. The errors indicated "No such file or directory."

This change modifies src/meson.build to adjust the arguments passed to `blueprint-compiler batch-compile`:
- The input directory for blueprint-compiler is now set to `meson.current_source_dir()` (i.e., the `src` directory).
- The filenames are now specified relative to this input directory (e.g., `gtk/window.blp`).

This ensures that blueprint-compiler correctly resolves the paths to the source .blp files.

Verifying this fix by running the full build or by directly invoking blueprint-compiler was unfortunately blocked by a persistent Python PyGObject import error in the execution environment (ImportError: cannot import name '_gi'). This environmental issue is unrelated to the pathing logic for blueprint-compiler. The submitted change is based on a direct analysis of the original error messages and the blueprint-compiler's expected command-line arguments.