### PR TITLE
feat: Implement privilege escalation for Nmap scans

### DIFF
--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -1,10 +1,16 @@
 import logging
 import re
+import platform
+import subprocess
+import shlex
+import shutil
+import tempfile # Added as per subtask description
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, List
 
 import nmap
+from nmap import PortScannerError # Added as per subtask description
 import yaml
 
 
@@ -20,6 +26,53 @@ class ScanStatus(Enum):
     COMPLETE = (1.0, "Scan complete")
     FAILED = (1.0, "Scan failed unexpectedly")
     IDLE = (0.0, "Idle")  # Added IDLE state
+
+
+# Helper function (module-level)
+def _is_scan_root_required(nmap_args_list: list[str]) -> bool:
+    # Check for options that typically require root privileges.
+    # -sS is the default TCP SYN scan.
+    # -O is OS detection.
+    # -A (Aggressive) implies -sS and -O.
+    # Other options like --traceroute (often part of -A) can also require root.
+    root_options = ["-sS", "-O", "-A"] # Add others if known
+    for opt in root_options:
+        if opt in nmap_args_list:
+            return True
+
+    # If no specific scan type is given, nmap might default to -sS if it thinks it has root,
+    # or -sT otherwise. Since we explicitly add -sS as our default, this check is primary.
+    return False
+
+
+def get_escalated_command(command_parts: List[str]) -> List[str]:
+    system = platform.system()
+    if not command_parts:
+        return []
+
+    nmap_executable = command_parts[0]
+    nmap_path = shutil.which(nmap_executable)
+
+    if not nmap_path:
+        # If nmap is not found, escalation won't help.
+        # This error should ideally be caught even before attempting escalation.
+        raise FileNotFoundError(f"Nmap executable '{nmap_executable}' not found in PATH.")
+
+    # Use the full path for the command
+    resolved_command_parts = [nmap_path] + command_parts[1:]
+
+    if system == "Linux":
+        # pkexec by default does not inherit the user's PATH for security reasons.
+        # It's crucial to use the full path to the executable.
+        return ["pkexec"] + resolved_command_parts
+    elif system == "Darwin": # macOS
+        quoted_command = " ".join(shlex.quote(part) for part in resolved_command_parts)
+        osascript_command = f'do shell script "{quoted_command}" with administrator privileges'
+        return ["osascript", "-e", osascript_command]
+    else:
+        logging.warning(f"Privilege escalation not configured for system: {system}. Returning original command.")
+        # It's better to raise an error if escalation is expected but not possible.
+        raise NotImplementedError(f"Privilege escalation not supported on this platform: {system}")
 
 
 class NmapScanner:
@@ -98,13 +151,14 @@ class NmapScanner:
         target: str,
         os_fingerprinting: bool,
         scan_all_ports: bool,
-        selected_script: str = None, # Modified to match nmap_page.py call
+        selected_script: str = None,
         service_version: bool = False,
         no_ping: bool = False,
         timing_template: str = "T3"
     ) -> nmap.PortScanner:
         """
-        Executes an Nmap scan against the specified target with the given options.
+        Executes an Nmap scan against the specified target with the given options,
+        handling privilege escalation and using subprocess.
 
         Args:
             target: The target host(s) for the Nmap scan.
@@ -116,45 +170,113 @@ class NmapScanner:
             An nmap.PortScanner object containing the scan results.
 
         Raises:
-            nmap.PortScannerError: If Nmap encounters an error during the scan.
-            Exception: For other unexpected errors during the scan process.
+            PortScannerError: If Nmap encounters an error or fails to execute/parse.
+            FileNotFoundError: If Nmap executable is not found (via PortScannerError).
+            NotImplementedError: If OS is not supported for escalation (via PortScannerError).
         """
