### PR TITLE
fix: Address runtime errors related to Gdk.WindowState and Preference…

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -114,19 +114,19 @@
             <child>
               <object class="AdwEntryRow" id="http_header_key_color_row">
                 <property name="title">Header Key Color</property>
-                <binding name="text" type="string" key="http-output-header-key-color" schema="com.github.mclellac.woes"/>
+                <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_header_value_color_row">
                 <property name="title">Header Value Color</property>
-                <binding name="text" type="string" key="http-output-header-value-color" schema="com.github.mclellac.woes"/>
+                <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_special_row_color_row">
                 <property name="title">Special Row Color</property>
-                <binding name="text" type="string" key="http-output-special-row-color" schema="com.github.mclellac.woes"/>
+                <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
           </object>

--- a/src/window.py
+++ b/src/window.py
@@ -162,7 +162,7 @@ class WoesWindow(Adw.ApplicationWindow):
 
         current_gdk_state = self.get_surface().get_state()
 
-        if current_gdk_state & Gdk.WindowState.MINIMIZED:
+        if current_gdk_state & Gdk.SurfaceState.MINIMIZED:
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
…s UI

This commit fixes two runtime errors identified from your feedback:

1.  **Gdk.WindowState AttributeError:**
    - I replaced the usage of the outdated `Gdk.WindowState.MINIMIZED` flag with the correct `Gdk.SurfaceState.MINIMIZED` in `src/window.py` when checking the window's minimized state. This resolves an `AttributeError: 'gi.repository.Gdk' object has no attribute 'WindowState'`.

2.  **Preferences UI Gtk-CRITICAL Error and AttributeError:**
    - I removed the `type="string"` attribute from `<binding>` tags for `Adw.EntryRow` widgets in `src/gtk/preferences.ui`. This attribute was causing a `Gtk-CRITICAL` error during template building (`attribute 'type' invalid for element 'binding'`).
    - This template building error prevented `Gtk.Template.Child` widgets in `src/preferences.py` from being initialized, leading to a subsequent `AttributeError: 'NoneType' object has no attribute 'connect'`. Correcting the UI bindings is expected to resolve this chain of errors.

These changes should improve the stability of window state handling and the preferences dialog.