### PR TITLE
Refactor: Update button labels and add keyboard shortcuts for HIG com…

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -37,6 +37,8 @@ class DNSPage(Adw.PreferencesPage):
             "changed::source-style-scheme",
             self._on_source_style_scheme_setting_changed
             )
+        if self.dns_apply_button:
+            self.dns_apply_button.set_use_underline(True)
 
         try:
             self.bold_tag = self.source_buffer.create_tag(

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -17,8 +17,7 @@
             <property name="activates-default">True</property>
             <child type="suffix">
               <object class="GtkButton" id="dns_apply_button">
-                <property name="icon-name">system-search-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Lookup</property>
+                <property name="label" translatable="yes">_Lookup</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="flat"/>

--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -5,20 +5,85 @@
     <child>
       <object class="GtkShortcutsSection">
         <property name="section-name">shortcuts</property>
-        <property name="max-height">10</property>
+        <property name="max-height">20</property>
         <child>
           <object class="GtkShortcutsGroup">
             <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="title" translatable="yes" context="shortcut window">Show Shortcuts</property>
+                <property name="title" translatable="yes" context="shortcut window">Show Keyboard Shortcuts</property>
+                <property name="accelerator">F1</property>
                 <property name="action-name">win.show-help-overlay</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Preferences</property>
+                <property name="accelerator">&lt;Primary&gt;comma</property>
+                <property name="action-name">app.preferences</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Quit</property>
+                <property name="accelerator">&lt;Primary&gt;q</property>
                 <property name="action-name">app.quit</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcut window">Navigation</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Switch to HTTP Page</property>
+                <property name="accelerator">&lt;Primary&gt;1</property>
+                <property name="action-name">app.switch-to-http</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Switch to Nmap Page</property>
+                <property name="accelerator">&lt;Primary&gt;2</property>
+                <property name="action-name">app.switch-to-nmap</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Switch to DNS Page</property>
+                <property name="accelerator">&lt;Primary&gt;3</property>
+                <property name="action-name">app.switch-to-dns</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Switch to Webscan Page</property>
+                <property name="accelerator">&lt;Primary&gt;4</property>
+                <property name="action-name">app.switch-to-webscan</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcut window">Page Actions</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Fetch (HTTP Page)</property>
+                <property name="accelerator">&lt;Alt&gt;F</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Scan (Nmap Page)</property>
+                <property name="accelerator">&lt;Alt&gt;S</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Lookup (DNS Page)</property>
+                <property name="accelerator">&lt;Alt&gt;L</property>
               </object>
             </child>
           </object>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -17,8 +17,7 @@
             <property name="title" translatable="yes">URL to fetch HTTP headers from</property>
             <child type="suffix">
               <object class="GtkButton" id="http_apply_button">
-                <property name="icon-name">go-next-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Fetch Headers</property>
+                <property name="label" translatable="yes">_Fetch</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="flat"/>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -16,8 +16,7 @@
             <property name="title" translatable="yes">Target (IP/CIDR/Hostname)</property>
             <child type="suffix">
               <object class="GtkButton" id="nmap_apply_button">
-                <property name="icon-name">media-playback-start-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Start Scan</property>
+                <property name="label" translatable="yes">_Scan</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="flat"/>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -99,6 +99,8 @@ class HttpPage(Adw.PreferencesPage):
         user_agent_options = ["None"] + USER_AGENTS
         self.http_user_agent_row.set_model(Gtk.StringList.new(user_agent_options))
         self.http_user_agent_row.set_selected(0)
+        if self.http_apply_button:
+            self.http_apply_button.set_use_underline(True)
 
     def _connect_signals(self) -> None:
         self.http_entry_row.connect(

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -71,6 +71,8 @@ class NmapPage(Adw.PreferencesPage):
 
         self._init_page_ui()
         self._connect_signals()
+        if self.nmap_apply_button:
+            self.nmap_apply_button.set_use_underline(True)
         logging.info("NmapPage initialized.")
         logging.debug("NmapPage __init__ completed.")
 


### PR DESCRIPTION
…pliance.

This commit implements user feedback to improve GNOME HIG compliance:

1.  **Button Labels Updated:**
    - HTTP Page: Main action button label changed from an icon to "_Fetch".
    - Nmap Page: Main action button label changed from an icon to "_Scan".
    - DNS Page: Main action button label changed from an icon to "_Lookup".
    - Tooltips and icons were removed from these buttons to favor text labels as per HIG for primary actions when space permits.

2.  **Keyboard Shortcuts Implemented (Mnemonics):**
    - HTTP Page: Added `Alt+F` mnemonic shortcut for the "Fetch" button.
    - Nmap Page: Added `Alt+S` mnemonic shortcut for the "Scan" button.
    - DNS Page: Added `Alt+L` mnemonic shortcut for the "Lookup" button.
    - This was achieved by setting the label with an underscore (e.g., "_Fetch") and ensuring `use_underline` is true for the buttons.

3.  **Keyboard Shortcuts Dialog Updated:**
    - The `help-overlay.ui` (Keyboard Shortcuts window) has been updated to reflect all relevant shortcuts: - General: Preferences (`<Primary>comma`), Show Shortcuts (`F1`), Quit (`<Primary>q`). - Navigation: Page switching shortcuts (`<Primary>1` through `<Primary>4`). - Page Actions: New mnemonics (`<Alt>F`, `<Alt>S`, `<Alt>L`).
    - The section height in the dialog was increased to accommodate all entries.

These changes aim to make the application more accessible and aligned with standard GNOME desktop interaction patterns.