### PR TITLE
Fix: Correct all instances of return_gerror typo in HttpPage

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -181,14 +181,14 @@ class HttpPage(Adw.PreferencesPage):
             error_message = "Connection Error: Failed to establish a connection."
             safe_error_message = str(error_message)
             g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
-            task.return_gerror(g_error)
+            task.return_error(g_error)
             return
         except requests.exceptions.Timeout as e:
             logger.warning("Task thread: Timeout for %s: %s", url, e, exc_info=True)
             error_message = "Timeout Error: The request timed out."
             safe_error_message = str(error_message)
             g_error = GLib.Error(message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.FAILED)
-            task.return_gerror(g_error)
+            task.return_error(g_error)
             return
         except requests.exceptions.RequestException as e:
             logger.error("Task thread: RequestException for %s: %s", url, e, exc_info=True)


### PR DESCRIPTION
This commit corrects all remaining instances of the `task.return_gerror` typo to `task.return_error` in the `_fetch_headers_task_thread_func` method within `src/http_page.py`. Specifically, the handlers for `requests.exceptions.ConnectionError` and `requests.exceptions.Timeout` were updated.

The `task.return_gerror` attribute does not exist for `Gio.Task` objects, and using it would lead to an `AttributeError`, preventing proper GError propagation from the task. Correcting this to `task.return_error` ensures that errors caught in the thread are correctly reported to the task callback, which can then be handled by `task.propagate_value()` (raising a GObject.GError) or similar mechanisms.

This is crucial for robust error handling and may resolve issues where unexpected object types (like `_ResultTuple`) were being propagated from tasks that encountered errors handled by these blocks.