### PR TITLE
Fix: Correct GtkListBox type in preferences UI definition

### DIFF
--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -164,7 +164,7 @@
             </child>
             <child>
               <!-- This Gtk.ListBox will act as a container for dynamically added Adw.ActionRows -->
-              <object class="Gtk.ListBox" id="custom_ua_list_container">
+              <object class="GtkListBox" id="custom_ua_list_container">
                 <property name="selection-mode">none</property> <!-- We don't want rows to be selectable -->
                 <style>
                   <class name="boxed-list"/> <!-- Adwaita style for a list of rows -->


### PR DESCRIPTION
Corrects the class name for the GtkListBox used as a container for custom User-Agent strings in `src/gtk/preferences.ui`. The class was specified as "Gtk.ListBox", which is an invalid type name in UI files, causing a template build failure.

Changed `<object class="Gtk.ListBox" id="custom_ua_list_container">` to `<object class="GtkListBox" id="custom_ua_list_container">`.

This resolves the "Gtk-CRITICAL: Invalid object type 'Gtk.ListBox'" error, allowing the Preferences window template to build correctly and thus fixing the subsequent AttributeError related to uninitialized template children.