### PR TITLE
Fix: Ensure GError code is int for Gio.Task.return_error

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -251,7 +251,7 @@ class HttpPage(Adw.PreferencesPage):
             safe_error_message = str(error_message)  # Ensure message is string
             # Use specific GIO error code for timeouts
             g_error = GLib.Error(
-                message=safe_error_message, domain=Gio.io_error_quark(), code=Gio.IOErrorEnum.TIMED_OUT
+                message=safe_error_message, domain=Gio.io_error_quark(), code=int(Gio.IOErrorEnum.TIMED_OUT)
             )
             task.return_error(g_error)
             return

--- a/src/tests/test_http_page.py
+++ b/src/tests/test_http_page.py
@@ -258,7 +258,7 @@ class TestHttpPage(unittest.TestCase):
         self.assertIsInstance(error_arg, MockGLibErrorForTest)
         self.assertIn("timed out", error_arg.message.lower())
         # Ensure the code used matches the mocked Gio.IOErrorEnum.TIMED_OUT
-        self.assertEqual(error_arg.code, MockGio.IOErrorEnum.TIMED_OUT)
+        self.assertEqual(error_arg.code, int(MockGio.IOErrorEnum.TIMED_OUT))
 
     @patch('src.http_page.requests.get')
     def test_timeout_error_post_fix_verification(self, mock_requests_get):
@@ -348,8 +348,8 @@ class TestHttpPage(unittest.TestCase):
         self.assertEqual(error_arg.domain, MockGio.io_error_quark.return_value)
 
         # 3d. Crucially, the error code matches Gio.IOErrorEnum.TIMED_OUT (mocked value)
-        # This verifies that `code=Gio.IOErrorEnum.TIMED_OUT` (and not `.value`) was used correctly.
-        self.assertEqual(error_arg.code, MockGio.IOErrorEnum.TIMED_OUT)
+        # This verifies that `code=int(Gio.IOErrorEnum.TIMED_OUT)` was used correctly.
+        self.assertEqual(error_arg.code, int(MockGio.IOErrorEnum.TIMED_OUT))
         self.assertIsInstance(error_arg.code, int) # Ensure it's an int, as expected by GLib.Error
 
     @patch('src.http_page.requests.get')


### PR DESCRIPTION
Corrects a TypeError ("Must be string, not int") that occurred when calling Gio.Task.return_error() with a GError whose code was initialized directly with a Gio.IOErrorEnum member without explicit casting to int.

While GLib.Error constructor can accept Gio.IOErrorEnum members, Gio.Task.return_error() appears to require the GError's code to be a plain integer.

This commit modifies the timeout exception handling in `src/http_page.py` to explicitly cast `Gio.IOErrorEnum.TIMED_OUT` to an integer using `int()` when creating the `GLib.Error` object.

Unit tests in `src/tests/test_http_page.py` have been updated to reflect this explicit integer casting in their assertions, ensuring continued accuracy in testing the error handling mechanism.