### PR TITLE
feat: Allow users to manage custom User-Agent strings

### DIFF
--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -66,5 +66,10 @@
       <summary>Color for special rows in HTTP output</summary>
       <description>Defines the color used for special informational rows in the HTTP output, like URL or Status lines.</description>
     </key>
+    <key name="custom-user-agents" type="as">
+      <default>[]</default>
+      <summary>A list of custom User-Agent strings.</summary>
+      <description>Users can add their own User-Agent strings to this list, which will be available in the HTTP Page.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -143,6 +143,38 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwPreferencesGroup" id="custom_ua_group">
+            <property name="title" translatable="yes">Custom User Agents</property>
+            <property name="description" translatable="yes">Manage your list of custom User-Agent strings for the HTTP Page.</property>
+            <child>
+              <object class="AdwEntryRow" id="new_custom_ua_entry">
+                <property name="title" translatable="yes">New User Agent</property>
+                <property name="placeholder-text" translatable="yes">Enter new User-Agent string here</property>
+                <child type="suffix">
+                  <object class="GtkButton" id="add_custom_ua_button">
+                    <property name="icon-name">list-add-symbolic</property>
+                    <property name="tooltip-text" translatable="yes">Add User Agent</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="flat"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <!-- This Gtk.ListBox will act as a container for dynamically added Adw.ActionRows -->
+              <object class="Gtk.ListBox" id="custom_ua_list_container">
+                <property name="selection-mode">none</property> <!-- We don't want rows to be selectable -->
+                <style>
+                  <class name="boxed-list"/> <!-- Adwaita style for a list of rows -->
+                </style>
+                <!-- Adw.ActionRows representing custom UAs will be added here from code -->
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -225,9 +225,9 @@ class HttpPage(Adw.PreferencesPage):
         self._clear_error()
         self._hide_results()
 
-        user_agent_options = ["None"] + USER_AGENTS
-        self.http_user_agent_row.set_model(Gtk.StringList.new(user_agent_options))
-        self.http_user_agent_row.set_selected(0)
+        self._update_user_agent_model() # Initial population
+        self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._update_user_agent_model())
+
         if self.http_apply_button:
             self.http_apply_button.set_use_underline(True)
 
@@ -1119,6 +1119,45 @@ class HttpPage(Adw.PreferencesPage):
         if self._current_header_items:
             logger.debug("Re-populating view to apply color changes.")
             self._update_column_view_model(self._current_header_items)
+
+    def _update_user_agent_model(self):
+        if not self.http_user_agent_row: # Check if UI element exists
+            return
+
+        current_selection_text = None
+        # Try to preserve current selection if the model is being rebuilt
+        if self.http_user_agent_row.get_model() and self.http_user_agent_row.get_selected() != Gtk.INVALID_LIST_POSITION:
+            selected_item = self.http_user_agent_row.get_selected_item()
+            if isinstance(selected_item, Gtk.StringObject):
+                current_selection_text = selected_item.get_string()
+
+        default_uas = ["None"] + USER_AGENTS # USER_AGENTS from .constants
+        custom_uas = list(self.settings.get_strv("custom-user-agents"))
+
+        combined_uas = default_uas[:] # Start with a copy of defaults
+
+        # Add custom UAs, avoiding duplicates with default_uas (case-sensitive)
+        for custom_ua in custom_uas:
+            if custom_ua not in combined_uas:
+                combined_uas.append(custom_ua)
+
+        self.http_user_agent_row.set_model(Gtk.StringList.new(combined_uas))
+
+        # Restore selection if possible
+        if current_selection_text:
+            model = self.http_user_agent_row.get_model()
+            if isinstance(model, Gtk.StringList): # Gtk.StringList model
+                for i in range(model.get_n_items()):
+                    if model.get_string(i) == current_selection_text:
+                        self.http_user_agent_row.set_selected(i)
+                        break
+                else: # If not found, default to "None" (index 0)
+                    if model.get_n_items() > 0:
+                         self.http_user_agent_row.set_selected(0)
+        elif self.http_user_agent_row.get_model().get_n_items() > 0: # Default to "None" if no prior selection
+            self.http_user_agent_row.set_selected(0)
+
+        logging.info(f"User-Agent dropdown model updated with {len(combined_uas)} items.")
 
     # Note: Removed @staticmethod decorator
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -46,6 +46,11 @@ class Preferences(Adw.PreferencesWindow):
     http_header_value_color_button = Gtk.Template.Child("http_header_value_color_button")
     http_special_row_color_button = Gtk.Template.Child("http_special_row_color_button")
 
