### PR TITLE
Fix window state persistence and preferences dialog errors

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -114,19 +114,19 @@
             <child>
               <object class="AdwEntryRow" id="http_header_key_color_row">
                 <property name="title">Header Key Color</property>
-                <binding name="text" key="http-output-header-key-color" schema="com.github.mclellac.woes"/>
+                <binding name="text" property="http-output-header-key-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_header_value_color_row">
                 <property name="title">Header Value Color</property>
-                <binding name="text" key="http-output-header-value-color" schema="com.github.mclellac.woes"/>
+                <binding name="text" property="http-output-header-value-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_special_row_color_row">
                 <property name="title">Special Row Color</property>
-                <binding name="text" key="http-output-special-row-color" schema="com.github.mclellac.woes"/>
+                <binding name="text" property="http-output-special-row-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
           </object>

--- a/src/window.py
+++ b/src/window.py
@@ -160,7 +160,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        if self.get_property("is-minimized"):
+        if self.is_minimized():
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
This commit addresses several issues:

1.  Fixes a TypeError in `WoesWindow._save_window_state_actual` by replacing `self.get_property("is-minimized")` with `self.is_minimized()`. This ensures that the window state (size, maximized) is correctly saved to GSettings without being interrupted by the error.

2.  Corrects GSettings bindings in `src/gtk/preferences.ui`. The attribute 'key' was incorrectly used instead of 'property' for `<binding>` elements, causing a Gtk-CRITICAL error during template instantiation. This fix allows the preferences dialog to load correctly.

3.  By fixing the preferences UI template, the `AttributeError` for `font_scale_combo_row` in `src/preferences.py` is also resolved, as the widget can now be properly initialized from the template.

These changes ensure that the application window remembers its size and maximized state between sessions and that the preferences dialog is functional.