### PR TITLE
Fix: Remove unknown working_directory argument from custom_target

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -88,7 +88,6 @@ foreach blp_file_name : blp_files
     # and the input directory to be relative to the current source directory (which is <source_dir>/src).
     # However, 'batch-compile' seems to interpret both paths relative to the CWD if they are relative.
     # By setting CWD to src/gtk, output dir becomes <build_dir>/src/gtk and input becomes <source_dir>/src/gtk.
-    working_directory: meson.current_source_dir() / gtk_dir_relative,
     command: [
       blueprint_compiler,
       'batch-compile',


### PR DESCRIPTION
The 'working_directory' keyword argument is not a valid argument for Meson's custom_target() function in the version you are using (1.8.1), causing a build failure.

This argument was originally intended to help blueprint-compiler resolve relative paths. However, the command already uses absolute paths for input and output directories, constructed with meson.current_build_dir() and meson.current_source_dir(). Therefore, the 'working_directory' argument is redundant and I have removed it to resolve the build error.