+    # Custom User Agent UI
+    new_custom_ua_entry = Gtk.Template.Child("new_custom_ua_entry")
+    add_custom_ua_button = Gtk.Template.Child("add_custom_ua_button")
+    custom_ua_list_container = Gtk.Template.Child("custom_ua_list_container")
+
     def __init__(self, main_window: Gtk.Window = None):
         """Initialize the Preferences window.
 
@@ -88,6 +93,14 @@ class Preferences(Adw.PreferencesWindow):
             dialog_sr = Gtk.ColorDialog(title="Select Special Row Colour", modal=True, with_alpha=True)
             self.http_special_row_color_button.set_dialog(dialog_sr)
             self.http_special_row_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-special-row-color")
+
+        # Custom User Agent Signals
+        if self.add_custom_ua_button:
+            self.add_custom_ua_button.connect("clicked", self._on_add_custom_ua_clicked)
+        if self.new_custom_ua_entry:
+            self.new_custom_ua_entry.connect("entry-activated", self._on_add_custom_ua_clicked)
+
+        self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._render_custom_ua_list())
 
     def on_error_banner_dismiss_clicked(self, _banner: Adw.Banner, *_args):
         """Handle the click event for dismissing the error banner.
@@ -260,9 +273,9 @@ class Preferences(Adw.PreferencesWindow):
     def on_http_color_changed(self, button: Gtk.ColorDialogButton, _gparam: GObject.ParamSpec, gsettings_key: str):
         rgba = button.get_rgba()
         if rgba:
-            color_hex_string = self._rgba_to_hex(rgba)
-            self.settings.set_string(gsettings_key, color_hex_string)
-            logging.debug(f"HTTP color for {gsettings_key} set to hex: {color_hex_string}")
+            color_hex_string = self._rgba_to_hex(rgba) # Use the new helper
+            self.settings.set_string(gsettings_key, color_hex_string) # Save hex string
+            logging.debug(f"HTTP color for {gsettings_key} set to hex: {color_hex_string}") # Update log
 
     def _load_color_button_preference(self, button: Gtk.ColorDialogButton, gsettings_key: str):
         color_string = self.settings.get_string(gsettings_key)
@@ -275,6 +288,70 @@ class Preferences(Adw.PreferencesWindow):
                     logging.warning(f"Gdk.RGBA.parse returned false for color string '{color_string}' for GSettings key '{gsettings_key}'.")
             except GLib.Error as e:
                 logging.warning(f"Failed to parse color string '{color_string}' for GSettings key '{gsettings_key}': {e}.")