-        arguments = []
-        # Base scan type: Default to TCP SYN scan (-sS) if user has root privileges,
-        # otherwise nmap falls back to TCP Connect scan (-sT).
-        # We can explicitly set -sS, nmap handles privilege check.
-        arguments.append("-sS")
+        self.nm = nmap.PortScanner() # Still useful for parsing
+
+        nmap_args_list = ["nmap"] # Start with 'nmap' as executable name
+
+        # Base scan type: Default to TCP SYN scan (-sS).
+        nmap_args_list.append("-sS")
 
         if os_fingerprinting:
-            arguments.append("-O") # OS Detection
+            nmap_args_list.append("-O")
         if service_version:
-            arguments.append("-sV") # Service Version Detection
-        if scan_all_ports: # Renamed from all_ports to match existing param name
-            arguments.append("-p-")
-        if selected_script and selected_script != "None": # Ensure "None" from dropdown isn't treated as a script
-            arguments.append(f"--script={selected_script}")
+            nmap_args_list.append("-sV")
+        if scan_all_ports:
+            nmap_args_list.append("-p-")
+        if selected_script and selected_script != "None":
+            nmap_args_list.append(f"--script={selected_script}")
         if no_ping:
-            arguments.append("-Pn")
+            nmap_args_list.append("-Pn")
 
         if timing_template and re.match(r"^T[0-5]$", timing_template):
-            arguments.append(f"-{timing_template}") # Nmap expects -T4
+            nmap_args_list.append(f"-{timing_template}")
         else:
-            arguments.append("-T3") # Default timing
+            nmap_args_list.append("-T3") # Default timing
 
-        arguments_str = " ".join(arguments)
-        logging.info("Nmap arguments for target '%s': %s", target, arguments_str)
+        nmap_args_list.append("-oX") # Output XML
+        nmap_args_list.append("-")   # to stdout
+
+        nmap_args_list.append(target) # Add target at the end
+
+        logging.info(f"Nmap base command parts: {nmap_args_list}")
+
+        final_command_parts = []
+        needs_escalation = _is_scan_root_required(nmap_args_list)
 
         try:
