### PR TITLE
Fix: Correct blueprint file paths for custom_target

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -96,7 +96,7 @@ foreach blp_file_name : blp_files
       # Let's try making them absolute to avoid ambiguity.
       meson.current_build_dir() / gtk_dir_relative, # Output directory
       meson.current_source_dir() / gtk_dir_relative, # Input directory
-      blp_file_name
+      '@INPUT@'
     ]
   )
   compiled_ui_outputs += compiled_blp_target


### PR DESCRIPTION
This commit addresses a build failure in the custom_target responsible for compiling .blp files using blueprint-compiler.

The previous attempt to fix an issue with an unknown 'working_directory' argument was incomplete. Removing 'working_directory' without adjusting the input file path for blueprint-compiler led to "No such file or directory" errors for the .blp files.

This fix involves two changes:
1. Ensuring the 'working_directory' argument is removed from the custom_target, as it's not a valid Meson argument and the command now uses absolute paths for output and input directories.
2. Modifying the 'command' array within the custom_target to use '@INPUT@' as the argument for the blueprint filename. This ensures that Meson substitutes the full path to the source .blp file, which is correctly defined in the 'input:' field of the custom_target. This allows blueprint-compiler to locate the files correctly regardless of the Meson build process's current working directory.