### PR TITLE
Fix: Use direct constructor for GLib.Error in HttpPage task

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -178,7 +178,11 @@ class HttpPage(Adw.PreferencesPage):
 
         try:
             if cancellable and cancellable.is_cancelled():
-                task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CANCELLED.value, "Task was cancelled."))
+                err = GLib.Error()
+                err.domain = GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN)
+                err.code = HttpErrorType.CANCELLED.value
+                err.message = "Task was cancelled."
+                task.return_error(err)
                 return
 
             response = requests.get(url, headers=request_headers, allow_redirects=True, timeout=10)
@@ -205,7 +209,11 @@ class HttpPage(Adw.PreferencesPage):
                 # This block is entered if response.status_code is an HTTP error (4xx or 5xx)
                 logger.warning("Task thread: HTTPError for %s: %s", url, http_err)
                 error_message = self._format_http_error(http_err)
-                task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.HTTP_ERROR.value, error_message))
+                err = GLib.Error()
+                err.domain = GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN)
+                err.code = HttpErrorType.HTTP_ERROR.value
+                err.message = error_message
+                task.return_error(err)
                 return # Exit the function after reporting the error
 
             # This part is reached ONLY if response.raise_for_status() did NOT raise an exception
@@ -222,7 +230,12 @@ class HttpPage(Adw.PreferencesPage):
 
         except requests.exceptions.Timeout as e:
             logger.warning("Task thread: Timeout for %s: %s", url, e)
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.TIMEOUT.value, "Request timed out. This could be due to a slow network, server issues, or a Web Application Firewall (WAF) interfering. Please check the URL or try again later."))
+            error_message = "Request timed out. This could be due to a slow network, server issues, or a Web Application Firewall (WAF) interfering. Please check the URL or try again later."
+            err = GLib.Error()
+            err.domain = GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN)
+            err.code = HttpErrorType.TIMEOUT.value
+            err.message = error_message
+            task.return_error(err)
         # HTTPError is handled above for the final response. If requests.get itself raises one for a redirect, it's caught by RequestException.
         except requests.exceptions.ConnectionError as e:
             logger.warning("Task thread: ConnectionError for %s: %s", url, e)
@@ -230,13 +243,27 @@ class HttpPage(Adw.PreferencesPage):
             error_message = custom_msg if custom_msg else f"Connection Error: {str(e)}"
             if not str(e) and not custom_msg: # Ensure some message is shown
                  error_message = "Connection Error: Failed to establish a connection."
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CONNECTION_ERROR.value, error_message))
+            err = GLib.Error()
+            err.domain = GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN)
+            err.code = HttpErrorType.CONNECTION_ERROR.value
+            err.message = error_message
+            task.return_error(err)
         except requests.exceptions.RequestException as e: # Catches other requests errors like TooManyRedirects, etc.
             logger.warning("Task thread: RequestException for %s: %s", url, e)
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.REQUEST_EXCEPTION.value, f"Request Error: {str(e)}"))
+            error_message = f"Request Error: {str(e)}"
+            err = GLib.Error()
+            err.domain = GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN)
+            err.code = HttpErrorType.REQUEST_EXCEPTION.value
+            err.message = error_message
+            task.return_error(err)
         except Exception as e:
             logger.error("Task thread: Truly unexpected error for %s: %s", url, e, exc_info=True)
-            task.return_error(GLib.Error.new_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.GENERIC_UNEXPECTED.value, f"An unexpected error occurred: {str(e)}"))
+            error_message = f"An unexpected error occurred: {str(e)}"
+            err = GLib.Error()
+            err.domain = GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN)
+            err.code = HttpErrorType.GENERIC_UNEXPECTED.value
+            err.message = error_message
+            task.return_error(err)
 
 
     def _get_detailed_connection_error_message(self, exc: Exception, url: str) -> Optional[str]:


### PR DESCRIPTION
Changes the method of GLib.Error object creation within the _fetch_headers_task_thread_func in src/http_page.py. Instead of GLib.Error.new_literal(), this commit now uses the direct GLib.Error() constructor, explicitly setting the .domain, .code, and .message attributes.

This change is made to ensure robust creation of GLib.Error objects and to resolve a TypeError that was occurring when task.return_error() was called with an error object created by new_literal() in some cases. Using the direct constructor is a standard alternative that should prevent such TypeErrors.

This allows HTTP task errors (Timeouts, HTTP errors, etc.) to be correctly packaged and propagated for UI display.