### PR TITLE
Fix: Define missing GSettings constants

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -19,3 +19,7 @@ USER_AGENTS = [
     "(KHTML, like Gecko) Version/16.3 Safari/605.1.15",
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0",
 ]
+
+GNOME_INTERFACE_SCHEMA = "org.gnome.desktop.interface"
+FONT_NAME_KEY = "font-name"
+TEXT_SCALING_FACTOR_KEY = "text-scaling-factor"


### PR DESCRIPTION
Adds definitions for GNOME_INTERFACE_SCHEMA, FONT_NAME_KEY, and TEXT_SCALING_FACTOR_KEY to src/constants.py.

These constants are used in src/window.py for integrating with GNOME desktop font and text scaling settings, and their absence caused an ImportError.