### PR TITLE
Feat: Re-enable SSL certificate verification for HTTP requests

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -224,8 +224,7 @@ class HttpPage(Adw.PreferencesPage):
         session = requests.Session()
         # Apply verify=False to the whole session for this task, as the entire operation
         # is under this "insecure" context (typically for specific self-signed certs or test IPs)
-        session.verify = False
-        logger.warning("Disabling SSL certificate verification for session. This is insecure and applies to URL: %s and its redirects.", url_to_fetch)
+        # session.verify = False # SSL Verification is now ON by default
 
         initial_request_specific_headers = {} # For Host header mainly
         session_headers = {} # For User-Agent, Pragma


### PR DESCRIPTION
This commit re-enables SSL certificate verification by default for all outgoing HTTP/HTTPS requests made through the `requests` library in `src/http_page.py`.

Modifications:
- Removed the explicit `session.verify = False` setting.
- Removed any `verify=False` arguments from `session.get()`.
- Deleted the warning log associated with disabled SSL verification.

Behavior Changes:
- SSL certificates are now verified by default. This enhances security.
- Connections to HTTPS servers with invalid, expired, or mismatched certificates (e.g., using an IP address when the certificate is for a hostname) will now fail with an SSL-related error, which is the secure and expected behavior.
- The `InsecureRequestWarning` from `urllib3` will no longer appear, as requests are no longer made with verification disabled.
- Redirects (e.g., HTTP to HTTPS, or HTTPS to HTTPS) will continue to be followed, and SSL verification will apply to each new HTTPS URL in the redirect chain.

This change ensures that the application adheres to standard secure practices for TLS connections. If you attempt to connect to HTTPS endpoints via IP address where the certificate is not valid for the IP, you will now encounter a connection error, reflecting that the identity of the server cannot be authoritatively verified for that IP.