### PR TITLE
Fix: Correct method for checking if window is minimized

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -160,7 +160,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        if self.props.is_minimized:
+        if self.get_property("is-minimized"):
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
The previous commit (fix/window-prefs-errors) attempted to fix an issue with Gdk.SurfaceState by using `self.props.is_minimized`. This resulted in an `AttributeError: 'gi._gi.GProps' object has no attribute 'is_minimized'`, as reported by your feedback.

This commit corrects the check in `src/window.py` to use `self.get_property("is-minimized")`. This is the standard GObject introspection method for accessing boolean properties and should correctly determine if the window is in a minimized state.

This change is made to the `_save_window_state_actual` method in the `WoesWindow` class.