### PR TITLE
Feat: Enhance HTTP Header output with copying and visual styling.

### DIFF
--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -58,11 +58,26 @@
         <property name="title" translatable="yes">Response Headers</property>
         <property name="description" translatable="yes">HTTP response headers will appear below.</property>
         <property name="header-suffix">
-          <object class="GtkButton" id="clear_results_button">
-            <property name="icon-name">edit-clear-all-symbolic</property>
-            <property name="tooltip-text" translatable="yes">Clear Results</property>
-            <property name="valign">center</property>
-            <signal name="clicked" handler="_on_clear_results_clicked"/>
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkButton" id="clear_results_button">
+                <property name="icon-name">edit-clear-all-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Clear Results</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="_on_clear_results_clicked"/>
+                <style><class name="flat"/></style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="copy_results_button">
+                <property name="icon-name">edit-copy-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Copy All Headers</property>
+                <property name="valign">center</property>
+                <style><class name="flat"/></style>
+              </object>
+            </child>
           </object>
         </property>
         <property name="visible">False</property> <!-- Initially hidden, shown when there are results -->

--- a/src/gtk/style-dark.css
+++ b/src/gtk/style-dark.css
@@ -1,0 +1,8 @@
+/* HTTP Page Specific Styles - Dark Theme */
+.header-key {
+    color: #78aeed; /* Lighter Adwaita Blue for dark theme */
+    /* font-weight: bold; */
+}
+.header-value {
+    color: @theme_fg_color;
+}

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -5,3 +5,12 @@
     margin-left: 10px;
     margin-right: 10px;
 }
+
+/* HTTP Page Specific Styles */
+.header-key {
+    color: #3584e4; /* Adwaita Blue */
+    /* font-weight: bold; */
+}
+.header-value {
+    color: @theme_fg_color;
+}

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -1,5 +1,5 @@
 from .constants import RESOURCE_PREFIX, USER_AGENTS
-from gi.repository import Adw, Gio, GObject, Gtk, GLib
+from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk
 import logging
 import re
 from typing import Optional
@@ -71,6 +71,7 @@ class HttpPage(Adw.PreferencesPage):
     error_banner = Gtk.Template.Child("error_banner")
     http_results_group = Gtk.Template.Child("http_results_group")
     clear_results_button = Gtk.Template.Child("clear_results_button")
+    copy_results_button = Gtk.Template.Child() # Added
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -111,8 +112,44 @@ class HttpPage(Adw.PreferencesPage):
             "notify::active", self._on_pragma_toggled
             )
         self.clear_results_button.connect("clicked", self._on_clear_results_clicked)
+        if self.copy_results_button: # Added
+            self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
         if self.error_banner:
             self.error_banner.connect("button-clicked", self._on_error_banner_dismiss)
+
+    def _on_copy_results_clicked(self, _button: Gtk.Button) -> None:
+        logger.info("Copying all headers to clipboard.")
+        lines = []
+        if self.header_list_store:
+            for i in range(self.header_list_store.get_n_items()):
+                item = self.header_list_store.get_item(i)
+                if isinstance(item, HeaderItem): # Make sure it's the correct type
+                    if item.is_special_row:
+                        # For special rows like URL/Status, just join key and value if value exists
+                        if item.value and item.value.strip():
+                            lines.append(f"{item.key} {item.value}")
+                        else:
+                            lines.append(item.key)
+                    else:
+                        lines.append(f"{item.key}: {item.value}")
+
+        if lines:
+            text_to_copy = "\n".join(lines)
+            try:
+                # Gtk.Clipboard.get_default() requires a Gdk.Display argument.
+                # self.get_display() should provide it.
+                clipboard = Gdk.Display.get_default().get_clipboard() # Corrected way to get clipboard
+                if clipboard:
+                    clipboard.set_text(text_to_copy) # Corrected: set_text does not take -1
+                    logger.info("Headers copied to clipboard successfully.")
+                    # Optional: Show a toast notification here
+                    # Example: self.show_toast(Adw.Toast(title="Headers copied to clipboard"))
+                else:
+                    logger.warning("Failed to get default clipboard.")
+            except Exception as e:
+                logger.error(f"Error copying to clipboard: {e}", exc_info=True)
+        else:
+            logger.info("No headers to copy.")
 
     def _on_entry_row_activated(self, _widget: Gtk.Widget) -> None:
         original_url = self.http_entry_row.get_text().strip()
@@ -572,14 +609,35 @@ class HttpPage(Adw.PreferencesPage):
             label = list_item.get_child()
             item = list_item.get_item()
             text_to_display = getattr(item, attr_name, "")
-            if label:
+            if label and isinstance(label, Gtk.Label):  # Ensure it's a label
+                # First, remove any existing custom style classes to avoid accumulation
+                label.remove_css_class('header-key')
+                label.remove_css_class('header-value')
+                # label.remove_css_class('special-row-text') # If we add one for special rows
+
                 if item and item.is_special_row:
+                    # Current logic uses Pango markup for bolding special rows.
+                    # We can add a specific class if we want to style special rows differently via CSS too.
+                    # For now, rely on Pango for special rows, and CSS for key/value.
                     escaped_text = GLib.markup_escape_text(text_to_display)
-                    label.set_markup(f"<b>{escaped_text}</b>")
+                    # Ensure value is also escaped if appended directly
+                    value_text = getattr(item, 'value', '') # Assuming 'value' attribute exists for special rows if needed
+                    if item.key and value_text and item.key.startswith("URL:"): # crude check for URL/Status special row
+                        full_special_text = f"{text_to_display} {GLib.markup_escape_text(value_text)}"
+                        label.set_markup(f"<b>{full_special_text}</b>")
+                    else:
+                        label.set_markup(f"<b>{escaped_text}</b>")
                 else:
-                    label.set_text(text_to_display)
+                    label.set_text(text_to_display)  # Set text normally first
+                    # Now, apply specific class based on which attribute this factory is for
+                    if attr_name == 'key':
+                        label.add_css_class('header-key')
+                    elif attr_name == 'value':
+                        label.add_css_class('header-value')
 
         factory.connect("setup", setup_func)
         factory.connect("bind", bind_func)
 
         return factory
+
+[end of src/http_page.py]


### PR DESCRIPTION
This commit introduces two improvements to the HTTP Headers page:

1.  **Copy All Headers Functionality:**
    - Added a "Copy All Headers" button to the header of the results section.
    - Clicking this button copies all displayed HTTP headers (including those from redirects, and special URL/Status lines) to your clipboard.
    - Headers are formatted as "Key: Value" and special lines as "Key Value", separated by newlines.

2.  **Visual Styling for Headers:**
    - Header keys and values in the results view are now visually distinct using different colors.
    - Added CSS rules to `style.css` and `style-dark.css` to define these colors:
        - Keys are colored blue (Adwaita blue, adjusted for light/dark themes).
        - Values use the standard theme foreground color.
    - The Python code for the `Gtk.ColumnView` factory in `HttpPage` was updated to apply these CSS classes (`header-key`, `header-value`) to the respective labels.
    - This styling is theme-aware and maintains readability in both light and dark modes.

These changes improve the usability of the HTTP header inspection tool.