-            nm = nmap.PortScanner() # Local instance, not self.nm
-            nm.scan(hosts=target, arguments=arguments_str)
-            logging.debug("Nmap scan completed with results: %s", nm.all_hosts())
-            return nm
-        except nmap.PortScannerError as e:
-            logging.error("Nmap scan failed for target %s: %s", target, e)
-            raise e
+            if needs_escalation:
+                logging.info("Escalation required for Nmap scan.")
+                final_command_parts = get_escalated_command(nmap_args_list)
+                if not final_command_parts:
+                    raise PortScannerError("Failed to prepare escalated command.")
+            else:
+                nmap_executable = nmap_args_list[0]
+                nmap_path = shutil.which(nmap_executable)
+                if not nmap_path:
+                    raise FileNotFoundError(f"Nmap executable '{nmap_executable}' not found.")
+                final_command_parts = [nmap_path] + nmap_args_list[1:]
+
+            logging.info(f"Executing Nmap command: {' '.join(shlex.quote(part) for part in final_command_parts)}")
+
+            process = subprocess.run(final_command_parts, capture_output=True, text=True, check=False, encoding='utf-8')
+
+            nmap_xml_output = process.stdout
+            nmap_stderr = process.stderr
+
+            if process.returncode != 0:
+                error_message = f"Nmap scan failed with exit code {process.returncode}."
+                # Try to get a more specific error from Nmap's output
+                if "QUITTING" in nmap_xml_output or "requires root privileges" in nmap_xml_output:
+                    output_lines = nmap_xml_output.strip().split('\n')
+                    for line in output_lines:
+                        if "QUITTING" in line or "privileges" in line:
+                            error_message = line.strip() # Use Nmap's direct message
+                            break
+                elif nmap_stderr: # If not an obvious Nmap stdout error, use stderr
+                    error_message += f" Stderr: {nmap_stderr.strip()}"
+
+                # Check for cancellation of privilege escalation prompts
+                if needs_escalation:
+                    if platform.system() == "Darwin" and process.returncode == 1 and not nmap_xml_output and not nmap_stderr.strip(): # osascript cancel
+                         error_message = "User cancelled the request for administrator privileges."
+                    elif platform.system() == "Linux" and process.returncode in [1, 126, 127] and not nmap_xml_output and not nmap_stderr.strip(): # pkexec common cancel/fail codes
+                         error_message = "User cancelled the request for administrator privileges or authentication failed."
+
+                logging.error(error_message)
+                raise PortScannerError(error_message)
+
+            if not nmap_xml_output.strip(): # Check if output is empty or just whitespace
+                no_output_msg = "Nmap scan completed but produced no XML output."
+                if nmap_stderr.strip(): # Add stderr if it has content
+                    no_output_msg += f" Stderr: {nmap_stderr.strip()}"
+                logging.warning(no_output_msg)
+                # Allow parsing of empty string, analyse_nmap_xml_scan should handle it
+                pass
+
+            try:
+                self.nm.analyse_nmap_xml_scan(nmap_xml_output=nmap_xml_output)
+            except PortScannerError as e:
+                logging.error(f"Failed to parse Nmap XML output: {e}")
+                logging.debug(f"Problematic XML Output (first 1000 chars):\n{nmap_xml_output[:1000]}...")
+                raise PortScannerError(f"Failed to parse Nmap XML output: {e}. Stderr: {nmap_stderr.strip()}")
+
+            return self.nm
+
+        except FileNotFoundError as e:
+            logging.error(f"Nmap execution error: {e}")
+            raise PortScannerError(str(e))
+        except NotImplementedError as e:
+            logging.error(f"Nmap execution error: {e}")
+            raise PortScannerError(str(e))
+        except PortScannerError: # Re-raise if it's already the correct type
+            raise
         except Exception as e:
-            logging.error("Unexpected error during scan for target %s (%s): %s", target, type(e).__name__, e)
-            raise e
+            logging.error(f"Unexpected error during Nmap scan process: {e}", exc_info=True)
+            raise PortScannerError(f"An unexpected error occurred: {e}")
 
     def convert_results_to_yaml(self, nm: nmap.PortScanner) -> Dict[str, str]:
         """


### PR DESCRIPTION
This commit introduces privilege escalation for Nmap scans that require root permissions, such as TCP SYN scans (-sS, the application's default) and OS detection (-O).

Key changes:
- Added `get_escalated_command` function in `nmap_scanner.py` to prepare Nmap commands for execution with `pkexec` on Linux and `osascript` (using "do shell script ... with administrator privileges") on macOS. This function also resolves the full path to the nmap executable.
- Overhauled `NmapScanner.run_nmap_scan` to:
  - Use `subprocess.run()` for executing all Nmap commands, providing a unified execution path.
  - Determine if root privileges are required based on scan arguments.
  - Employ `get_escalated_command` if escalation is needed.
  - Capture Nmap's XML output from stdout (`-oX -`).
  - Parse the captured XML using `python-nmap`'s `analyse_nmap_xml_scan` method.
- Enhanced error handling in `NmapScanner` to provide more specific messages, including cases like:
  - Your cancellation of the privilege escalation prompt.
  - Nmap executable not found in PATH.
  - OS not supported for escalation (fallback/error).
  - Nmap command execution errors.
- These specific errors are wrapped in `PortScannerError` for consistent handling and display in the NmapPage UI.
- The default Nmap scan type remains `-sS`. If privilege escalation for this (or other root-requiring options) is denied or fails, the scan will fail with a clear error message, rather than attempting an automatic fallback to a non-privileged scan type.

This change addresses the issue where scans requiring root would fail silently or with unclear errors. The application now actively requests necessary privileges, improving functionality and your experience for common and powerful Nmap scan techniques.