### PR TITLE
I've stabilized the HttpPage initialization by fixing a signal error.

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -108,7 +108,6 @@ class HttpPage(Adw.PreferencesPage):
             "notify::active", self._on_pragma_toggled
         )
         self.clear_results_button.connect("clicked", self._on_clear_results_clicked)
-        self.error_banner.connect("clicked", self._on_error_banner_dismiss)
 
     def _on_entry_row_activated(self, _widget: Gtk.Widget) -> None: # Parameter renamed
         original_url = self.http_entry_row.get_text().strip() # Changed to self.http_entry_row


### PR DESCRIPTION
This update addresses a TypeError that occurred during HttpPage initialization when trying to connect an 'unknown signal name: clicked' to an Adw.Banner widget. This TypeError would stop the initialization process, preventing further UI setup, like setting the model for the User-Agent AdwComboRow, which led to more AttributeErrors.

Here's what I did:
- I removed the problematic programmatic connection `self.error_banner.connect("clicked", self._on_error_banner_dismiss)` from `_connect_signals` in `src/http_page.py`.
- I ensured no signal handler is defined for the `error_banner` in `src/gtk/http_page.ui`.

Because of this, the error banner's dedicated dismiss button won't work for now. The banner will clear when other actions trigger `_clear_error()` (for instance, a new request or clearing results). This approach prioritizes the stability of your application. I'll need to look into a more robust way to dismiss the AdwBanner if the 'clicked' signal isn't the right one.

This change should allow `HttpPage.__init__` to complete successfully, which will also resolve the AttributeError on `user_agent_model.get_string()`.

I've deferred investigating the Gtk-CRITICAL warnings related to GtkBox properties (like hadjustment) for now. It's not immediately clear where they're coming from in your project's UI files, and they might not be related to the main HttpPage stability issues.