### PR TITLE
Refactor: Use GLib.Variant for task return value in HttpPage

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -161,7 +161,11 @@ class HttpPage(Adw.PreferencesPage):
 
             response = requests.get(url, headers=request_headers, allow_redirects=False, timeout=10)
             response.raise_for_status()
-            task.return_value(dict(response.headers))
+            headers_dict = dict(response.headers)
+            # Ensure all keys and values in headers_dict are strings for "a{ss}"
+            cleaned_headers_dict = {str(k): str(v) for k, v in headers_dict.items()}
+            variant = GLib.Variant("a{ss}", cleaned_headers_dict)
+            task.return_value(variant)
         except requests.exceptions.HTTPError as e:
             logger.error("Task thread: HTTPError for %s: %s", url, e, exc_info=True)
             # Create a GError for HTTP errors
@@ -207,33 +211,38 @@ class HttpPage(Adw.PreferencesPage):
         headers = None  # Initialize headers
 
         try:
-            if local_task_ref:
-                # This call will raise a GLib.Error (caught as GObject.GError)
-                # if task.return_error() was called in the thread.
-                returned_value = local_task_ref.propagate_value()
-                # Check if returned_value is a dictionary and not None
-                if isinstance(returned_value, dict):
-                    headers = returned_value # No longer calling .get_boxed()
-                    logger.info("Successfully fetched headers (async)")
-                    self._update_column_view_model(headers)
-                    self.http_entry_row.remove_css_class("error")
-                elif returned_value is None: # Explicitly check for None
-                    logger.error("propagate_value returned None unexpectedly.")
-                    self._display_error("Failed to retrieve task result (returned None).")
-                    self.http_entry_row.add_css_class("error")
-                    self._update_column_view_model(None)
-                else:
-                    # Handle cases where returned_value is not a dict and not None
-                    logger.error(f"propagate_value returned an unexpected type: {type(returned_value)}")
-                    self._display_error(f"Failed to process task result (unexpected type: {type(returned_value).__name__}).")
-                    self.http_entry_row.add_css_class("error")
-                    self._update_column_view_model(None)
-            else:
-                logger.error("current_http_task was None in _fetch_headers_task_done_cb. Task might have been superseded or cleared prematurely.")
-                self._update_column_view_model(None) # Clear view if no task to process
-                # Optionally, display a generic error if this state is unexpected
-                # self._display_error("An unexpected error occurred (task not found).")
+            returned_gobject = local_task_ref.propagate_value()
+            headers = None  # Initialize headers
 
+            if isinstance(returned_gobject, GLib.Variant):
+                try:
+                    unpacked_value = returned_gobject.deep_unpack() # deep_unpack is safer for nested variants
+                    if isinstance(unpacked_value, dict):
+                        headers = unpacked_value
+                        logger.info("Successfully fetched headers (async, unpacked from GLib.Variant)")
+                        self._update_column_view_model(headers)
+                        self.http_entry_row.remove_css_class("error")
+                    else:
+                        logger.error(f"Unpacked GLib.Variant but did not get a dict, got {type(unpacked_value)}")
+                        self._display_error(f"Failed to process task result (unpacked unexpected type: {type(unpacked_value).__name__}).")
+                        self.http_entry_row.add_css_class("error")
+                        self._update_column_view_model(None)
+                except Exception as e:
+                    logger.error(f"Error unpacking GLib.Variant: {e}", exc_info=True)
+                    self._display_error(f"Failed to process task result (unpacking error: {e}).")
+                    self.http_entry_row.add_css_class("error")
+                    self._update_column_view_model(None)
+            elif returned_gobject is None: # Check if propagate_value itself returned None
+                logger.error("propagate_value returned None unexpectedly (task might have been cancelled or failed to set result).")
+                self._display_error("Failed to retrieve task result (returned None).")
+                self.http_entry_row.add_css_class("error")
+                self._update_column_view_model(None)
+            else:
+                # This block handles cases where propagate_value returns something other than GLib.Variant or None
+                logger.error(f"propagate_value returned an unexpected GObject type: {type(returned_gobject)}. Expected GLib.Variant.")
+                self._display_error(f"Failed to process task result (unexpected data type: {type(returned_gobject).__name__}).")
+                self.http_entry_row.add_css_class("error")
+                self._update_column_view_model(None)
         except GObject.GError as e: # Catch errors propagated by propagate_value()
             error_message = e.message
             logger.error("Error fetching headers (async GObject.GError): %s", error_message)


### PR DESCRIPTION
Previously, HttpPage's `_fetch_headers_task_thread_func` would return a Python dictionary directly via `task.return_value()`. In some cases, this led to `task.propagate_value()` in the callback returning an internal `_ResultTuple` type instead of the expected dictionary, causing errors.

This commit modifies the code to explicitly use `GLib.Variant` for transferring the headers dictionary:
- In `_fetch_headers_task_thread_func`, the dictionary of headers is wrapped into a `GLib.Variant("a{ss}", headers_dict)` before being passed to `task.return_value()`. Header keys and values are ensured to be strings.
- In `_fetch_headers_task_done_cb`, the result from `propagate_value()` is now expected to be a `GLib.Variant`. The code attempts to `deep_unpack()` this variant to retrieve the dictionary.

This change ensures a more robust and explicit way of passing Python dictionary data between threads via `Gio.Task`, resolving the issue of unexpected types being received in the callback.