### PR TITLE
Refactor: Update UI to use modern libadwaita style classes

### DIFF
--- a/src/gtk/style-dark.css
+++ b/src/gtk/style-dark.css
@@ -1,9 +1,0 @@
-.label-target {
-    font-weight: bold;
-    color: #ffffff; 
-}
-
-.label-output {
-    font-style: italic;
-    color: #ffffff;
-}

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -1,27 +1,3 @@
-.label-target {
-    color: #373b39;
-    font-weight: bold;
-}
-
-.label-output {
-    color: #333333;
-    font-style: italic;
-}
-
-/* In your application's CSS file */
-.custom-listbox-row {
-    padding: 10px;
-    border-bottom: 1px solid #ddd;
-}
-
-.custom-listbox-row:selected {
-    background-color: #e0e0e0;
-}
-
-.custom-listbox-row:hover {
-    background-color: #f0f0f0;
-}
-
 /* Margin for GtkSourceView widgets */
 .source-view {
     margin-top: 10px;

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -29,7 +29,8 @@
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_scan_button_clicked"/>
                 <style>
-                  <class name="suggested-action"/>
+  <class name="pill"/>
+  <class name="accent"/>
                 </style>
               </object>
             </child>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -27,9 +27,6 @@
                 <property name="menu-model">primary_menu</property>
                 <property name="primary">True</property>
                 <property name="tooltip-text" translatable="yes">Menu</property>
-                <style>
-                  <class name="GtkMenuButton"/>
-                </style>
               </object>
             </child>
           </object>


### PR DESCRIPTION
I've replaced deprecated style classes and removed unused CSS definitions to align with current libadwaita best practices.

Changes include:
- Updated a GtkButton in `webscan_page.ui` from `suggested-action` to `pill` and `accent` style classes.
- Removed unused CSS classes (`.label-target`, `.label-output`, `.custom-listbox-row`) from `src/gtk/style.css` and `src/gtk/style-dark.css`.
- Removed a redundant `<class name="GtkMenuButton"/>` style from a GtkMenuButton in `src/gtk/window.ui`.

Note: Full build and runtime verification were hindered by a build environment issue (missing `pygobject-3.0.pc` file). The changes are primarily to UI definition (.ui) and CSS files and are expected to be safe.