+
+    def _render_custom_ua_list(self):
+        if not self.custom_ua_list_container:
+            return
+
+        # Clear existing rows
+        child = self.custom_ua_list_container.get_first_child()
+        while child:
+            self.custom_ua_list_container.remove(child)
+            child = self.custom_ua_list_container.get_first_child()
+
+        custom_uas = self.settings.get_strv("custom-user-agents")
+        if not custom_uas: # Should be an empty list by default, not None
+            custom_uas = []
+
+        for ua_string in custom_uas:
+            row = Adw.ActionRow(title=ua_string)
+            row.set_activatable(False) # Don't want the row itself to be activatable
+            remove_button = Gtk.Button(icon_name="edit-delete-symbolic", valign=Gtk.Align.CENTER)
+            remove_button.add_css_class("flat")
+            remove_button.set_tooltip_text(f"Remove '{ua_string}'")
+            # Use a lambda that captures the ua_string for this iteration
+            remove_button.connect("clicked", lambda _btn, s=ua_string: self._on_remove_custom_ua_clicked(s))
+            row.add_suffix(remove_button)
+            row.set_activatable_widget(remove_button) # Makes the button part of row activation focus
+            self.custom_ua_list_container.append(row)
+
+    def _on_add_custom_ua_clicked(self, _widget):
+        if not self.new_custom_ua_entry:
+            return
+        ua_text = self.new_custom_ua_entry.get_text().strip()
+        if not ua_text:
+            # Optionally show a small error/toast or just ignore
+            logging.info("Attempted to add empty custom User-Agent.")
+            return
+
+        current_uas = list(self.settings.get_strv("custom-user-agents")) # Get a mutable copy
+        if ua_text in current_uas:
+            logging.info(f"Custom User-Agent '{ua_text}' already exists.")
+            # Optionally show a small error/toast
+            self.new_custom_ua_entry.set_text("") # Clear entry even if duplicate
+            return
+
+        current_uas.append(ua_text)
+        if self.settings.set_strv("custom-user-agents", current_uas):
+            logging.info(f"Added custom User-Agent: {ua_text}")
+            self.new_custom_ua_entry.set_text("")
+            self._render_custom_ua_list() # Re-render the list
+        else:
+            logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {ua_text}")
+            # Optionally show an error to the user
+
+    def _on_remove_custom_ua_clicked(self, ua_to_remove: str):
+        current_uas = list(self.settings.get_strv("custom-user-agents"))
+        if ua_to_remove in current_uas:
+            current_uas.remove(ua_to_remove)
+            if self.settings.set_strv("custom-user-agents", current_uas):
+                logging.info(f"Removed custom User-Agent: {ua_to_remove}")
+                self._render_custom_ua_list() # Re-render the list
+            else:
+                logging.error(f"Failed to save custom User-Agent list to GSettings after removing: {ua_to_remove}")
+                # Optionally show an error
+        else:
+            logging.warning(f"Attempted to remove non-existent User-Agent: {ua_to_remove}")
 
     def _select_combo_row_item(
         self, combo_row: Adw.ComboRow, setting_value: str, case_sensitive: bool = True
@@ -349,3 +426,5 @@ class Preferences(Adw.PreferencesWindow):
             self._load_color_button_preference(self.http_header_value_color_button, "http-output-header-value-color")
         if self.http_special_row_color_button:
             self._load_color_button_preference(self.http_special_row_color_button, "http-output-special-row-color")
+
+        self._render_custom_ua_list()


### PR DESCRIPTION
This feature introduces a new section in the Preferences window for you to manage a list of custom User-Agent (UA) strings. These custom UAs are then available for selection in the User-Agent dropdown on the HTTP Page.

Key changes:

1.  **GSettings Schema (`data/com.github.mclellac.woes.gschema.xml`):**
    *   I added a new key `custom-user-agents` of type 'as' (array of strings) to store your custom UA list.

2.  **Preferences UI (`src/gtk/preferences.ui`):**
    *   I added a new "Custom User Agents" group in the Preferences window.
    *   This group includes an `AdwEntryRow` for you to input new UA strings and a `GtkButton` to add them.
    *   A `Gtk.ListBox` is used as a container to display the list of currently saved custom UAs.

3.  **Preferences Logic (`src/preferences.py`):**
    *   I implemented `_render_custom_ua_list` to dynamically populate the ListBox with `Adw.ActionRow`s, each showing a custom UA and a "Remove" button.
    *   I added `_on_add_custom_ua_clicked` to handle adding new UAs. It validates input (non-empty, no duplicates) and updates GSettings.
    *   I added `_on_remove_custom_ua_clicked` to handle removing UAs from the GSettings list.
    *   The list in Preferences is updated dynamically when GSettings change and upon initial load.

4.  **HTTP Page Integration (`src/http_page.py`):**
    *   I modified `HttpPage` to fetch both the default `USER_AGENTS` and the custom list from GSettings.
    *   The `http_user_agent_row` (Adw.ComboRow) model is now populated with the combined list, avoiding duplicates.
    *   The dropdown attempts to preserve the current selection when the list is updated.
    *   I connected to the `changed::custom-user-agents` GSettings signal to dynamically update the dropdown if the custom list changes.

This enhancement provides you with greater flexibility in defining User-Agent strings for HTTP requests made through the application.