### PR TITLE
Fix: Correct AttributeError in HttpPage error handling

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -191,14 +191,14 @@ class HttpPage(Adw.PreferencesPage):
             error_message = f"Request Error: {str(e)}"
             safe_error_message = str(error_message)
             g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
-            task.return_gerror(g_error) # Corrected: single call
+            task.return_error(g_error) # Corrected: single call
             return
         except Exception as e: # Catch any other unexpected errors
             logger.error("Task thread: Unexpected error for %s: %s", url, e, exc_info=True)
             error_message = f"An unexpected error occurred: {str(e)}"
             safe_error_message = str(error_message)
             g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
-            task.return_gerror(g_error) # Corrected: use return_gerror
+            task.return_error(g_error) # Corrected: use return_gerror
             return
 
 


### PR DESCRIPTION
The `_fetch_headers_task_thread_func` in `src/http_page.py` was attempting to call `task.return_gerror(g_error)` which is not a valid attribute of `Gio.Task`. This resulted in an `AttributeError` when handling exceptions like timeouts or other request errors, preventing proper error propagation.

This commit corrects the call to `task.return_error(g_error)`.

Attempts to add a specific unit test for timeout error propagation in `HttpPage` were unsuccessful due to pervasive mocking of the GTK and Gio environment in the existing test setup. This made it impossible to reliably instantiate or interact with the `HttpPage` class as a non-mock object.