### PR TITLE
Fix window iconified state detection for persistence

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -160,7 +160,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        if self.get_state() & Gdk.WindowState.ICONIFIED:
+        if self.get_property("state") & Gdk.WindowState.ICONIFIED:
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
This commit corrects the method used to check if the WoesWindow is iconified (minimized) before saving its state.

Previously, attempts to use `is_minimized()`, `get_property('is-minimized')`, or `get_state()` resulted in AttributeErrors.

The `_save_window_state_actual` method in `src/window.py` now uses `self.get_property("state") & Gdk.WindowState.ICONIFIED` to correctly access the window's state flags. This ensures that the application does not try to save its dimensions when iconified and correctly restores its previous size and state.

The preferences dialog fixes from previous commits are assumed to be correct and are included with this change. The reported SSL error in HTTP fetching is unrelated and not addressed here.