### PR TITLE
Applied the `suggested-action` and `destructive-action` style classes

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -20,7 +20,7 @@
                 <property name="label" translatable="yes">_Lookup</property>
                 <property name="valign">center</property>
                 <style>
-                  <class name="flat"/>
+                  <class name="suggested-action"/>
                 </style>
               </object>
             </child>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -20,7 +20,7 @@
                 <property name="label" translatable="yes">_Fetch</property>
                 <property name="valign">center</property>
                 <style>
-                  <class name="flat"/>
+                  <class name="suggested-action"/>
                 </style>
               </object>
             </child>
@@ -67,7 +67,7 @@
                 <property name="tooltip-text" translatable="yes">Clear Results</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="_on_clear_results_clicked"/>
-                <style><class name="flat"/></style>
+                <style><class name="destructive-action"/></style>
               </object>
             </child>
             <child>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -19,7 +19,7 @@
                 <property name="label" translatable="yes">_Scan</property>
                 <property name="valign">center</property>
                 <style>
-                  <class name="flat"/>
+                  <class name="suggested-action"/>
                 </style>
               </object>
             </child>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -29,8 +29,7 @@
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_scan_button_clicked"/>
                 <style>
-  <class name="pill"/>
-  <class name="accent"/>
+                  <class name="suggested-action"/>
                 </style>
               </object>
             </child>


### PR DESCRIPTION
to buttons across various pages of the application to align with GNOME HIG and libadwaita best practices.

Key changes:
- `suggested-action` applied to:
    - HTTP page: 'Fetch' button
    - DNS page: 'Lookup' button
    - Nmap page: 'Scan' button
    - WebScan page: 'Start Scan' button
- `destructive-action` applied to:
    - HTTP page: 'Clear Results' button

This change leverages Adw.StyleManager for theme handling (which was already in place) and standard Adwaita CSS classes for button styling. Removed existing `flat`, `pill`, and `accent` classes where these new standard classes were applied.