### PR TITLE
Build: Use 'blueprint-compiler compile' per Medium article

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -85,13 +85,10 @@ foreach blp_file_name : blp_files
     output: local_ui_file_name,
     command: [
       blueprint_compiler,
-      'batch-compile',
-      # Output directory for blueprint-compiler: <build_dir>/src/
-      meson.current_build_dir(),
-      # Input directory for blueprint-compiler: <source_dir>/src/
-      meson.current_source_dir(),
-      # File to compile, relative to the input directory specified above
-      join_paths(gtk_dir_relative, blp_file_name)
+      'compile',
+      '--output',
+      '@OUTPUT@',
+      '@INPUT@'
     ]
   )
   compiled_ui_outputs += compiled_blp_target


### PR DESCRIPTION
This commit updates the `custom_target` for blueprint compilation in `src/meson.build` based on the example found in a Medium article by "codenomad".

The command is changed from 'batch-compile' with positional arguments to 'compile' with an explicit '--output' flag:
  `[blueprint_compiler, 'compile', '--output', '@OUTPUT@', '@INPUT@']`

This uses Meson's `@OUTPUT@` and `@INPUT@` variables, which resolve to absolute paths for the output and input files respectively, making the command more explicit and hopefully robust.

This change is made after my previous attempts using 'batch-compile' based on other documentation interpretations failed to resolve the "No such file or directory" errors.