### PR TITLE
Fix Gdk.SurfaceState error and preferences window loading

### DIFF
--- a/=1.5.0
+++ b/=1.5.0
@@ -1,0 +1,17 @@
+Collecting wheel
+  Downloading wheel-0.45.1-py3-none-any.whl.metadata (2.3 kB)
+Collecting setuptools
+  Downloading setuptools-80.9.0-py3-none-any.whl.metadata (6.6 kB)
+Collecting meson
+  Downloading meson-1.8.1-py3-none-any.whl.metadata (1.8 kB)
+Collecting ninja
+  Downloading ninja-1.11.1.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl.metadata (5.0 kB)
+Downloading wheel-0.45.1-py3-none-any.whl (72 kB)
+Downloading setuptools-80.9.0-py3-none-any.whl (1.2 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 42.5 MB/s eta 0:00:00
+Downloading meson-1.8.1-py3-none-any.whl (1.0 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 546.0 MB/s eta 0:00:00
+Downloading ninja-1.11.1.4-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (422 kB)
+Installing collected packages: wheel, setuptools, ninja, meson
+
+Successfully installed meson-1.8.1 ninja-1.11.1.4 setuptools-80.9.0 wheel-0.45.1

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -114,19 +114,19 @@
             <child>
               <object class="AdwEntryRow" id="http_header_key_color_row">
                 <property name="title">Header Key Color</property>
-                <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/>
+                <!-- <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/> -->
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_header_value_color_row">
                 <property name="title">Header Value Color</property>
-                <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/>
+                <!-- <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/> -->
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_special_row_color_row">
                 <property name="title">Special Row Color</property>
-                <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/>
+                <!-- <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/> -->
               </object>
             </child>
           </object>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -41,6 +41,40 @@ class Preferences(Adw.PreferencesWindow):
         self.dns_server_entryrow.connect("entry-activated", self.on_dns_server_changed)
         self.prefs_dns_apply_button.connect("clicked", self.on_dns_server_changed)
 
+        # New bindings:
+        if self.http_header_key_color_row:
+            self.settings.bind_property(
+                "http-output-header-key-color",
+                self.http_header_key_color_row,
+                "text",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+            logging.debug("Bound http_header_key_color_row text to GSettings.")
+        else:
+            logging.warning("http_header_key_color_row is None, cannot bind GSettings.")
+
+        if self.http_header_value_color_row:
+            self.settings.bind_property(
+                "http-output-header-value-color",
+                self.http_header_value_color_row,
+                "text",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+            logging.debug("Bound http_header_value_color_row text to GSettings.")
+        else:
+            logging.warning("http_header_value_color_row is None, cannot bind GSettings.")
+
+        if self.http_special_row_color_row:
+            self.settings.bind_property(
+                "http-output-special-row-color",
+                self.http_special_row_color_row,
+                "text",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+            logging.debug("Bound http_special_row_color_row text to GSettings.")
+        else:
+            logging.warning("http_special_row_color_row is None, cannot bind GSettings.")
+
     def on_error_banner_dismiss_clicked(self, _banner, *_args):
         self.hide_banner_and_clear_error_state()
 

--- a/src/window.py
+++ b/src/window.py
@@ -160,9 +160,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        current_gdk_state = self.get_surface().get_state()
-
-        if current_gdk_state & Gdk.SurfaceState.MINIMIZED:
+        if self.props.is_minimized:
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
This commit addresses two main issues:

1.  AttributeError: 'gi.repository.Gdk' object has no attribute 'SurfaceState'
    - This occurred in `window.py` when trying to save the window state.
    - The fix replaces the problematic check `current_gdk_state & Gdk.SurfaceState.MINIMIZED` with `self.props.is_minimized`, which is a more direct and robust way to check if the window is minimized.

2.  AttributeError: 'NoneType' object has no attribute 'connect' in preferences.py
    - This was caused by a Gtk-CRITICAL error: `Error building template class 'Preferences' ... attribute 'key' invalid for element 'binding'`, which prevented UI elements like `font_scale_combo_row` from being initialized.
    - The problematic `<binding>` tags for HTTP color settings in `src/gtk/preferences.ui` were commented out.
    - The GSettings bindings for these HTTP color `AdwEntryRow` widgets were then re-implemented programmatically in `src/preferences.py` using `self.settings.bind_property()`.

Due to difficulties with installing PyGObject in the execution environment, I could not fully test these changes by running the application. The solutions are based on code analysis and Gtk/Adwaita documentation.