### PR TITLE
I've fixed an issue that was preventing the HttpPage template from bu…

### DIFF
--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -52,7 +52,6 @@
         <property name="button-label" translatable="yes">Dismiss</property>
         <property name="revealed">False</property> <!-- Initially hidden -->
         <property name="title"></property> <!-- Title will be set from code -->
-        <signal name="clicked" handler="_on_error_banner_dismiss"/>
       </object>
     </child>
     <child>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -108,6 +108,7 @@ class HttpPage(Adw.PreferencesPage):
             "notify::active", self._on_pragma_toggled
         )
         self.clear_results_button.connect("clicked", self._on_clear_results_clicked)
+        self.error_banner.connect("clicked", self._on_error_banner_dismiss)
 
     def _on_entry_row_activated(self, _widget: Gtk.Widget) -> None: # Parameter renamed
         original_url = self.http_entry_row.get_text().strip() # Changed to self.http_entry_row


### PR DESCRIPTION
…ilding correctly and was causing errors when you tried to access UI elements.

The problem was an "Invalid signal 'clicked' for type 'AdwBanner'" error, which I've resolved by:
1.  Removing a problematic line from the `src/gtk/http_page.ui` file.
2.  In `src/http_page.py`, I programmatically connected the "clicked" signal of `self.error_banner` to `self._on_error_banner_dismiss`.

This should allow HttpPage to initialize correctly and restore its functionality.

I'll look into separate Gtk-CRITICAL warnings later, as they might not be issues once the HttpPage template loads successfully.