### PR TITLE
fix(NmapPage): Resolve AttributeError for ListBox.get_model

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -106,8 +106,8 @@ class NmapPage(Adw.PreferencesPage):
         self.nmap_host_listbox.bind_model( # Changed to nmap_host_listbox
             self.nmap_target_listbox_store, self._create_target_listbox_row
         )
-        if self.nmap_host_listbox.get_model() == self.nmap_target_listbox_store:
-            logging.debug("nmap_host_listbox successfully bound.")
+        # Removed: if self.nmap_host_listbox.get_model() == self.nmap_target_listbox_store:
+        # Removed:     logging.debug("nmap_host_listbox successfully bound.")
 
         # Initial visibility states for split view and placeholder
         self.nmap_split_view.set_show_sidebar(True) # Changed from nmap_results_flap.set_revealed(True)


### PR DESCRIPTION
This commit fixes an `AttributeError: 'ListBox' object has no attribute 'get_model'` that occurred during the initialization of the NmapPage. The error was caused by an incorrect attempt to call `get_model()` on `self.nmap_host_listbox` within the `_init_page_ui` method.

The erroneous check has been removed. `Gtk.ListBox` does not use the `get_model()` method in the same way as `Gtk.TreeView`; its model is managed via direct population or, as used here, through `bind_model()` with a `Gio.ListStore`. The `bind_model()` call itself correctly establishes the data binding.

This fix ensures that the NmapPage initializes without error, allowing the Nmap scanner UI to load and function as intended, including the display of scan results and associated debug logging.