### PR TITLE
Okay, I've added some detailed logging to help figure out why `_fetch…

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -387,6 +387,20 @@ class HttpPage(Adw.PreferencesPage):
 
         try:
             returned_obj = local_task_ref.propagate_value()
+            # --- START DEBUG LOGGING ---
+            logger.error(f"DEBUG: Raw returned_obj: {returned_obj!r}")
+            logger.error(f"DEBUG: Type of returned_obj: {type(returned_obj)}")
+            logger.error(f"DEBUG: Class of returned_obj: {getattr(returned_obj, '__class__', 'N/A')}")
+            if hasattr(returned_obj, '__class__') and hasattr(returned_obj.__class__, '__mro__'):
+                logger.error(f"DEBUG: MRO of returned_obj: {returned_obj.__class__.__mro__}")
+            else:
+                logger.error("DEBUG: MRO of returned_obj: N/A")
+            logger.error(f"DEBUG: Is returned_obj a GObject.Object? {isinstance(returned_obj, GObject.Object)}")
+            try:
+                logger.error(f"DEBUG: vars(returned_obj): {vars(returned_obj)}")
+            except TypeError:
+                logger.error("DEBUG: vars(returned_obj): Not applicable for this type.")
+            # --- END DEBUG LOGGING ---
             all_responses_data = None
 
             if returned_obj is None:


### PR DESCRIPTION
…_headers_task_done_cb` is getting an unexpected `_ResultTuple` type. This logging happens right after `task.propagate_value()` is called.

Here's what I'll be logging:
- The raw `repr()` of the object that's returned.
- Its `type()` and `__class__`.
- Its `__mro__` (Method Resolution Order).
- Whether it's a `GObject.Object`.
- The output of `vars()` if that's relevant.

This should give us a better idea of what kind of object is actually being returned by `GIO.Task` and where it's coming from.