### PR TITLE
Refactor page UI structure based on feedback

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -2,38 +2,28 @@
 <!-- Created with Cambalache 0.91.3 -->
 <interface>
   <requires lib="gtk" version="4.10"/>
-  <requires lib="libadwaita" version="1.4"/>
+  <requires lib="libadwaita" version="1.7"/>
   <template class="DNSPage" parent="AdwPreferencesPage">
     <property name="title" translatable="yes">DNS Lookup</property>
     <property name="icon-name">org.gnome.Epiphany-symbolic</property>
     <child>
       <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Lookup Parameters</property>
         <child>
-          <object class="AdwActionRow">
-            <property name="selectable">False</property>
-            <property name="focusable">False</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label">The DNS tool allows users to perform DNS queries for various record types, including &lt;b&gt;A&lt;/b&gt;, &lt;b&gt;TXT&lt;/b&gt;, &lt;b&gt;CNAME&lt;/b&gt; and others. By entering an IP address, users can perform reverse DNS lookups.</property>
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="xalign">0</property>
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label">The DNS tool allows users to perform DNS queries for various record types, including &lt;b&gt;A&lt;/b&gt;, &lt;b&gt;TXT&lt;/b&gt;, &lt;b&gt;CNAME&lt;/b&gt; and others. By entering an IP address, users can perform reverse DNS lookups.</property>
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">12</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Lookup Parameters</property>
         <child>
           <object class="AdwEntryRow" id="dns_ip_entryrow">
             <property name="input-purpose">url</property>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -2,37 +2,27 @@
 <!-- Created with Cambalache 0.91.3 -->
 <interface>
   <requires lib="gtk" version="4.12"/>
-  <requires lib="libadwaita" version="1.4"/>
+  <requires lib="libadwaita" version="1.7"/>
   <template class="HttpPage" parent="AdwPreferencesPage">
     <property name="title" translatable="yes">HTTP Headers</property>
     <property name="icon-name">network-transmit-receive-symbolic</property>
-    <child>
-      <object class="AdwPreferencesGroup">
-        <child>
-          <object class="AdwActionRow">
-            <property name="selectable">False</property>
-            <property name="focusable">False</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label">This tool is ideal for developers, as well as systems and network administrators, who need to inspect HTTP headers for debugging, troubleshooting, and security analysis.</property>
-                <property name="wrap">True</property>
-                <property name="xalign">0</property>
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
     <child> <!-- This is the original first child, now second -->
       <object class="AdwPreferencesGroup" id="http_request_group">
         <property name="title" translatable="yes">Request Parameters</property>
+        <child>
+          <object class="GtkLabel" id="http_page_description_label">
+            <property name="label">This tool is ideal for developers, as well as systems and network administrators, who need to inspect HTTP headers for debugging, troubleshooting, and security analysis.</property>
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">12</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
         <child>
           <object class="AdwEntryRow" id="http_entry_row">
             <property name="activates-default">True</property>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -7,40 +7,23 @@
     <property name="title" translatable="yes">Nmap Scanner</property>
     <property name="icon-name">face-devilish-symbolic</property> <!-- Or an appropriate network scanning icon -->
     <child>
-      <object class="AdwPreferencesGroup">
-        <child>
-          <object class="AdwActionRow">
-            <property name="selectable">False</property>
-            <property name="focusable">False</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="xalign">0</property>
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="AdwBanner" id="warning_banner">
-        <property name="title" translatable="yes">WARNING: Do not use this tool on any hosts or networks you do not have explicit permission to scan.</property>
-        <property name="revealed">True</property>
-        <property name="hexpand">true</property>
-      </object>
-    </child>
-    <child>
       <object class="AdwPreferencesGroup" id="nmap_scan_parameters_group">
         <property name="title" translatable="yes">Scan Parameters</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">12</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
         <child>
           <object class="AdwEntryRow" id="nmap_target_entryrow">
             <property name="activates-default">True</property>
@@ -141,6 +124,13 @@
             </child>
           </object>
         </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwBanner" id="warning_banner">
+        <property name="title" translatable="yes">WARNING: Do not use this tool on any hosts or networks you do not have explicit permission to scan.</property>
+        <property name="revealed">True</property>
+        <property name="hexpand">true</property>
       </object>
     </child>
     <child>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -1,36 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <requires lib="libadwaita" version="1.0"/>
+  <requires lib="libadwaita" version="1.7"/>
   <template class="WebScanPage" parent="AdwPreferencesPage">
     <property name="title">Web Scan</property>
     <child>
       <object class="AdwPreferencesGroup">
+        <property name="title">Scan Target</property>
         <child>
-          <object class="AdwActionRow">
-            <property name="selectable">False</property>
-            <property name="focusable">False</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="label">This tool allows you to perform web vulnerability scans using Nikto. Enter a target URL to begin.</property>
-                <property name="wrap">True</property>
-                <property name="xalign">0</property>
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <property name="margin-start">12</property>
-                <property name="margin-end">12</property>
-                <style>
-                  <class name="dim-label"/>
-                </style>
-              </object>
-            </child>
+          <object class="GtkLabel">
+            <property name="label">This tool allows you to perform web vulnerability scans using Nikto. Enter a target URL to begin.</property>
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">12</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="AdwPreferencesGroup">
-        <property name="title">Scan Target</property>
         <child>
           <object class="AdwEntryRow" id="webscan_url_entry">
             <property name="title">Target URL</property>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -42,12 +42,12 @@
               <object class="AdwViewStackPage" id="http_page">
                 <property name="child">
                   <object class="AdwClampScrollable" id="http_clamp_scrollable">
+                    <property name="vexpand">True</property>
                     <property name="maximum-size">1400</property>
                     <property name="tightening-threshold">500</property>
                     <property name="unit">px</property>
                     <child>
                       <object class="HttpPage">
-                        <property name="overflow">hidden</property>
                       </object>
                     </child>
                   </object>
@@ -100,6 +100,7 @@
               <object class="AdwViewStackPage" id="webscan_page">
                 <property name="child">
                   <object class="AdwClampScrollable">
+                    <property name="vexpand">True</property>
                     <property name="maximum-size">1400</property>
                     <property name="tightening-threshold">500</property>
                     <property name="unit">px</property>


### PR DESCRIPTION
This commit adjusts the structure of the AdwPreferencesPage instances (DNS, HTTP, Nmap, WebScan pages) based on your feedback suggesting that having multiple AdwPreferencesGroup elements as direct children of an AdwPreferencesPage was problematic.

The changes include:
- Reverted an earlier attempt that wrapped descriptive labels in their own AdwPreferencesGroup.
- Moved the descriptive GtkLabel on each page to be the first child inside the primary AdwPreferencesGroup (e.g., within "Lookup Parameters" group for DNS page).
- Ensured libadwaita version requirements are consistent at "1.7" across relevant UI files.
- Maintained previous adjustments to window.ui for vexpand properties on AdwClampScrollable and removal of an overflow="hidden" property.

This new structure aims to resolve the UI issue where only the initial descriptive labels were visible, by ensuring that the primary content of each page is better encapsulated within a single leading AdwPreferencesGroup, as per the guidance received.