### PR TITLE
Build: Align blueprint-compiler command with GNOME docs

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -88,10 +88,10 @@ foreach blp_file_name : blp_files
       'batch-compile',
       # Output directory for blueprint-compiler: <build_dir>/src/
       meson.current_build_dir(),
-      # Input directory for blueprint-compiler: <source_dir>/src/gtk/
-      join_paths(meson.current_source_dir(), gtk_dir_relative),
+      # Input directory for blueprint-compiler: <source_dir>/src/
+      meson.current_source_dir(),
       # File to compile, relative to the input directory specified above
-      '@INPUT@'
+      join_paths(gtk_dir_relative, blp_file_name)
     ]
   )
   compiled_ui_outputs += compiled_blp_target


### PR DESCRIPTION
This commit updates the `custom_target` for blueprint compilation in `src/meson.build` to strictly follow the command structure specified in the official GNOME Blueprint compiler documentation: `blueprint-compiler batch-compile @OUTPUT@ @CURRENT_SOURCE_DIR@ @INPUT@`

For the project's looped compilation of individual .blp files, this translates to:
- `@OUTPUT@` -> `meson.current_build_dir()`
- `@CURRENT_SOURCE_DIR@` -> `meson.current_source_dir()` (the `src/` dir)
- `@INPUT@` -> `join_paths(gtk_dir_relative, blp_file_name)` (e.g., `gtk/window.blp`)

This results in the command structure:
`[blueprint_compiler, 'batch-compile', meson.current_build_dir(), meson.current_source_dir(), join_paths(gtk_dir_relative, blp_file_name)]`

This version is being committed for your testing, as per your request to adhere to the documentation.