### PR TITLE
Fix: Use absolute paths for blueprint-compiler in meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -88,10 +88,10 @@ foreach blp_file_name : blp_files
       'batch-compile',
       # Output directory for blueprint-compiler: <build_dir>/src/
       meson.current_build_dir(),
-      # Input directory for blueprint-compiler: <source_dir>/src/
-      meson.current_source_dir(),
+      # Input directory for blueprint-compiler: <source_dir>/src/gtk/
+      join_paths(meson.current_source_dir(), gtk_dir_relative),
       # File to compile, relative to the input directory specified above
-      join_paths(gtk_dir_relative, blp_file_name)
+      '@INPUT@'
     ]
   )
   compiled_ui_outputs += compiled_blp_target


### PR DESCRIPTION
The build was failing because blueprint-compiler could not find the .blp files. Previous attempts to fix this by adjusting relative paths were unsuccessful.

This change modifies src/meson.build to use Meson's '@INPUT@' directive for the filename argument passed to `blueprint-compiler`. This ensures that an absolute path to each .blp source file is provided.

The command structure for blueprint-compiler is now:
  blueprint-compiler batch-compile \
    <build_dir>/src \                  # Output directory
    <source_dir>/src/gtk \             # Input directory (base for resolving .blp files)
    @INPUT@                             # Absolute path to the .blp file

This approach is being tested by you to confirm it resolves the "No such file or directory" errors.