### PR TITLE
Fix: Correct GLib.ParamSpec usage in window.py

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -7,7 +7,7 @@ and integrates system font settings.
 import logging
 import platform
 import gi
-from gi.repository import Adw, Gdk, Gio, Gtk, GLib
+from gi.repository import Adw, Gdk, Gio, Gtk, GLib, GObject # Added GObject
 
 from .constants import (
     APP_ID,
@@ -224,7 +224,7 @@ class WoesWindow(Adw.ApplicationWindow):
                 _e,
             )
 
-    def on_page_switched(self, _widget: Adw.ViewSwitcherTitle, _gparam: GLib.ParamSpec):
+    def on_page_switched(self, _widget: Adw.ViewSwitcherTitle, _gparam: GObject.ParamSpec): # Changed GLib.ParamSpec to GObject.ParamSpec
         """Handle the page switch event from the Adw.ViewSwitcherTitle.
 
         Logs the name of the newly visible child in the Adw.ViewStack.


### PR DESCRIPTION
This commit addresses an `AttributeError` caused by an incorrect type hint in `src/window.py`.

- I changed the type hint for the `_gparam` argument in the `on_page_switched` method from `GLib.ParamSpec` to `GObject.ParamSpec`.
- I ensured `GObject` is imported from `gi.repository` in `src/window.py`.

This resolves the `AttributeError: 'gi.repository.GLib' object has no attribute 'ParamSpec'` that occurred in `window.py`.

Note: Runtime testing in the development environment was hindered by a persistent `ImportError: cannot import name '_gi'`, which is related to the GObject Introspection setup in the environment itself. The fix is based on GObject API conventions and directly addresses the traceback provided.