### PR TITLE
Fix UI bindings and window minimized state check

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -114,19 +114,19 @@
             <child>
               <object class="AdwEntryRow" id="http_header_key_color_row">
                 <property name="title">Header Key Color</property>
-                <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/>
+                <binding property="text" name="http-output-header-key-color" schema="com.github.mclellac.woes"></binding>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_header_value_color_row">
                 <property name="title">Header Value Color</property>
-                <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/>
+                <binding property="text" name="http-output-header-value-color" schema="com.github.mclellac.woes"></binding>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_special_row_color_row">
                 <property name="title">Special Row Color</property>
-                <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/>
+                <binding property="text" name="http-output-special-row-color" schema="com.github.mclellac.woes"></binding>
               </object>
             </child>
           </object>

--- a/src/window.py
+++ b/src/window.py
@@ -160,7 +160,9 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        if self.props.is_minimized:
+        surface = self.get_surface()
+        is_minimized_flag = bool(surface.get_state() & Gdk.SurfaceState.MINIMIZED) if surface else False
+        if is_minimized_flag:
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
This commit addresses two issues:

1.  Corrects GSettings binding syntax in `src/gtk/preferences.ui`:
    - The GtkBuilder `<binding>` elements were using an incorrect `key` attribute for the GSettings key and `name` for the widget property.
    - This has been changed to the correct syntax: `property` for the widget property (e.g., "text") and `name` for the GSettings key (e.g., "http-output-header-key-color").
    - This resolves a `Gtk-CRITICAL` error during template instantiation and a subsequent `AttributeError` when trying to connect signals to uninitialized widgets in `preferences.py`.

2.  Fixes TypeError for `is-minimized` property in `src/window.py`:
    - The code was attempting to access `self.props.is_minimized`, but `is-minimized` is not a valid GObject property for `Adw.ApplicationWindow`.
    - The check has been replaced by querying the window's `Gdk.Surface` state for the `Gdk.SurfaceState.MINIMIZED` flag.
    - This resolves the `TypeError: object of type 'WoesWindow' does not have property 'is-minimized'`.