### PR TITLE
Feat: Add theme and font scaling preferences

### DIFF
--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -2,16 +2,28 @@
 <schemalist gettext-domain="woes">
   <schema id="com.github.mclellac.woes"
     path="/com/github/mclellac/woes/">
-    <key name="font-size" type="i">
-      <default>12</default>
-      <range min="8" max="24" />
-      <summary>Font size</summary>
-      <description>Font size in points</description>
+    <key name="font-scaling-percentage" type="s">
+      <default>'100% (Normal)'</default>
+      <choices>
+        <choice value='100% (Normal)'/>
+        <choice value='110%'/>
+        <choice value='120%'/>
+        <choice value='130%'/>
+        <choice value='140%'/>
+        <choice value='150%'/>
+      </choices>
+      <summary>Font scaling percentage</summary>
+      <description>Allows users to select a scaling factor for the application font size.</description>
     </key>
-    <key name="dark-theme" type="b">
-      <default>false</default>
-      <summary>Dark theme</summary>
-      <description>Enable dark theme</description>
+    <key name="theme-preference" type="s">
+      <default>'System'</default>
+      <choices>
+        <choice value='System'/>
+        <choice value='Light'/>
+        <choice value='Dark'/>
+      </choices>
+      <summary>Application theme preference</summary>
+      <description>Allows users to choose between System, Light, or Dark themes.</description>
     </key>
     <key name="source-style-scheme" type="s">
       <default>'Adwaita'</default>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -23,10 +23,19 @@
             <!-- Removed margin-top to let banner be flush if at top -->
             <property name="title">Appearance</property>
             <child>
-              <object class="AdwSwitchRow" id="theme_switch_row">
-                <property name="title">Dark Theme</property>
-                <property name="subtitle">Toggle application-wide dark theme</property>
-                <!-- Binding will be done in code or via GSettings -->
+              <object class="AdwComboRow" id="theme_combo_row">
+                <property name="title" translatable="yes">Theme</property>
+                <property name="subtitle" translatable="yes">Choose the application theme</property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">System</item>
+                      <item translatable="yes">Light</item>
+                      <item translatable="yes">Dark</item>
+                    </items>
+                  </object>
+                </property>
+                <property name="selected">0</property>
               </object>
             </child>
             <child>
@@ -56,24 +65,22 @@
               </object>
             </child>
             <child>
-              <object class="AdwActionRow" id="font_size_row">
-                <property name="title">Font Size</property>
-                <child type="suffix">
-                  <object class="GtkScale" id="font_size_scale">
-                    <property name="adjustment">
-                      <object class="GtkAdjustment">
-                        <property name="lower">8</property>
-                        <property name="step-increment">1</property>
-                        <property name="upper">32</property>
-                        <property name="value">12</property>
-                      </object>
-                    </property>
-                    <property name="digits">0</property>
-                    <property name="hexpand">true</property>
-                    <property name="orientation">horizontal</property>
-                    <property name="width-request">200</property> <!-- Give it some minimum width -->
+              <object class="AdwComboRow" id="font_scale_combo_row">
+                <property name="title" translatable="yes">Font Size</property>
+                <property name="subtitle" translatable="yes">Select text scaling percentage</property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">100% (Normal)</item>
+                      <item translatable="yes">110%</item>
+                      <item translatable="yes">120%</item>
+                      <item translatable="yes">130%</item>
+                      <item translatable="yes">140%</item>
+                      <item translatable="yes">150%</item>
+                    </items>
                   </object>
-                </child>
+                </property>
+                <property name="selected">0</property>
               </object>
             </child>
           </object>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -13,8 +13,8 @@ from .constants import APP_ID, RESOURCE_PREFIX
 class Preferences(Adw.PreferencesWindow):
     __gtype_name__ = "Preferences"
 
-    font_size_scale = Gtk.Template.Child("font_size_scale")
-    theme_switch_row = Gtk.Template.Child("theme_switch_row")
+    font_scale_combo_row = Gtk.Template.Child("font_scale_combo_row")
+    theme_combo_row = Gtk.Template.Child("theme_combo_row")
     source_style_scheme_combo_row = Gtk.Template.Child("source_style_scheme_combo_row")
     dns_server_entryrow = Gtk.Template.Child("dns_server_entryrow")
     preferences_error_banner = Gtk.Template.Child("preferences_error_banner")
