### PR TITLE
Fix: Correct TypeError for code in GLib.Error creation (HttpPage)

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -178,7 +178,7 @@ class HttpPage(Adw.PreferencesPage):
 
         try:
             if cancellable and cancellable.is_cancelled():
-                task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CANCELLED, "Task was cancelled."))
+                task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CANCELLED.value, "Task was cancelled."))
                 return
 
             response = requests.get(url, headers=request_headers, allow_redirects=True, timeout=10)
@@ -205,7 +205,7 @@ class HttpPage(Adw.PreferencesPage):
                 # This block is entered if response.status_code is an HTTP error (4xx or 5xx)
                 logger.warning("Task thread: HTTPError for %s: %s", url, http_err)
                 error_message = self._format_http_error(http_err)
-                task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.HTTP_ERROR, error_message))
+                task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.HTTP_ERROR.value, error_message))
                 return # Exit the function after reporting the error
 
             # This part is reached ONLY if response.raise_for_status() did NOT raise an exception
@@ -222,7 +222,7 @@ class HttpPage(Adw.PreferencesPage):
 
         except requests.exceptions.Timeout as e:
             logger.warning("Task thread: Timeout for %s: %s", url, e)
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.TIMEOUT, "Request timed out. This could be due to a slow network, server issues, or a Web Application Firewall (WAF) interfering. Please check the URL or try again later."))
+            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.TIMEOUT.value, "Request timed out. This could be due to a slow network, server issues, or a Web Application Firewall (WAF) interfering. Please check the URL or try again later."))
         # HTTPError is handled above for the final response. If requests.get itself raises one for a redirect, it's caught by RequestException.
         except requests.exceptions.ConnectionError as e:
             logger.warning("Task thread: ConnectionError for %s: %s", url, e)
@@ -230,13 +230,13 @@ class HttpPage(Adw.PreferencesPage):
             error_message = custom_msg if custom_msg else f"Connection Error: {str(e)}"
             if not str(e) and not custom_msg: # Ensure some message is shown
                  error_message = "Connection Error: Failed to establish a connection."
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CONNECTION_ERROR, error_message))
+            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CONNECTION_ERROR.value, error_message))
         except requests.exceptions.RequestException as e: # Catches other requests errors like TooManyRedirects, etc.
             logger.warning("Task thread: RequestException for %s: %s", url, e)
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.REQUEST_EXCEPTION, f"Request Error: {str(e)}"))
+            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.REQUEST_EXCEPTION.value, f"Request Error: {str(e)}"))
         except Exception as e:
             logger.error("Task thread: Truly unexpected error for %s: %s", url, e, exc_info=True)
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.GENERIC_UNEXPECTED, f"An unexpected error occurred: {str(e)}"))
+            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.GENERIC_UNEXPECTED.value, f"An unexpected error occurred: {str(e)}"))
 
 
     def _get_detailed_connection_error_message(self, exc: Exception, url: str) -> Optional[str]:


### PR DESCRIPTION
Resolves a TypeError that occurred when creating GLib.Error objects in `_fetch_headers_task_thread_func` within `src/http_page.py`. The `GLib.Error.new_literal()` function expects the error code argument to be an integer, but it was being passed an HttpErrorType enum member directly.

This commit fixes the issue by using `HttpErrorType.XXX.value` for the code argument in all `GLib.Error.new_literal` calls within the HttpPage task thread.

This ensures that `GLib.Error` objects are constructed with the correct integer error code, allowing errors from the HTTP task (like timeouts, HTTP errors, etc.) to be properly propagated with their intended codes and handled by the callback for UI display.