### PR TITLE
Fix: Window state detection and Preferences DNS input

### DIFF
--- a/src/preferences.py
+++ b/src/preferences.py
@@ -77,8 +77,9 @@ class Preferences(Adw.PreferencesWindow):
     def on_error_banner_dismiss_clicked(self, _banner, *_args):
         self.hide_banner_and_clear_error_state()
 
-    def on_dns_server_changed(self, entryrow: Adw.EntryRow):
-        dns_server = entryrow.get_text().strip()
+    # Changed 'entryrow: Adw.EntryRow' to 'widget' as it can be a button or entry row
+    def on_dns_server_changed(self, widget):
+        dns_server = self.dns_server_entryrow.get_text().strip()
 
         ip_pattern = re.compile(
             r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$"
@@ -88,18 +89,19 @@ class Preferences(Adw.PreferencesWindow):
             self.settings.set_string("custom-dns-server", dns_server)
             logging.info("Custom DNS server set to: %s", dns_server)
             self.preferences_error_banner.set_revealed(False)
-            entryrow.remove_css_class("error")
+            self.dns_server_entryrow.remove_css_class("error")
         else:
-            entryrow.add_css_class("error")
+            self.dns_server_entryrow.add_css_class("error")
             error_message = "Invalid IPv4 address for DNS server."
             logging.error("Invalid custom DNS server IP address provided: %s", dns_server)
 
             self.preferences_error_banner.set_title(error_message)
             self.preferences_error_banner.set_revealed(True)
 
-            entryrow.set_text("")
+            self.dns_server_entryrow.set_text("")
 
-            GLib.timeout_add_seconds(4, self.hide_banner_and_clear_error_state, entryrow)
+            # Pass self.dns_server_entryrow explicitly to the timeout handler
+            GLib.timeout_add_seconds(4, self.hide_banner_and_clear_error_state, self.dns_server_entryrow)
 
     def hide_banner_and_clear_error_state(self, entry_row_widget=None):
         """Hides the banner and clears error CSS from the entry row if provided."""

--- a/src/window.py
+++ b/src/window.py
@@ -160,7 +160,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def _save_window_state_actual(self):
         self._save_state_timer_id = 0  # Reset timer ID
 
-        if self.get_property("state") & Gdk.WindowState.ICONIFIED:
+        if self.get_surface().get_state() & Gdk.SurfaceState.MINIMIZED:
             logging.debug("Window is minimized, skipping state save.")
             return GLib.SOURCE_REMOVE  # Or False
 


### PR DESCRIPTION
This commit addresses two specific UI issues:

1.  **Window State Detection (`src/window.py`):**
    *   Corrected the method for checking if the `WoesWindow` (an
      `Adw.ApplicationWindow`) is iconified (minimized).
    *   The `_save_window_state_actual` method now uses
      `self.get_surface().get_state() & Gdk.SurfaceState.MINIMIZED`.
      This is the appropriate way for GTK4/Adwaita to query surface
      states, resolving previous `TypeError`s related to invalid
      property access. This ensures the window state is saved correctly
      (i.e., not when minimized).

2.  **Preferences DNS Input (`src/preferences.py`):**
    *   Fixed an `AttributeError: 'Button' object has no attribute 'get_text'`
      that occurred in the `on_dns_server_changed` callback.
    *   This error happened when the callback was triggered by the "Apply"
      button for the custom DNS server, as the button object (not the
      entry row) was passed as an argument.
    *   The `on_dns_server_changed` method has been refactored to
      consistently use `self.dns_server_entryrow` for all operations
      requiring the entry row's text or CSS state.
    *   The argument passed to `hide_banner_and_clear_error_state` via
      `GLib.timeout_add_seconds` has also been corrected to explicitly
      pass `self.dns_server_entryrow`.

These changes should improve the stability of window state persistence and the functionality of the DNS settings in the preferences dialog.

The previously addressed HTTP/SSL issues are separate and included in prior commits.