### PR TITLE
fix(NmapPage): Adjust warning banner layout for full width

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -10,6 +10,7 @@
       <object class="AdwBanner" id="warning_banner">
         <property name="title" translatable="yes">WARNING: Do not use this tool on any hosts or networks you do not have explicit permission to scan.</property>
         <property name="revealed">True</property>
+        <property name="hexpand">true</property>
       </object>
     </child>
     <child>


### PR DESCRIPTION
This commit adjusts the layout of the 'warning_banner' on the Nmap scanner page to ensure it is positioned at the very top and spans the full width of the page content area.

Changes:
- Added `hexpand="true"` to the `Adw.Banner` with `id="warning_banner"` in `src/gtk/nmap_page.ui`.
- Ensured the `warning_banner` is the first child of the `NmapPage` (which is an `Adw.PreferencesPage`) in the UI template.

This change aims to make the warning message more prominent and visually distinct from the clamped content (like `Adw.PreferencesGroup`s) below it, improving its visibility and adherence to typical banner design.