### PR TITLE
Fix: Disable SSL certificate verification for HTTP requests

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -311,7 +311,8 @@ class HttpPage(Adw.PreferencesPage):
                     )
                 return
 
-            response = requests.get(url_to_fetch, headers=request_headers, allow_redirects=True, timeout=5)
+            logger.warning("Disabling SSL certificate verification for URL: %s. This is insecure.", url_to_fetch)
+            response = requests.get(url_to_fetch, headers=request_headers, allow_redirects=True, timeout=5, verify=False)
 
             all_responses_data = []
 


### PR DESCRIPTION
This commit addresses the issue where HTTP header fetching would fail for HTTPS URLs using IP addresses due to SSL certificate verification errors (e.g., IP address mismatch).

To ensure headers can be fetched from such targets as per your request, SSL certificate verification has been disabled in `src/http_page.py` for all requests made via the `requests.get()` method by adding the `verify=False` parameter.

A warning is now logged each time a request is made with SSL verification disabled, highlighting the security implications of this change.

This change prioritizes functionality for fetching headers from targets with certificate issues over strict SSL enforcement. You should be aware of the reduced security when making requests to HTTPS endpoints where certificate verification is bypassed.

The previous, unresolved issues regarding window state persistence may still be present. This commit focuses solely on the HTTP SSL verification bypass.