### PR TITLE
Fix: Correct AttributeError in Nmap OS details display

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -413,6 +413,7 @@ class NmapPage(Adw.PreferencesPage):
         expander = Adw.ExpanderRow(title=f"Operating System Detection - {host_key}")
         expander.set_expanded(True) # Expand if OS data is present
 
+        os_details_added = False # Initialize flag
         for match in osmatch_data:
             name = match.get('name', 'N/A')
             accuracy = match.get('accuracy', 'N/A')
@@ -441,8 +442,9 @@ class NmapPage(Adw.PreferencesPage):
             if subtitle == "No OS class details.": # make it less prominent if no subtitle
                  row.set_subtitle("") # Or some other indicator
             expander.add_row(row)
+            os_details_added = True # Set flag to True as a row was added
 
-        if expander.get_n_rows() == 0: # Check if no rows were added
+        if not os_details_added: # Check the flag
             no_data_row = Adw.ActionRow(title="OS Detection", subtitle="No specific OS matches found.")
             expander.add_row(no_data_row)
 


### PR DESCRIPTION
The method _add_os_expander was attempting to call `get_n_rows()` on an Adw.ExpanderRow object, which is not a valid method for that class. This caused an AttributeError and prevented the Nmap scan results, particularly the OS details and subsequent YAML output, from displaying correctly when OS data was processed.

This commit replaces the incorrect `expander.get_n_rows()` check with a boolean flag `os_details_added`. This flag correctly tracks whether any OS detail rows have been added to the expander. If no rows are added from the scan data, a fallback row indicating "No specific OS matches found" is now correctly added.

This resolves the issue you reported where the YAML output was not appearing due to this error.