### PR TITLE
Fix Nmap page errors and add new scan options

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -66,6 +66,36 @@
           </object>
         </child>
         <child>
+          <object class="AdwSwitchRow" id="nmap_service_version_switchrow">
+            <property name="title" translatable="yes">Service Version Detection (-sV)</property>
+            <property name="subtitle" translatable="yes">Attempt to determine the version of the service running on port</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwSwitchRow" id="nmap_no_ping_switchrow">
+            <property name="title" translatable="yes">No Ping Scan (-Pn)</property>
+            <property name="subtitle" translatable="yes">Skip host discovery, scan all targets</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwComboRow" id="nmap_timing_template_comborow">
+            <property name="title" translatable="yes">Timing Template (-T)</property>
+            <property name="model">
+              <object class="GtkStringList">
+                <items>
+                  <item translatable="yes">Polite (T0)</item>
+                  <item translatable="yes">Sneaky (T1)</item>
+                  <item translatable="yes">Paranoid (T2)</item>
+                  <item translatable="yes">Normal (T3)</item>
+                  <item translatable="yes">Aggressive (T4)</item>
+                  <item translatable="yes">Insane (T5)</item>
+                </items>
+              </object>
+            </property>
+            <property name="selected">3</property> <!-- Default to Normal (T3) -->
+          </object>
+        </child>
+        <child>
           <object class="AdwActionRow" id="status_row">
             <property name="title" translatable="yes">Scan Status</property>
             <property name="subtitle" translatable="yes">Idle</property> <!-- Initial status message -->

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -1,5 +1,6 @@
 import logging
 import nmap
+import re
 import gi
 
 gi.require_version('Adw', '1')
@@ -24,6 +25,16 @@ class NmapItem(GObject.Object):
         self.value = value
 
 
+class NmapTargetRow(Gtk.ListBoxRow):
+    nmap_item = GObject.Property(type=NmapItem)
+
+    def __init__(self, nmap_item: NmapItem, **kwargs):
+        super().__init__(**kwargs)
+        self.nmap_item = nmap_item
+        label = Gtk.Label(label=nmap_item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
+        self.set_child(label)
+
+
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
 class NmapPage(Adw.PreferencesPage):
     __gtype_name__ = "NmapPage"
@@ -33,6 +44,9 @@ class NmapPage(Adw.PreferencesPage):
     nmap_fingerprint_switchrow = Gtk.Template.Child("nmap_fingerprint_switchrow")
     nmap_all_ports_switchrow = Gtk.Template.Child("nmap_all_ports_switchrow")
     nmap_scripts_dropdown = Gtk.Template.Child("nmap_scripts_dropdown")
+    nmap_service_version_switchrow = Gtk.Template.Child("nmap_service_version_switchrow")
+    nmap_no_ping_switchrow = Gtk.Template.Child("nmap_no_ping_switchrow")
+    nmap_timing_template_comborow = Gtk.Template.Child("nmap_timing_template_comborow")
     status_row = Gtk.Template.Child("status_row")  # AdwActionRow for status
     scan_spinner = Gtk.Template.Child("scan_spinner")  # GtkSpinner within status_row
 
@@ -136,9 +150,19 @@ class NmapPage(Adw.PreferencesPage):
             else None
         )
 
+        service_version_detection = self.nmap_service_version_switchrow.get_active()
+        no_ping_scan = self.nmap_no_ping_switchrow.get_active()
+        selected_timing_item = self.nmap_timing_template_comborow.get_selected_item()
+        timing_template_str = selected_timing_item.get_string() # e.g., "Normal (T3)"
+        # Extract the T-number (e.g., "T3") or just the number
+        timing_match = re.search(r"\(T([0-5])\)", timing_template_str)
+        timing_template = f"T{timing_match.group(1)}" if timing_match else "T3" # Default to T3 if parsing fails
+
         logging.info(
-            "Submitting Nmap scan for target: %s, OS Fingerprint: %s, All Ports: %s, Script: %s",
-            target, os_fingerprinting, all_ports, script_name
+            "Submitting Nmap scan for target: %s, OS Fingerprint: %s, All Ports: %s, Script: %s, "
+            "Service Version Detection: %s, No Ping: %s, Timing: %s",
+            target, os_fingerprinting, all_ports, script_name,
+            service_version_detection, no_ping_scan, timing_template
         )
         self.scanner.executor.submit(
             self._run_nmap_scan_task,
@@ -146,12 +170,15 @@ class NmapPage(Adw.PreferencesPage):
             os_fingerprinting,
             all_ports,
             script_name,
+            service_version_detection, # new
+            no_ping_scan,              # new
+            timing_template            # new
         )
 
