### PR TITLE
Fix window state and preferences dialog (Revised)

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -114,19 +114,16 @@
             <child>
               <object class="AdwEntryRow" id="http_header_key_color_row">
                 <property name="title">Header Key Color</property>
-                <binding name="text" property="http-output-header-key-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_header_value_color_row">
                 <property name="title">Header Value Color</property>
-                <binding name="text" property="http-output-header-value-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
             <child>
               <object class="AdwEntryRow" id="http_special_row_color_row">
                 <property name="title">Special Row Color</property>
-                <binding name="text" property="http-output-special-row-color" schema="com.github.mclellac.woes"/>
               </object>
             </child>
           </object>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -41,39 +41,38 @@ class Preferences(Adw.PreferencesWindow):
         self.dns_server_entryrow.connect("entry-activated", self.on_dns_server_changed)
         self.prefs_dns_apply_button.connect("clicked", self.on_dns_server_changed)
 
-        # New bindings:
-        # if self.http_header_key_color_row:
-        #     self.settings.bind_property(
-        #         "http-output-header-key-color",
-        #         self.http_header_key_color_row,
-        #         "text",
-        #         Gio.SettingsBindFlags.DEFAULT
-        #     )
-        #     logging.debug("Bound http_header_key_color_row text to GSettings.")
-        # else:
-        #     logging.warning("http_header_key_color_row is None, cannot bind GSettings.")
+        if self.http_header_key_color_row:
+            self.settings.bind(
+                "http-output-header-key-color",
+                self.http_header_key_color_row,
+                "text",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+            logging.debug("Bound http_header_key_color_row text to GSettings.")
+        else:
+            logging.warning("http_header_key_color_row is None, cannot bind GSettings.")
 
-        # if self.http_header_value_color_row:
-        #     self.settings.bind_property(
-        #         "http-output-header-value-color",
-        #         self.http_header_value_color_row,
-        #         "text",
-        #         Gio.SettingsBindFlags.DEFAULT
-        #     )
-        #     logging.debug("Bound http_header_value_color_row text to GSettings.")
-        # else:
-        #     logging.warning("http_header_value_color_row is None, cannot bind GSettings.")
+        if self.http_header_value_color_row:
+            self.settings.bind(
+                "http-output-header-value-color",
+                self.http_header_value_color_row,
+                "text",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+            logging.debug("Bound http_header_value_color_row text to GSettings.")
+        else:
+            logging.warning("http_header_value_color_row is None, cannot bind GSettings.")
 
-        # if self.http_special_row_color_row:
-        #     self.settings.bind_property(
-        #         "http-output-special-row-color",
-        #         self.http_special_row_color_row,
-        #         "text",
-        #         Gio.SettingsBindFlags.DEFAULT
-        #     )
-        #     logging.debug("Bound http_special_row_color_row text to GSettings.")
-        # else:
-        #     logging.warning("http_special_row_color_row is None, cannot bind GSettings.")
+        if self.http_special_row_color_row:
+            self.settings.bind(
+                "http-output-special-row-color",
+                self.http_special_row_color_row,
+                "text",
+                Gio.SettingsBindFlags.DEFAULT
+            )
+            logging.debug("Bound http_special_row_color_row text to GSettings.")
+        else:
+            logging.warning("http_special_row_color_row is None, cannot bind GSettings.")
 
     def on_error_banner_dismiss_clicked(self, _banner, *_args):
         self.hide_banner_and_clear_error_state()

--- a/src/window.py
+++ b/src/window.py
@@ -160,7 +160,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        if self.is_minimized():
+        if self.get_state() & Gdk.WindowState.ICONIFIED:
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
This commit addresses issues with window state persistence and the preferences dialog, revising previous fixes based on new error reports.

1.  **Window State Persistence (`src/window.py`):**
    *   Corrected the check for a minimized (iconified) window in
      `_save_window_state_actual`. Instead of the non-existent
      `self.is_minimized()` or direct property, it now uses
      `self.get_state() & Gdk.WindowState.ICONIFIED`. This ensures
      the window state (size, maximized) is not saved when the window
      is iconified, and saved correctly otherwise.

2.  **Preferences Dialog (`src/gtk/preferences.ui`, `src/preferences.py`):**
    *   Removed `<binding>` tags from `src/gtk/preferences.ui` for
      `AdwEntryRow` widgets related to HTTP output colors. These were
      causing `Gtk-CRITICAL` errors during template instantiation,
      as neither 'key' nor 'property' attributes were valid as used.
    *   Implemented programmatic GSettings bindings in `src/preferences.py`
      for these `AdwEntryRow` text properties. This is done by
      uncommenting and adapting the existing `self.settings.bind(...)`
      calls in the `load_ui` method.
    *   These changes are expected to resolve the `Gtk-CRITICAL` errors
      and the consequent `AttributeError: 'NoneType' object has no
      attribute 'connect'` for `font_scale_combo_row` and other
      widgets in the preferences dialog, making it fully functional.

These revised changes should ensure robust window state handling and a correctly functioning preferences dialog.