@@ -28,9 +28,9 @@ class Preferences(Adw.PreferencesWindow):
         self.load_preferences()
 
     def load_ui(self):
-        self.font_size_scale.connect("value-changed", self.on_font_size_changed)
-        # Connect to notify::active for AdwSwitchRow
-        self.theme_switch_row.connect("notify::active", self.on_theme_switch_changed)
+        self.font_scale_combo_row.connect("notify::selected", self.on_font_scale_changed)
+        # Connect to notify::selected for AdwComboRow
+        self.theme_combo_row.connect("notify::selected", self.on_theme_preference_changed)
         self.source_style_scheme_combo_row.connect(
             "notify::selected", self.on_source_style_scheme_changed
         )
@@ -90,14 +90,21 @@ class Preferences(Adw.PreferencesWindow):
                 return False
         return True
 
-    def on_font_size_changed(self, scale):
-        font_size = int(scale.get_value())
-        self.settings.set_int("font-size", font_size)
+    def on_font_scale_changed(self, combo_row: Adw.ComboRow, _gparam):
+        selected_item_obj = combo_row.get_selected_item()
+        if isinstance(selected_item_obj, Gtk.StringObject):
+            selected_scale_str = selected_item_obj.get_string()
+            self.settings.set_string("font-scaling-percentage", selected_scale_str)
+            # The actual application of font size will be handled by WoesWindow
+            # based on this setting change, similar to how theme changes are handled.
+            logging.debug("Font scaling preference set to %s.", selected_scale_str)
 
-    def on_theme_switch_changed(self, switch_row: Adw.SwitchRow, _gparam):
-        theme_enabled = switch_row.get_active()
-        self.settings.set_boolean("dark-theme", theme_enabled)
-        logging.debug("Dark theme preference set to %s. WoesWindow will handle the change.", theme_enabled)
+    def on_theme_preference_changed(self, combo_row: Adw.ComboRow, _gparam):
+        selected_item_obj = combo_row.get_selected_item()
+        if isinstance(selected_item_obj, Gtk.StringObject):
+            selected_theme_str = selected_item_obj.get_string()
+            self.settings.set_string("theme-preference", selected_theme_str)
+            logging.debug("Theme preference set to %s. WoesWindow will handle the change.", selected_theme_str)
 
     def on_source_style_scheme_changed(self, combo_row: Adw.ComboRow, _gparam):
         selected_item = combo_row.get_selected_item()
@@ -106,11 +113,27 @@ class Preferences(Adw.PreferencesWindow):
             self.settings.set_string("source-style-scheme", source_style_scheme)
 
     def load_preferences(self):
-        font_size = self.settings.get_int("font-size")
-        self.font_size_scale.set_value(float(font_size))
+        font_scale_pref = self.settings.get_string("font-scaling-percentage")
+        model = self.font_scale_combo_row.get_model()
+        if isinstance(model, Gtk.StringList):
+            for i in range(model.get_n_items()):
+                item_string = model.get_string(i)
+                if item_string == font_scale_pref:
+                    self.font_scale_combo_row.set_selected(i)
+                    break
+        else: # Fallback or if model is not as expected
+            self.font_scale_combo_row.set_selected(0) # Default to "100% (Normal)"
 
-        dark_theme_enabled = self.settings.get_boolean("dark-theme")
-        self.theme_switch_row.set_active(dark_theme_enabled)
+        theme_pref_value = self.settings.get_string("theme-preference")
+        model = self.theme_combo_row.get_model()
+        if isinstance(model, Gtk.StringList):
+            for i in range(model.get_n_items()):
+                item_string = model.get_string(i)
+                if item_string == theme_pref_value:
+                    self.theme_combo_row.set_selected(i)
+                    break
+        else: # Fallback or if model is not as expected
+            self.theme_combo_row.set_selected(0) # Default to "System"
 
         source_style_scheme = self.settings.get_string("source-style-scheme")
         model = self.source_style_scheme_combo_row.get_model()

--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import gi
 
 gi.require_version('Adw', '1')