-    def _run_nmap_scan_task(self, target, os_fingerprinting, all_ports, script_name):
+    def _run_nmap_scan_task(self, target, os_fingerprinting, all_ports, script_name, service_version_detection, no_ping_scan, timing_template):
         logging.info("Nmap scan task started for %s in executor thread.", target)
         try:
-            nm = self.scanner.run_nmap_scan(target, os_fingerprinting, all_ports, script_name)
+            nm = self.scanner.run_nmap_scan(target, os_fingerprinting, all_ports, script_name, service_version_detection, no_ping_scan, timing_template)
             GLib.idle_add(self._process_scan_results, nm, target)
         except nmap.PortScannerError as e:
             logging.error("Nmap PortScannerError for %s: %s", target, e, exc_info=True)
@@ -176,8 +203,8 @@ class NmapPage(Adw.PreferencesPage):
                 "Scan complete for %s. No hosts found or responsive." % original_target
             )
             self._display_error("No hosts found or responsive for target: %s" % original_target)
-            self.targets_group.set_revealed(False)
-            self.results_group.set_revealed(False)
+            self.targets_group.set_visible(False)
+            self.results_group.set_visible(False)
             return
 
         results_yaml_map = self.scanner.convert_results_to_yaml(nm)
@@ -197,7 +224,11 @@ class NmapPage(Adw.PreferencesPage):
             self.source_buffer.set_text("")
             return
 
-        item_obj = row.get_child().get_data("NmapItem")
+        if isinstance(row, NmapTargetRow):
+            item_obj = row.nmap_item
+        else:
+            item_obj = None # Or handle error appropriately
+
         if item_obj and isinstance(item_obj, NmapItem):
             selected_target_key = item_obj.key
             logging.debug("Target selected: %s", selected_target_key)
@@ -205,7 +236,7 @@ class NmapPage(Adw.PreferencesPage):
             result_yaml = self.results_by_host.get(selected_target_key, f"# No results found for {selected_target_key}")
             self.source_buffer.set_text(result_yaml)
             self._refresh_source_view()
-            self.results_group.set_revealed(True)
+            self.results_group.set_visible(True)
         else:
             logging.warning("Could not retrieve NmapItem from selected row.")
             self.source_buffer.set_text("")
@@ -220,8 +251,8 @@ class NmapPage(Adw.PreferencesPage):
         self.results_by_host.clear()  # Clear previous results mapping
 
         if not hosts:
-            self.targets_group.set_revealed(False)
-            self.results_group.set_revealed(False)
+            self.targets_group.set_visible(False)
+            self.results_group.set_visible(False)
             self.source_buffer.set_text("# No hosts found in this scan.")
             return
 
@@ -231,12 +262,12 @@ class NmapPage(Adw.PreferencesPage):
             self.nmap_target_listbox_store.append(nmap_item)
             self.results_by_host[host_key] = yaml_data
 
-        self.targets_group.set_revealed(True)
+        self.targets_group.set_visible(True)
 
         if self.nmap_target_listbox_store.get_n_items() > 0:
             self.nmap_target_listbox.select_row(self.nmap_target_listbox.get_row_at_index(0))
         else:
-            self.results_group.set_revealed(False)
+            self.results_group.set_visible(False)
             self.source_buffer.set_text("")
 
     def _set_scan_status(self, status_type: ScanStatus, message: str):
@@ -265,8 +296,8 @@ class NmapPage(Adw.PreferencesPage):
         self.source_buffer.set_text("")
         self.results_by_host.clear()
 
-        self.targets_group.set_revealed(False)
-        self.results_group.set_revealed(False)
+        self.targets_group.set_visible(False)
+        self.results_group.set_visible(False)
         self.error_banner.set_revealed(False)
         self.nmap_target_entryrow.remove_css_class("error")
         self.nmap_target_entryrow.set_sensitive(True)
