### PR TITLE
Fix Flatpak build and refine Meson configuration

### DIFF
--- a/build-flatpak.py
+++ b/build-flatpak.py
@@ -97,7 +97,7 @@ def build_flatpak():
             "-v",
             REPO_DIR,
             flatpak_bundle_path,
-            "com.github.mclellac.webops",
+            "com.github.mclellac.woes",
         ]
     )
 

--- a/com.github.mclellac.woes.json
+++ b/com.github.mclellac.woes.json
@@ -32,10 +32,7 @@
           "url": "https://files.pythonhosted.org/packages/f7/1b/8e6b3d1461331e4e8600faf099e7c62ba3c1603987dafdd558681fb8ba37/python-nmap-0.7.1.tar.gz",
           "sha256": "f75af6b91dd8e3b0c31f869db32163f62ada686945e5b7c25f84bc0f7fad3b64"
         }
-      ],
-      "build-options": {
-        "build-args": ["--share=network"]
-      }
+      ]
     },
     {
       "name": "dnspython",
@@ -46,8 +43,7 @@
       "build-options": {
         "env": {
           "FLATPAK_BUILD": "1"
-        },
-        "build-args": ["--share=network"]
+        }
       }
     },
     {
@@ -56,9 +52,7 @@
       "build-commands": [
         "pip3 install --no-cache-dir --prefix=/app git+https://github.com/psf/requests.git"
       ],
-      "build-options": {
-        "build-args": ["--share=network"]
-      }
+      ]
     },
     {
       "name": "pyyaml",
@@ -72,10 +66,7 @@
           "url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz",
           "sha256": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"
         }
-      ],
-      "build-options": {
-        "build-args": ["--share=network"]
-      }
+      ]
     },
     {
       "name": "nmap",

--- a/meson.build
+++ b/meson.build
@@ -35,11 +35,6 @@ dependencies = [
 ]
 
 # Python-based check for PyGObject
-python_exe = import('python').find_installation('python3') # python_bin is already defined, use that
-if not python_bin.found() # Use python_bin as defined earlier
-  error('Python3 installation not found by find_installation().')
-endif
-
 pygobject_check_script = '''#!/usr/bin/env python3
 import gi; print(gi.__version__)'''
 pygobject_check = run_command(python_bin, '-c', pygobject_check_script, check: false)


### PR DESCRIPTION
This commit addresses several issues to improve the Flatpak build process and clean up the Meson build configuration:

1.  **Corrected Flatpak App ID:** The `build-flatpak.py` script was using an incorrect application ID (`com.github.mclellac.webops`) when creating the Flatpak bundle. This has been changed to `com.github.mclellac.woes` to match the ID in the Flatpak manifest (`com.github.mclellac.woes.json`), resolving a critical error in the bundling process.

2.  **Refined `meson.build`:**
    *   Removed a redundant check for Python 3 installation. An earlier check for `python_bin` already covers this.

3.  **Standardized Flatpak Python Dependencies:**
    *   Removed unnecessary `build-args: ["--share=network"]` from the `build-options` of several Python library modules (`python-nmap`, `dnspython`, `python3-requests`, `pyyaml`) in the `com.github.mclellac.woes.json` manifest. These libraries typically do not require network access during their installation phase within the Flatpak build once their sources are downloaded.

These changes should improve the reliability of the Flatpak build and the clarity of the Meson build scripts.