### PR TITLE
Fix: Remove AdwEntryRow.placeholder-text to resolve template error

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -150,7 +150,6 @@
             <child>
               <object class="AdwEntryRow" id="new_custom_ua_entry">
                 <property name="title" translatable="yes">New User Agent</property>
-                <property name="placeholder-text" translatable="yes">Enter new User-Agent string here</property>
                 <child type="suffix">
                   <object class="GtkButton" id="add_custom_ua_button">
                     <property name="icon-name">list-add-symbolic</property>


### PR DESCRIPTION
Removes the `placeholder-text` property from the `AdwEntryRow` with `id="new_custom_ua_entry"` in `src/gtk/preferences.ui`.

This property was causing a "Gtk-CRITICAL: Invalid property" error during template instantiation, likely due to version incompatibility with the Adwaita library being used. The template build failure resulted in `Gtk.Template.Child` widgets not being initialized, leading to subsequent `AttributeError`s when trying to connect signals.

Removing this non-critical property allows the preferences dialog template to build correctly and restores its functionality.