@@ -284,10 +315,4 @@ class NmapPage(Adw.PreferencesPage):
         self.error_banner.set_title("")
 
     def _create_target_listbox_row(self, item: NmapItem) -> Gtk.ListBoxRow:
-        """Factory function to create a Gtk.ListBoxRow for an NmapItem."""
-        simple_row = Gtk.ListBoxRow()
-        # Create a label for the host key and store the NmapItem on it for easy retrieval.
-        simple_label = Gtk.Label(label=item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
-        simple_label.set_data("NmapItem", item)
-        simple_row.set_child(simple_label)
-        return simple_row
+        return NmapTargetRow(nmap_item=item)

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -98,7 +98,10 @@ class NmapScanner:
         target: str,
         os_fingerprinting: bool,
         scan_all_ports: bool,
-        selected_script: str,
+        selected_script: str = None, # Modified to match nmap_page.py call
+        service_version: bool = False,
+        no_ping: bool = False,
+        timing_template: str = "T3"
     ) -> nmap.PortScanner:
         """
         Executes an Nmap scan against the specified target with the given options.
@@ -116,17 +119,34 @@ class NmapScanner:
             nmap.PortScannerError: If Nmap encounters an error during the scan.
             Exception: For other unexpected errors during the scan process.
         """
-        nmap_options = self.build_nmap_options(
-            os_fingerprinting, scan_all_ports, selected_script
-        )
-        logging.debug(
-            "Running Nmap scan for target: %s with options: %s",
-            target,
-            nmap_options
-        )
+        arguments = []
+        # Base scan type: Default to TCP SYN scan (-sS) if user has root privileges,
+        # otherwise nmap falls back to TCP Connect scan (-sT).
+        # We can explicitly set -sS, nmap handles privilege check.
+        arguments.append("-sS")
+
+        if os_fingerprinting:
+            arguments.append("-O") # OS Detection
+        if service_version:
+            arguments.append("-sV") # Service Version Detection
+        if scan_all_ports: # Renamed from all_ports to match existing param name
+            arguments.append("-p-")
+        if selected_script and selected_script != "None": # Ensure "None" from dropdown isn't treated as a script
+            arguments.append(f"--script={selected_script}")
+        if no_ping:
+            arguments.append("-Pn")
+
+        if timing_template and re.match(r"^T[0-5]$", timing_template):
+            arguments.append(f"-{timing_template}") # Nmap expects -T4
+        else:
+            arguments.append("-T3") # Default timing
+
+        arguments_str = " ".join(arguments)
+        logging.info("Nmap arguments for target '%s': %s", target, arguments_str)
+
         try:
-            nm = nmap.PortScanner()
-            nm.scan(hosts=target, arguments=nmap_options)
+            nm = nmap.PortScanner() # Local instance, not self.nm
+            nm.scan(hosts=target, arguments=arguments_str)
             logging.debug("Nmap scan completed with results: %s", nm.all_hosts())
             return nm
         except nmap.PortScannerError as e:

