### PR TITLE
Refactor: Use British English spelling for 'Colour' in UI

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -110,10 +110,10 @@
         </child>
         <child>
           <object class="AdwPreferencesGroup" id="http_colors_group">
-            <property name="title">HTTP Output Colors</property>
+            <property name="title">HTTP Output Colours</property>
             <child>
               <object class="AdwActionRow">
-                <property name="title">Header Key Color</property>
+                <property name="title">Header Key Colour</property>
                 <child type="suffix">
                   <object class="GtkColorDialogButton" id="http_header_key_color_button">
                     <property name="valign">center</property>
@@ -123,7 +123,7 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title">Header Value Color</property>
+                <property name="title">Header Value Colour</property>
                 <child type="suffix">
                   <object class="GtkColorDialogButton" id="http_header_value_color_button">
                     <property name="valign">center</property>
@@ -133,7 +133,7 @@
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title">Special Row Color</property>
+                <property name="title">Special Row Colour</property>
                 <child type="suffix">
                   <object class="GtkColorDialogButton" id="http_special_row_color_button">
                     <property name="valign">center</property>

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -77,15 +77,15 @@ class Preferences(Adw.PreferencesWindow):
         self.prefs_dns_apply_button.connect("clicked", self.on_dns_server_changed)
 
         if self.http_header_key_color_button:
-            dialog_hk = Gtk.ColorDialog(title="Select Header Key Color", modal=True, with_alpha=True)
+            dialog_hk = Gtk.ColorDialog(title="Select Header Key Colour", modal=True, with_alpha=True)
             self.http_header_key_color_button.set_dialog(dialog_hk)
             self.http_header_key_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-header-key-color")
         if self.http_header_value_color_button:
-            dialog_hv = Gtk.ColorDialog(title="Select Header Value Color", modal=True, with_alpha=True)
+            dialog_hv = Gtk.ColorDialog(title="Select Header Value Colour", modal=True, with_alpha=True)
             self.http_header_value_color_button.set_dialog(dialog_hv)
             self.http_header_value_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-header-value-color")
         if self.http_special_row_color_button:
-            dialog_sr = Gtk.ColorDialog(title="Select Special Row Color", modal=True, with_alpha=True)
+            dialog_sr = Gtk.ColorDialog(title="Select Special Row Colour", modal=True, with_alpha=True)
             self.http_special_row_color_button.set_dialog(dialog_sr)
             self.http_special_row_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-special-row-color")
 


### PR DESCRIPTION
I've updated user-facing strings in the preferences window to use the British English spelling "Colour" instead of the American English "Color".

Changes were made in the following files:

- src/gtk/preferences.ui:
  - Changed "HTTP Output Colors" group title to "HTTP Output Colours".
  - Changed "Header Key Color" to "Header Key Colour".
  - Changed "Header Value Color" to "Header Value Colour".
  - Changed "Special Row Color" to "Special Row Colour".

- src/preferences.py:
  - Updated Gtk.ColorDialog titles from "Select ... Color" to "Select ... Colour".

This change ensures consistency in language for users like you who prefer British English spelling.