### PR TITLE
Refactor page UI structure for Adwaita compliance

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -7,18 +7,28 @@
     <property name="title" translatable="yes">DNS Lookup</property>
     <property name="icon-name">org.gnome.Epiphany-symbolic</property>
     <child>
-      <object class="GtkLabel">
-        <property name="label">The DNS tool allows users to perform DNS queries for various record types, including &lt;b&gt;A&lt;/b&gt;, &lt;b&gt;TXT&lt;/b&gt;, &lt;b&gt;CNAME&lt;/b&gt; and others. By entering an IP address, users can perform reverse DNS lookups.</property>
-        <property name="use-markup">True</property>
-        <property name="wrap">True</property>
-        <property name="xalign">0</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">18</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <style>
-          <class name="dim-label"/>
-        </style>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <object class="AdwActionRow">
+            <property name="selectable">False</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">The DNS tool allows users to perform DNS queries for various record types, including &lt;b&gt;A&lt;/b&gt;, &lt;b&gt;TXT&lt;/b&gt;, &lt;b&gt;CNAME&lt;/b&gt; and others. By entering an IP address, users can perform reverse DNS lookups.</property>
+                <property name="use-markup">True</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -7,17 +7,27 @@
     <property name="title" translatable="yes">HTTP Headers</property>
     <property name="icon-name">network-transmit-receive-symbolic</property>
     <child>
-      <object class="GtkLabel" id="http_page_description_label"> <!-- Added id for clarity -->
-        <property name="label">This tool is ideal for developers, as well as systems and network administrators, who need to inspect HTTP headers for debugging, troubleshooting, and security analysis.</property>
-        <property name="wrap">True</property>
-        <property name="xalign">0</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">18</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <style>
-          <class name="dim-label"/>
-        </style>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <object class="AdwActionRow">
+            <property name="selectable">False</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">This tool is ideal for developers, as well as systems and network administrators, who need to inspect HTTP headers for debugging, troubleshooting, and security analysis.</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child> <!-- This is the original first child, now second -->

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -7,18 +7,28 @@
     <property name="title" translatable="yes">Nmap Scanner</property>
     <property name="icon-name">face-devilish-symbolic</property> <!-- Or an appropriate network scanning icon -->
     <child>
-      <object class="GtkLabel">
-        <property name="label">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
-        <property name="use-markup">True</property>
-        <property name="wrap">True</property>
-        <property name="xalign">0</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">18</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <style>
-          <class name="dim-label"/>
-        </style>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <object class="AdwActionRow">
+            <property name="selectable">False</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
+                <property name="use-markup">True</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -5,17 +5,27 @@
   <template class="WebScanPage" parent="AdwPreferencesPage">
     <property name="title">Web Scan</property>
     <child>
-      <object class="GtkLabel">
-        <property name="label">This tool allows you to perform web vulnerability scans using Nikto. Enter a target URL to begin.</property>
-        <property name="wrap">True</property>
-        <property name="xalign">0</property>
-        <property name="margin-top">6</property>
-        <property name="margin-bottom">18</property>
-        <property name="margin-start">12</property>
-        <property name="margin-end">12</property>
-        <style>
-          <class name="dim-label"/>
-        </style>
+      <object class="AdwPreferencesGroup">
+        <child>
+          <object class="AdwActionRow">
+            <property name="selectable">False</property>
+            <property name="focusable">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">This tool allows you to perform web vulnerability scans using Nikto. Enter a target URL to begin.</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>


### PR DESCRIPTION
The existing UI for DNS, HTTP, Nmap, and WebScan pages had an introductory GtkLabel as a direct child of the AdwPreferencesPage, followed by AdwPreferencesGroup elements. This was causing an issue where only the initial label was visible, and the groups containing the interactive widgets were not being rendered.

This commit refactors the structure of these pages:
- The initial descriptive GtkLabel on each page is now wrapped within a new, initial AdwPreferencesGroup.
- Inside this new group, the GtkLabel is placed within an AdwActionRow (configured as non-selectable and non-focusable).

This revised structure adheres more closely to libadwaita design patterns and GNOME HIG, which typically expect AdwPreferencesPage to contain AdwPreferencesGroup elements as its primary children.

This change is intended to resolve the widget visibility issue by ensuring all sections of the page are correctly laid out and rendered.