@@ -6,10 +7,26 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('GtkSource', '5')
 from gi.repository import Adw, Gdk, Gio, Gtk, GtkSource
 
+BASE_FONT_SIZE_PT = 10.0  # Define a base font size
 
-def apply_font_size(_settings: Gio.Settings, font_size: int):  # Prefixed unused 'settings'
+def apply_font_size(_settings: Gio.Settings, font_scale_percentage_str: str):  # Prefixed unused 'settings'
+    logging.debug(f"apply_font_size called with: '{font_scale_percentage_str}'")
+    parsed_percentage = 100.0  # Default
+    match = re.match(r"(\d+)\%?", font_scale_percentage_str)
+    if match:
+        try:
+            parsed_percentage = float(match.group(1))
+        except ValueError:
+            logging.warning(f"Could not parse percentage from '{font_scale_percentage_str}', defaulting to 100%.")
+            parsed_percentage = 100.0
+    else:
+        logging.warning(f"Could not parse percentage from '{font_scale_percentage_str}', defaulting to 100%.")
+
+    actual_font_size_pt = BASE_FONT_SIZE_PT * (parsed_percentage / 100.0)
+    logging.debug(f"Applying font: base={BASE_FONT_SIZE_PT}pt, scale_pref='{font_scale_percentage_str}', calculated_size={actual_font_size_pt}pt")
+
     css_provider = Gtk.CssProvider()
-    css = f"* {{ font-size: {font_size}pt; }}"
+    css = f"* {{ font-size: {actual_font_size_pt}pt; }}"
     css_provider.load_from_data(css.encode())
 
     Gtk.StyleContext.add_provider_for_display(
@@ -19,11 +36,14 @@ def apply_font_size(_settings: Gio.Settings, font_size: int):  # Prefixed unused
     )
 
 
