### PR TITLE
Fix TypeError in preferences dialog by moving GSettings bindings to UI

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -114,19 +114,19 @@
             <child>
               <object class="AdwEntryRow" id="http_header_key_color_row">
                 <property name="title">Header Key Color</property>
-                <!-- <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/> -->
+                <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_header_value_color_row">
                 <property name="title">Header Value Color</property>
-                <!-- <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/> -->
+                <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_special_row_color_row">
                 <property name="title">Special Row Color</property>
-                <!-- <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/> -->
+                <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
           </object>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -42,38 +42,38 @@ class Preferences(Adw.PreferencesWindow):
         self.prefs_dns_apply_button.connect("clicked", self.on_dns_server_changed)
 
         # New bindings:
-        if self.http_header_key_color_row:
-            self.settings.bind_property(
-                "http-output-header-key-color",
-                self.http_header_key_color_row,
-                "text",
-                Gio.SettingsBindFlags.DEFAULT
-            )
-            logging.debug("Bound http_header_key_color_row text to GSettings.")
-        else:
-            logging.warning("http_header_key_color_row is None, cannot bind GSettings.")
+        # if self.http_header_key_color_row:
+        #     self.settings.bind_property(
+        #         "http-output-header-key-color",
+        #         self.http_header_key_color_row,
+        #         "text",
+        #         Gio.SettingsBindFlags.DEFAULT
+        #     )
+        #     logging.debug("Bound http_header_key_color_row text to GSettings.")
+        # else:
+        #     logging.warning("http_header_key_color_row is None, cannot bind GSettings.")
 
-        if self.http_header_value_color_row:
-            self.settings.bind_property(
-                "http-output-header-value-color",
-                self.http_header_value_color_row,
-                "text",
-                Gio.SettingsBindFlags.DEFAULT
-            )
-            logging.debug("Bound http_header_value_color_row text to GSettings.")
-        else:
-            logging.warning("http_header_value_color_row is None, cannot bind GSettings.")
+        # if self.http_header_value_color_row:
+        #     self.settings.bind_property(
+        #         "http-output-header-value-color",
+        #         self.http_header_value_color_row,
+        #         "text",
+        #         Gio.SettingsBindFlags.DEFAULT
+        #     )
+        #     logging.debug("Bound http_header_value_color_row text to GSettings.")
+        # else:
+        #     logging.warning("http_header_value_color_row is None, cannot bind GSettings.")
 
-        if self.http_special_row_color_row:
-            self.settings.bind_property(
-                "http-output-special-row-color",
-                self.http_special_row_color_row,
-                "text",
-                Gio.SettingsBindFlags.DEFAULT
-            )
-            logging.debug("Bound http_special_row_color_row text to GSettings.")
-        else:
-            logging.warning("http_special_row_color_row is None, cannot bind GSettings.")
+        # if self.http_special_row_color_row:
+        #     self.settings.bind_property(
+        #         "http-output-special-row-color",
+        #         self.http_special_row_color_row,
+        #         "text",
+        #         Gio.SettingsBindFlags.DEFAULT
+        #     )
+        #     logging.debug("Bound http_special_row_color_row text to GSettings.")
+        # else:
+        #     logging.warning("http_special_row_color_row is None, cannot bind GSettings.")
 
     def on_error_banner_dismiss_clicked(self, _banner, *_args):
         self.hide_banner_and_clear_error_state()


### PR DESCRIPTION
A TypeError occurred when programmatically binding GSettings string properties to Adw.EntryRow 'text' properties in the preferences dialog. The error indicated an inability to create the binding despite the GSettings schema and widget property types both being strings.

This commit resolves the issue by:
1. Uncommenting the GSettings binding declarations within the `src/gtk/preferences.ui` file for the affected Adw.EntryRow widgets (`http_header_key_color_row`, `http_header_value_color_row`, `http_special_row_color_row`). This allows GTK's UI processing mechanism to handle the bindings.
2. Commenting out the corresponding Python code in `src/preferences.py` that attempted these bindings programmatically via `self.settings.bind_property(...)`.

This approach relies on GTK's built-in binding capabilities, which appear to be more robust for this scenario, and should prevent the TypeError, allowing the preferences dialog to load correctly with the intended settings.