### PR TITLE
I'm working on the build for blueprint-compiler.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -83,12 +83,13 @@ foreach blp_file_name : blp_files
     'compile_blueprint_' + blp_file_name.replace('.blp',''),
     input: join_paths(gtk_dir_relative, blp_file_name),
     output: local_ui_file_name,
+    working_directory: join_paths(meson.current_source_dir(), gtk_dir_relative),
     command: [
       blueprint_compiler,
-      'compile',
-      '--output',
-      '@OUTPUT@',
-      '@INPUT@'
+      'batch-compile',
+      meson.current_build_dir(), # Absolute path to <build_dir>/src/
+      '.',                       # Input directory for blueprint-compiler (current dir, which is now src/gtk/)
+      blp_file_name              # Filename (e.g., "window.blp")
     ]
   )
   compiled_ui_outputs += compiled_blp_target


### PR DESCRIPTION
This involves an attempt to fix the blueprint compilation by using the `batch-compile` subcommand with Meson's `working_directory` feature.

The `custom_target` in `src/meson.build` is now configured to execute `blueprint-compiler batch-compile` with its working directory set to `src/gtk/` (where the .blp files reside).

The command structure is:
  `[blueprint_compiler, 'batch-compile', abs_output_dir, '.', blueprint_filename]`
run from within the `src/gtk/` directory.

This is an attempt to address issues where `blueprint-compiler` might not be correctly resolving relative paths based on its arguments alone. If this fails, I'll need your help to investigate further.