--- a/src/tests/test_nmap_scanner.py
+++ b/src/tests/test_nmap_scanner.py
@@ -1,0 +1,112 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from src.nmap_scanner import NmapScanner # Assuming src is in PYTHONPATH or structure allows this
+
+class TestNmapScanner(unittest.TestCase):
+
+    @patch('nmap.PortScanner')
+    def test_run_nmap_scan_service_version(self, mock_port_scanner_class):
+        mock_nm_instance = MagicMock()
+        mock_port_scanner_class.return_value = mock_nm_instance
+
+        scanner = NmapScanner()
+        scanner.run_nmap_scan(
+            target="127.0.0.1",
+            os_fingerprinting=False,
+            scan_all_ports=False,
+            selected_script=None,
+            service_version=True, # Test this
+            no_ping=False,
+            timing_template="T3"
+        )
+
+        # nm.scan(hosts=target, arguments=arguments_str)
+        # call_args will be call_args.kwargs['arguments'] or call_args[1]['arguments']
+        called_arguments = mock_nm_instance.scan.call_args[1]['arguments']
+        self.assertIn("-sV", called_arguments)
+        self.assertNotIn("-O", called_arguments) # Ensure -O is not there if os_fingerprint is False
+
+    @patch('nmap.PortScanner')
+    def test_run_nmap_scan_no_ping(self, mock_port_scanner_class):
+        mock_nm_instance = MagicMock()
+        mock_port_scanner_class.return_value = mock_nm_instance
+
+        scanner = NmapScanner()
+        scanner.run_nmap_scan(
+            target="127.0.0.1",
+            os_fingerprinting=False,
+            scan_all_ports=False,
+            selected_script=None,
+            service_version=False,
+            no_ping=True, # Test this
+            timing_template="T3"
+        )
+
+        called_arguments = mock_nm_instance.scan.call_args[1]['arguments']
+        self.assertIn("-Pn", called_arguments)
+
+    @patch('nmap.PortScanner')
+    def test_run_nmap_scan_timing_template(self, mock_port_scanner_class):
+        mock_nm_instance = MagicMock()
+        mock_port_scanner_class.return_value = mock_nm_instance
+
+        scanner = NmapScanner()
+        scanner.run_nmap_scan(
+            target="127.0.0.1",
+            os_fingerprinting=False,
+            scan_all_ports=False,
+            selected_script=None,
+            service_version=False,
+            no_ping=False,
+            timing_template="T4" # Test this
+        )
+
+        called_arguments = mock_nm_instance.scan.call_args[1]['arguments']
+        self.assertIn("-T4", called_arguments)
+
+    @patch('nmap.PortScanner')
+    def test_run_nmap_scan_os_and_service_version(self, mock_port_scanner_class):
+        mock_nm_instance = MagicMock()
+        mock_port_scanner_class.return_value = mock_nm_instance
+
+        scanner = NmapScanner()
+        scanner.run_nmap_scan(
+            target="127.0.0.1",
+            os_fingerprint=True, # Test this
+            scan_all_ports=False,
+            selected_script=None,
+            service_version=True, # Test this
+            no_ping=False,
+            timing_template="T3"
+        )
+
+        called_arguments = mock_nm_instance.scan.call_args[1]['arguments']
+        self.assertIn("-O", called_arguments)
+        self.assertIn("-sV", called_arguments)
+
+    @patch('nmap.PortScanner')
+    def test_run_nmap_scan_defaults(self, mock_port_scanner_class):
+        mock_nm_instance = MagicMock()
+        mock_port_scanner_class.return_value = mock_nm_instance
+
+        scanner = NmapScanner()
+        scanner.run_nmap_scan(
+            target="127.0.0.1",
+            os_fingerprinting=False,
+            scan_all_ports=False,
+            selected_script=None,
+            service_version=False,
+            no_ping=False,
+            timing_template="T3" # Explicitly T3 but also default
+        )
+        called_arguments = mock_nm_instance.scan.call_args[1]['arguments']
+        self.assertIn("-sS", called_arguments) # Default scan type
+        self.assertIn("-T3", called_arguments) # Default timing
+        self.assertNotIn("-O", called_arguments)
+        self.assertNotIn("-sV", called_arguments)
+        self.assertNotIn("-p-", called_arguments)
+        self.assertNotIn("-Pn", called_arguments)
+        self.assertNotIn("--script", called_arguments)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses two primary issues on the Nmap scanner page:
1.  Resolves a `RuntimeError: Data access methods are unsupported` by replacing the deprecated `set_data`/`get_data` GObject mechanism with a custom `NmapTargetRow(Gtk.ListBoxRow)` holding an `nmap_item` property.
2.  Fixes an `AttributeError: 'PreferencesGroup' object has no attribute 'set_revealed'` by correctly using `set_visible()` for `Adw.PreferencesGroup` widgets.

Additionally, this commit enhances the Nmap scanner functionality by adding UI controls and backend logic for the following common Nmap options:
-   Service Version Detection (-sV) via an `AdwSwitchRow`.
-   No Ping Scan (-Pn) via an `AdwSwitchRow`.
-   Timing Template (-T0 to -T5) via an `AdwComboRow`.

The `NmapScanner` class in `nmap_scanner.py` has been updated to incorporate these new options into the Nmap command arguments.

Unit tests have been added in `src/tests/test_nmap_scanner.py` to verify the correct construction of Nmap arguments with these new options, mocking `nmap.PortScanner`.