-def apply_theme(style_manager: Adw.StyleManager, dark_theme_enabled: bool):
-    if dark_theme_enabled:
-        style_manager.set_color_scheme(Adw.ColorScheme.PREFER_DARK)
-    else:
-        style_manager.set_color_scheme(Adw.ColorScheme.PREFER_LIGHT)
+def apply_theme(style_manager: Adw.StyleManager, theme_preference: str):
+    logging.debug("Applying theme preference: %s", theme_preference)
+    if theme_preference == "Light":
+        style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
+    elif theme_preference == "Dark":
+        style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
+    else:  # Default to "System" or any other unexpected value
+        style_manager.set_color_scheme(Adw.ColorScheme.DEFAULT)
 
 
 def apply_source_style_scheme(

--- a/src/window.py
+++ b/src/window.py
@@ -38,9 +38,12 @@ class WoesWindow(Adw.ApplicationWindow):
         self.style_manager = Adw.StyleManager.get_default()
         logging.debug("WoesWindow.__init__: StyleManager obtained.")
 
-        logging.debug("WoesWindow.__init__: Connecting dark-theme setting change listener...")
-        self.settings.connect("changed::dark-theme", self._on_dark_theme_setting_changed)
-        logging.debug("WoesWindow.__init__: dark-theme listener connected.")
+        logging.debug("WoesWindow.__init__: Connecting theme-preference setting change listener...")
+        self.settings.connect("changed::theme-preference", self._on_theme_preference_setting_changed)
+        logging.debug("WoesWindow.__init__: theme-preference listener connected.")
+        logging.debug("WoesWindow.__init__: Connecting font-scaling-percentage setting change listener...")
+        self.settings.connect("changed::font-scaling-percentage", self._on_font_scaling_setting_changed)
+        logging.debug("WoesWindow.__init__: font-scaling-percentage listener connected.")
 
         logging.debug("WoesWindow.__init__: Calling setup_ui...")
         try:
@@ -77,20 +80,25 @@ class WoesWindow(Adw.ApplicationWindow):
             logging.warning("switcher_title or stack not found during setup_ui.")
         logging.debug("WoesWindow.setup_ui: Finished")
 
-    def _on_dark_theme_setting_changed(self, settings, key): # Added method
-        logging.debug(f"WoesWindow._on_dark_theme_setting_changed: '{key}' setting changed.")
-        dark_theme_enabled = settings.get_boolean(key)
-        apply_theme(self.style_manager, dark_theme_enabled)
-        self.load_css()
+    def _on_theme_preference_setting_changed(self, settings, key):
+        logging.debug(f"WoesWindow._on_theme_preference_setting_changed: '{key}' setting changed.")
+        theme_pref = settings.get_string(key)
+        apply_theme(self.style_manager, theme_pref)
+        self.load_css() # Reload CSS to apply potential theme-specific styles (e.g., style-dark.css)
+
+    def _on_font_scaling_setting_changed(self, settings, key):
+        logging.debug(f"WoesWindow._on_font_scaling_setting_changed: '{key}' setting changed.")
+        font_scale_pref_str = settings.get_string(key)
+        # The _settings parameter in apply_font_size is currently unused but part of its signature
+        apply_font_size(self.settings, font_scale_pref_str)
 
     def load_css(self):
         logging.debug("WoesWindow.load_css: Starting")
         # Determine which CSS file to use based on the current theme
-        css_file = (
-            "style-dark.css"
-            if self.style_manager.get_color_scheme() == Adw.ColorScheme.PREFER_DARK
-            else "style.css"
-        )
+        if self.style_manager.get_dark():
+            css_file = "style-dark.css"
+        else:
+            css_file = "style.css"
         logging.debug(f"WoesWindow.load_css: Determined css_file: {css_file}")
         css_path = f"{RESOURCE_PREFIX}/{css_file}"
         logging.debug(f"WoesWindow.load_css: css_path: {css_path}")
@@ -119,13 +127,13 @@ class WoesWindow(Adw.ApplicationWindow):
     def apply_preferences(self):
         logging.debug("WoesWindow.apply_preferences: Starting")
         try:
-            font_size = self.settings.get_int("font-size")
-            logging.debug(f"WoesWindow.apply_preferences: Font size from settings: {font_size}")
-            dark_theme_enabled = self.settings.get_boolean("dark-theme")
-            logging.debug(f"WoesWindow.apply_preferences: Dark theme from settings: {dark_theme_enabled}")
+            font_scale_pref_str = self.settings.get_string("font-scaling-percentage")
+            logging.debug(f"WoesWindow.apply_preferences: Font scale preference from settings: {font_scale_pref_str}")
+            theme_pref = self.settings.get_string("theme-preference")
+            logging.debug(f"WoesWindow.apply_preferences: Theme preference from settings: {theme_pref}")
 
-            apply_font_size(self.settings, font_size)
-            apply_theme(self.style_manager, dark_theme_enabled)
+            apply_font_size(self.settings, font_scale_pref_str)
+            apply_theme(self.style_manager, theme_pref)
         except GLib.Error as e:
             logging.error(f"Error applying preferences (GSettings): {e}")
         except Exception as e:


### PR DESCRIPTION
This implements user-configurable theme selection (System, Light, Dark) and font scaling (100%-150%) in your preferences window.

Changes:
- Modified GSettings schema:
    - Replaced 'dark-theme' (boolean) with 'theme-preference' (string: System, Light, Dark).
    - Replaced 'font-size' (int) with 'font-scaling-percentage' (string: 100%-150%).
- Updated 'preferences.ui':
    - Replaced theme switch with an AdwComboRow for System/Light/Dark.
    - Replaced font size GtkScale with an AdwComboRow for scaling percentages.
- Updated 'preferences.py':
    - Adapted logic to use new AdwComboRow widgets and GSettings keys.
- Updated 'style_utils.py':
    - Modified 'apply_theme' to accept "System", "Light", or "Dark" strings.
    - Modified 'apply_font_size' to accept a percentage string and calculate actual font size based on a BASE_FONT_SIZE_PT of 10.0pt.
- Updated 'window.py':
    - Adapted to new GSettings keys and updated 'apply_theme' and 'apply_font_size' function signatures/logic.
    - Improved logic in 'load_css' to select dark/light CSS based on Adw.StyleManager.get_dark().

Note: I was hindered in fully testing this at runtime by a persistent build environment issue (missing `pygobject-3.0.pc` file). The changes are syntactically correct and follow the planned logic.