### PR TITLE
Fix: Correct GLib.ParamSpec usage and GtkSource version warning

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import dns.resolver
 import dns.reversename
 import gi
-from gi.repository import Adw, Gio, Gtk, GtkSource, Pango, GLib
+from gi.repository import Adw, Gio, Gtk, GtkSource, Pango, GLib, GObject # Added GObject
 from typing import Tuple, Sequence, Any # Removed Optional as it's not explicitly used
 
 from .constants import APP_ID, RESOURCE_PREFIX
@@ -139,7 +139,7 @@ class DNSPage(Adw.PreferencesPage):
         """
         self._perform_lookup()
 
-    def _on_record_type_changed(self, _dropdown: Gtk.DropDown, _param_spec: GLib.ParamSpec):
+    def _on_record_type_changed(self, _dropdown: Gtk.DropDown, _param_spec: GObject.ParamSpec): # Changed GLib.ParamSpec to GObject.ParamSpec
         """Handle the record type dropdown change event.
 
         Args:

--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -17,11 +17,10 @@ import platform
 from typing import Optional, Tuple # Added Tuple
 
 import gi
-from gi.repository import Adw, Gdk, Gio, Gtk, GtkSource, GLib
-
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 gi.require_version("GtkSource", "5")
+from gi.repository import Adw, Gdk, Gio, Gtk, GtkSource, GLib
 
 BASE_FONT_SIZE_PT = 10.0
 


### PR DESCRIPTION
I've addressed two issues I identified from runtime feedback:

1.  I resolved `AttributeError: 'gi.repository.GLib' object has no attribute 'ParamSpec'`:
    - I changed the type hint for `_param_spec` in `dns_page.py` from `GLib.ParamSpec` to `GObject.ParamSpec`.
    - I updated the import statement in `dns_page.py` to include `GObject` from `gi.repository`. This is the correct usage as `ParamSpec` is part of the GObject introspection bindings.

2.  I addressed `PyGIWarning: GtkSource was imported without specifying a version first`:
    - I added `gi.require_version('GtkSource', '5')` in `src/style_utils.py` before `GtkSource` is imported from `gi.repository`. This ensures the correct version of GtkSource is loaded.

Note: My runtime testing in the development environment was hindered by a persistent `ImportError: cannot import name '_gi'`, which is related to the GObject Introspection setup in the environment itself. The fixes are based on GObject API conventions.