### PR TITLE
Fix GIO assertion failure in HTTP task error handling

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -239,6 +239,7 @@ class HttpPage(Adw.PreferencesPage):
                 "%s",
                 error_message
             )
+            return
         # HTTPError is handled above for the final response. If requests.get itself raises one for a redirect, it's caught by RequestException.
         except requests.exceptions.ConnectionError as e:
             logger.warning("Task thread: ConnectionError for %s: %s", url, e)
@@ -252,6 +253,7 @@ class HttpPage(Adw.PreferencesPage):
                 "%s",
                 error_message
             )
+            return
         except requests.exceptions.RequestException as e: # Catches other requests errors like TooManyRedirects, etc.
             logger.warning("Task thread: RequestException for %s: %s", url, e)
             error_message = f"Request Error: {str(e)}"
@@ -261,6 +263,7 @@ class HttpPage(Adw.PreferencesPage):
                 "%s",
                 error_message
             )
+            return
         except Exception as e:
             logger.error("Task thread: Truly unexpected error for %s: %s", url, e, exc_info=True)
             error_message = f"An unexpected error occurred: {str(e)}"
@@ -270,6 +273,7 @@ class HttpPage(Adw.PreferencesPage):
                 "%s",
                 error_message
             )
+            return
 
 
     def _get_detailed_connection_error_message(self, exc: Exception, url: str) -> Optional[str]:


### PR DESCRIPTION
Ensures that the HTTP header fetching thread (_fetch_headers_task_thread_func) explicitly returns after calling task.return_error() in all relevant exception handling blocks (Timeout, ConnectionError, RequestException, and generic Exception).

This prevents the thread from continuing execution after an error has been reported on the Gio.Task, which is suspected to be the cause of the "g_task_propagate_value: assertion 'task->result_set' failed" error observed in some cases. This GIO assertion failure would then lead to the "TypeError: Invalid type" in the task callback (_fetch_headers_task_done_cb) when local_task_ref.propagate_value() returned an unexpected type due to the inconsistent task state.

This change aims to make the error handling in the threaded task more robust and ensure correct error propagation to the UI, so that you see the intended error messages (e.g., for timeouts) instead of generic application errors.