### PR TITLE
I've fixed a TypeError in Gio.Task error reporting for HTTP tasks.

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -178,10 +178,9 @@ class HttpPage(Adw.PreferencesPage):
 
         try:
             if cancellable and cancellable.is_cancelled():
-                task.return_error(
+                task.return_new_error_literal(
                     GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
                     HttpErrorType.CANCELLED.value,
-                    "%s",
                     "Task was cancelled."
                 )
                 return
@@ -210,10 +209,9 @@ class HttpPage(Adw.PreferencesPage):
                 # This block is entered if response.status_code is an HTTP error (4xx or 5xx)
                 logger.warning("Task thread: HTTPError for %s: %s", url, http_err)
                 error_message = self._format_http_error(http_err)
-                task.return_error(
+                task.return_new_error_literal(
                     GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
                     HttpErrorType.HTTP_ERROR.value,
-                    "%s",
                     error_message
                 )
                 return # Exit the function after reporting the error
@@ -233,10 +231,9 @@ class HttpPage(Adw.PreferencesPage):
         except requests.exceptions.Timeout as e:
             logger.warning("Task thread: Timeout for %s: %s", url, e)
             error_message = "Request timed out. This could be due to a slow network, server issues, or a Web Application Firewall (WAF) interfering. Please check the URL or try again later."
-            task.return_error(
+            task.return_new_error_literal(
                 GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
                 HttpErrorType.TIMEOUT.value,
-                "%s",
                 error_message
             )
             return
@@ -247,30 +244,27 @@ class HttpPage(Adw.PreferencesPage):
             error_message = custom_msg if custom_msg else f"Connection Error: {str(e)}"
             if not str(e) and not custom_msg: # Ensure some message is shown
                  error_message = "Connection Error: Failed to establish a connection."
-            task.return_error(
+            task.return_new_error_literal(
                 GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
                 HttpErrorType.CONNECTION_ERROR.value,
-                "%s",
                 error_message
             )
             return
         except requests.exceptions.RequestException as e: # Catches other requests errors like TooManyRedirects, etc.
             logger.warning("Task thread: RequestException for %s: %s", url, e)
             error_message = f"Request Error: {str(e)}"
-            task.return_error(
+            task.return_new_error_literal(
                 GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
                 HttpErrorType.REQUEST_EXCEPTION.value,
-                "%s",
                 error_message
             )
             return
         except Exception as e:
             logger.error("Task thread: Truly unexpected error for %s: %s", url, e, exc_info=True)
             error_message = f"An unexpected error occurred: {str(e)}"
-            task.return_error(
+            task.return_new_error_literal(
                 GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
                 HttpErrorType.GENERIC_UNEXPECTED.value,
-                "%s",
                 error_message
             )
             return

--- a/src/tests/test_http_page.py
+++ b/src/tests/test_http_page.py
@@ -175,7 +175,7 @@ class TestHttpPage(unittest.TestCase):
         self.page = None
         self.mock_task_instance = MagicMock(spec=MockGio.Task)
         self.mock_task_instance.get_cancellable.return_value = mock_cancellable
-        self.mock_task_instance.return_error = MagicMock() # Added for new test
+        self.mock_task_instance.return_new_error_literal = MagicMock() # Changed mock name
 
         self.done_cb_to_call = None
         self.done_cb_args = None
@@ -201,11 +201,11 @@ class TestHttpPage(unittest.TestCase):
         def mock_task_propagate_val_method():
             # This method is called by _fetch_headers_task_done_cb on self.mock_task_instance
             # It returns the captured dictionary, or raises if it's an error meant to be raised by propagate_value itself.
-            if self.mock_task_instance.return_error.called:
-                # If task.return_error() was called in the thread, simulate GLib.Error being raised by propagate_value()
-                # The first call to return_error has args: (domain_quark, code_int, format_str, message_str)
-                call_args = self.mock_task_instance.return_error.call_args[0]
-                domain_quark, code_int, _, message_str = call_args
+            if self.mock_task_instance.return_new_error_literal.called:
+                # If task.return_new_error_literal() was called, simulate GLib.Error being raised by propagate_value()
+                # Arguments are: (domain_quark, code_int, message_str)
+                call_args = self.mock_task_instance.return_new_error_literal.call_args[0]
+                domain_quark, code_int, message_str = call_args[0], call_args[1], call_args[2]
                 # print(f"mock_task_propagate_val_method raising MockGLibErrorForTest: domain={domain_quark}, code={code_int}, msg='{message_str}'")
                 raise MockGLibErrorForTest(message=message_str, domain=domain_quark, code=code_int)
 
@@ -320,8 +320,10 @@ class TestHttpPage(unittest.TestCase):
         page.http_entry_row.set_sensitive.assert_called_with(True)
         page.http_entry_row.add_css_class.assert_called_with("error")
 
-        # self.mock_task_instance.return_error should NOT have been called for this.
-        self.mock_task_instance.return_error.assert_not_called()
+        # self.mock_task_instance.return_new_error_literal should NOT have been called for this specific old test.
+        # This test might need re-evaluation based on whether it should now expect return_new_error_literal
+        # For now, assuming it tests a path that *doesn't* call it.
+        self.mock_task_instance.return_new_error_literal.assert_not_called()
 
 
     @patch('src.http_page.requests.get')
@@ -371,8 +373,8 @@ class TestHttpPage(unittest.TestCase):
         page.http_entry_row.set_sensitive.assert_called_with(True)
         page.http_entry_row.add_css_class.assert_called_with("error")
 
-        # 3. Gio.Task.return_error should NOT be called.
-        self.mock_task_instance.return_error.assert_not_called()
+        # 3. Gio.Task.return_new_error_literal should NOT be called for this specific old test.
+        self.mock_task_instance.return_new_error_literal.assert_not_called()
 
         # 4. self.mock_task_instance.return_value (the method on the task) should have been called once
         # by _fetch_headers_task_thread_func
@@ -477,7 +479,7 @@ class TestHttpPage(unittest.TestCase):
         page.http_entry_row.set_sensitive.assert_called_with(True)
         page.http_entry_row.add_css_class.assert_called_with("error")
 
-        self.mock_task_instance.return_error.assert_not_called()
+        self.mock_task_instance.return_new_error_literal.assert_not_called()
         self.mock_task_instance.return_value.assert_called_once() # The method on the task instance
         args_call = self.mock_task_instance.return_value.call_args[0][0]
         self.assertIsInstance(args_call, dict)
@@ -533,7 +535,7 @@ class TestHttpPage(unittest.TestCase):
         page.http_entry_row.set_sensitive.assert_called_with(True)
         page.http_entry_row.add_css_class.assert_called_with("error")
 
-        self.mock_task_instance.return_error.assert_not_called()
+        self.mock_task_instance.return_new_error_literal.assert_not_called()
         self.mock_task_instance.return_value.assert_called_once()
         args_call = self.mock_task_instance.return_value.call_args[0][0]
         self.assertIsInstance(args_call, dict)
@@ -1115,19 +1117,19 @@ def _create_mock_response(url, status_code, headers, history_list=None):
         page._on_entry_row_activated(page.http_entry_row)
 
         # --- Assertions ---
-        # 1. task.return_error was called correctly in the thread
-        self.mock_task_instance.return_error.assert_called_once()
-        args, _ = self.mock_task_instance.return_error.call_args
+        # 1. task.return_new_error_literal was called correctly in the thread
+        self.mock_task_instance.return_new_error_literal.assert_called_once()
 
-        # Check domain (quark_from_string returns the string itself due to our mock)
-        self.assertEqual(args[0], WOES_HTTP_ERROR_DOMAIN)
-        # Check error code
-        self.assertEqual(args[1], HttpErrorType.TIMEOUT.value)
-        # Check format string
-        self.assertEqual(args[2], "%s")
-        # Check specific timeout message
         expected_timeout_message = "Request timed out. This could be due to a slow network, server issues, or a Web Application Firewall (WAF) interfering. Please check the URL or try again later."
-        self.assertEqual(args[3], expected_timeout_message)
+        # Ensure module-level constants are used for assertion if available, otherwise direct values
+        expected_domain = WOES_HTTP_ERROR_DOMAIN if WOES_HTTP_ERROR_DOMAIN else "woes-http-error-domain"
+        expected_code = HttpErrorType.TIMEOUT.value if HttpErrorType else 0
+
+        self.mock_task_instance.return_new_error_literal.assert_called_once_with(
+            expected_domain,
+            expected_code,
+            expected_timeout_message
+        )
 
         # 2. UI reflects the error state (via _fetch_headers_task_done_cb)
         page.error_banner.set_revealed.assert_called_with(True)


### PR DESCRIPTION
This corrects a TypeError that occurred when reporting errors from the HTTP header fetching task. The `task.return_error()` method was being called with a signature (domain, code, format, message) that corresponds to the C `g_task_return_new_error()` function. The correct PyGObject method for this is `task.return_new_error_literal()`, which takes (domain_quark, code_int, message_literal).

I've changed all relevant calls in `_fetch_headers_task_thread_func` to use `task.return_new_error_literal()` with the correct arguments.

Additionally, I've updated the test suite (`src/tests/test_http_page.py`):
- Mocking for `Gio.Task` in `setUp` now correctly reflects the `return_new_error_literal` method.
- The test `test_actual_timeout_error_flow` now asserts that `return_new_error_literal` is called with the appropriate domain, code, and message.
- Other tests were updated to assert that `return_new_error_literal` is not called where appropriate.

This resolves the `TypeError: Gio.Task.return_error() takes exactly 2 arguments (5 given)` and should fix the downstream `GLib-GIO-CRITICAL: g_task_propagate_value: assertion 'task->result_set' failed` and `TypeError: Invalid type` in the task callback, ensuring that you see the specific error messages intended by the application.