### PR TITLE
Here's the plan to address the issue:

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -49,26 +49,30 @@ class CustomSNIAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        # The **pool_kwargs received here are from HTTPAdapter's own __init__ (e.g. self.pool_connections)
+        # or from calls like session.close() which might re-init.
+        # We are adding our SNI-specific configurations to this dictionary.
+
         if self.sni_hostname:
-            # Ensure connection_pool_kw exists
-            if 'connection_pool_kw' not in pool_kwargs:
-                pool_kwargs['connection_pool_kw'] = {}
-
-            # Set server_hostname for SNI in the connection arguments for the pool
-            pool_kwargs['connection_pool_kw']['server_hostname'] = self.sni_hostname
-
-            # Tell the PoolManager to assert the hostname against this SNI value during verification
+            # Configure the PoolManager instance itself
             pool_kwargs['assert_hostname'] = self.sni_hostname
+            # Ensure cert_reqs is set for validation.
+            # ssl.CERT_REQUIRED is the typical value when verification is enabled.
+            # requests.Session.verify = True should translate to this via urllib3's defaults,
+            # but being explicit when overriding assert_hostname is safer.
+            pool_kwargs['cert_reqs'] = ssl.CERT_REQUIRED
 
-            # Ensure certificate requirements are set to CERT_REQUIRED.
-            # This should be the default if session.verify is True, but being explicit is safer.
-            # Requests/urllib3 usually handle translating session.verify to cert_reqs.
-            # If session.verify is True (default), cert_reqs will be CERT_REQUIRED.
-            # We are just ensuring the assert_hostname matches our SNI.
-            if 'cert_reqs' not in pool_kwargs: # Only set if not already specified (e.g. by session.verify=False)
-                 pool_kwargs['cert_reqs'] = ssl.CERT_REQUIRED
+            # Configure arguments for the HTTPSConnectionPool instances
+            # that this PoolManager will create. This is done via 'connection_pool_kw'.
+            # Take a copy to avoid modifying a shared dict if pool_kwargs came from elsewhere.
+            current_conn_pool_kw = pool_kwargs.get('connection_pool_kw', {}).copy()
+            current_conn_pool_kw['server_hostname'] = self.sni_hostname
+            # 'assert_hostname' can also be set per-pool, but PoolManager's should cover it if SNI matches.
+            # current_conn_pool_kw['assert_hostname'] = self.sni_hostname
+            pool_kwargs['connection_pool_kw'] = current_conn_pool_kw
 
-
+        # Call the superclass's init_poolmanager, which will create
+        # self.poolmanager = urllib3.PoolManager(**pool_kwargs)
         super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
 
     # If proxies are a concern, proxy_manager_for might also need overriding.


### PR DESCRIPTION
I'll refine the `CustomSNIAdapter` in `src/http_page.py` to more accurately configure `urllib3.PoolManager` and its underlying `HTTPSConnectionPool` instances for Server Name Indication (SNI) override. This is crucial for HTTPS connections where a hostname is resolved to an IP address via your custom DNS feature.

Previous attempts to configure the PoolManager led to a `TypeError` related to `PoolKey.__new__` receiving an unexpected keyword argument (`key_connection_pool_kw`). This error typically indicates a mismatch or misconfiguration in how arguments are passed through `requests` to `urllib3`'s pooling mechanisms, possibly exacerbated by `urllib3` version differences or environment specifics.

Here are the refinements I'll make to `CustomSNIAdapter.init_poolmanager`:
- I'll ensure `assert_hostname` and `cert_reqs` are now directly set in the `pool_kwargs` passed to the `PoolManager` constructor. This ensures the manager is configured to validate certificates against the specified SNI hostname.
- I'll add `server_hostname` (containing the SNI hostname) to a `connection_pool_kw` dictionary within `pool_kwargs`. This is the standard mechanism for `PoolManager` to pass specific arguments (like `server_hostname`) to the constructors of the `HTTPSConnectionPool` instances it creates.

This revised structure adheres closely to the documented usage of `requests` and `urllib3` for such advanced configurations. It aims to resolve the `PoolKey` TypeError and ensure correct SNI behavior, allowing SSL certificates to be validated against the original hostname when its DNS is resolved to an IP address.

SSL verification will remain enabled by default for all connections.