### PR TITLE
feat: Enhance User-Agent management with titles and AI defaults

### DIFF
--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -66,10 +66,10 @@
       <summary>Color for special rows in HTTP output</summary>
       <description>Defines the color used for special informational rows in the HTTP output, like URL or Status lines.</description>
     </key>
-    <key name="custom-user-agents" type="as">
+    <key name="custom-user-agents" type="a(ss)">
       <default>[]</default>
-      <summary>A list of custom User-Agent strings.</summary>
-      <description>Users can add their own User-Agent strings to this list, which will be available in the HTTP Page.</description>
+      <summary>A list of custom User-Agent string pairs (title, value).</summary>
+      <description>Users can add their own User-Agent strings to this list. Each entry consists of a display title and the full User-Agent value.</description>
     </key>
   </schema>
 </schemalist>

--- a/src/constants.py
+++ b/src/constants.py
@@ -15,10 +15,46 @@ PKGDATADIR = os.environ.get("WOES_PKGDATADIR", _default_pkgdatadir)
 # This allows overriding with an environment variable for testing or different installations.
 
 USER_AGENTS = [
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
-    "(KHTML, like Gecko) Version/16.3 Safari/605.1.15",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0",
+    {
+        "title": "Chrome (Windows)",
+        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    },
+    {
+        "title": "Firefox (Windows)",
+        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
+    },
+    {
+        "title": "Safari (macOS)",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+    },
+    {
+        "title": "Edge (Windows)",
+        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
+    },
+    {
+        "title": "OpenAI GPTBot",
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.0; +https://openai.com/gptbot"
+    },
+    {
+        "title": "Googlebot (Generic)",
+        "value": "Googlebot/2.1 (+http://www.google.com/bot.html)"
+    },
+    {
+        "title": "Googlebot (Smartphone)",
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+    },
+    {
+        "title": "Microsoft Bingbot",
+        "value": "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)"
+    },
+    {
+        "title": "AppleBot",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15 (AppleBot/0.1)"
+    },
+    {
+        "title": "ClaudeBot (General)",
+        "value": "ClaudeBot/1.0 (+https://anthropic.com/claude-bot)"
+    }
 ]
 
 GNOME_INTERFACE_SCHEMA = "org.gnome.desktop.interface"

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -148,16 +148,30 @@
             <property name="title" translatable="yes">Custom User Agents</property>
             <property name="description" translatable="yes">Manage your list of custom User-Agent strings for the HTTP Page.</property>
             <child>
-              <object class="AdwEntryRow" id="new_custom_ua_entry">
-                <property name="title" translatable="yes">New User Agent</property>
-                <child type="suffix">
+              <object class="AdwEntryRow" id="new_custom_ua_title_entry">
+                <property name="title" translatable="yes">Display Title</property>
+                <property name="tooltip-text" translatable="yes">A short, user-friendly title for the User-Agent (e.g., 'My Custom Bot')</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwEntryRow" id="new_custom_ua_value_entry">
+                <property name="title" translatable="yes">User-Agent String</property>
+                <property name="tooltip-text" translatable="yes">The full User-Agent string (e.g., 'Mozilla/5.0 ...')</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="halign">end</property>
+                <property name="spacing">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <child>
                   <object class="GtkButton" id="add_custom_ua_button">
+                    <property name="label" translatable="yes">Add User Agent</property>
                     <property name="icon-name">list-add-symbolic</property>
-                    <property name="tooltip-text" translatable="yes">Add User Agent</property>
-                    <property name="valign">center</property>
-                    <style>
-                      <class name="flat"/>
-                    </style>
+                    <property name="tooltip-text" translatable="yes">Add the new User-Agent (Title and String) to the list</property>
+                    <style><class name="pill"/></style>
                   </object>
                 </child>
               </object>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -190,6 +190,7 @@ class HttpPage(Adw.PreferencesPage):
         self.current_http_task = None
         self._current_header_items = []
         self._http_task_data_for_thread = {}
+        self._ua_title_to_value_map = {} # Initialize the map
 
         self.settings = Gio.Settings(schema_id=APP_ID)
         self._header_key_color = self.settings.get_string("http-output-header-key-color")
@@ -310,11 +311,13 @@ class HttpPage(Adw.PreferencesPage):
             self.http_apply_button.set_sensitive(False)
 
         host_header = self.http_host_header_row.get_text().strip()
-        selected_ua_index = self.http_user_agent_row.get_selected()
-        user_agent = None
-        if selected_ua_index > 0:
-            user_agent_model = self.http_user_agent_row.get_model()
-            user_agent = user_agent_model.get_string(selected_ua_index)
+
+        user_agent_to_send = None
+        selected_title_obj = self.http_user_agent_row.get_selected_item()
+        if isinstance(selected_title_obj, Gtk.StringObject):
+            selected_title = selected_title_obj.get_string()
+            # .get will return None if selected_title is not found, or if its mapped value is None
+            user_agent_to_send = self._ua_title_to_value_map.get(selected_title)
 
         custom_dns_server = self.settings.get_string("custom-dns-server")
 
@@ -531,7 +534,7 @@ class HttpPage(Adw.PreferencesPage):
                 host_header_from_input,
             )
 
-        if user_agent and user_agent != "None":
+        if user_agent: # user_agent is now the actual string or None
             session_headers["User-Agent"] = user_agent
         if use_akamai_pragma:
             akamai_pragma_directives = [
@@ -1121,43 +1124,57 @@ class HttpPage(Adw.PreferencesPage):
             self._update_column_view_model(self._current_header_items)
 
     def _update_user_agent_model(self):
-        if not self.http_user_agent_row: # Check if UI element exists
+        if not self.http_user_agent_row:
             return
 
+        # Ensure the map is initialized (e.g., in __init__)
+        # self._ua_title_to_value_map is already initialized in __init__
+        self._ua_title_to_value_map.clear()
+
         current_selection_text = None
-        # Try to preserve current selection if the model is being rebuilt
         if self.http_user_agent_row.get_model() and self.http_user_agent_row.get_selected() != Gtk.INVALID_LIST_POSITION:
             selected_item = self.http_user_agent_row.get_selected_item()
             if isinstance(selected_item, Gtk.StringObject):
                 current_selection_text = selected_item.get_string()
 
-        default_uas = ["None"] + USER_AGENTS # USER_AGENTS from .constants
-        custom_uas = list(self.settings.get_strv("custom-user-agents"))
+        display_titles = []
 
-        combined_uas = default_uas[:] # Start with a copy of defaults
+        # "None" option
+        none_title = "None"
+        display_titles.append(none_title)
+        self._ua_title_to_value_map[none_title] = None # Represents no UA header override
 
-        # Add custom UAs, avoiding duplicates with default_uas (case-sensitive)
-        for custom_ua in custom_uas:
-            if custom_ua not in combined_uas:
-                combined_uas.append(custom_ua)
+        # Default UAs from constants.py
+        for ua_dict in USER_AGENTS: # USER_AGENTS is now list of {"title": ..., "value": ...}
+            title = ua_dict.get("title")
+            value = ua_dict.get("value")
+            if title and value:
+                if title not in self._ua_title_to_value_map:
+                    display_titles.append(title)
+                self._ua_title_to_value_map[title] = value
 
-        self.http_user_agent_row.set_model(Gtk.StringList.new(combined_uas))
+        # Custom UAs from GSettings
+        variant = self.settings.get_value("custom-user-agents")
+        # Ensure variant is not None and is of the correct type 'a(ss)' before unpacking
+        custom_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
 
-        # Restore selection if possible
-        if current_selection_text:
-            model = self.http_user_agent_row.get_model()
-            if isinstance(model, Gtk.StringList): # Gtk.StringList model
-                for i in range(model.get_n_items()):
-                    if model.get_string(i) == current_selection_text:
-                        self.http_user_agent_row.set_selected(i)
-                        break
-                else: # If not found, default to "None" (index 0)
-                    if model.get_n_items() > 0:
-                         self.http_user_agent_row.set_selected(0)
-        elif self.http_user_agent_row.get_model().get_n_items() > 0: # Default to "None" if no prior selection
-            self.http_user_agent_row.set_selected(0)
+        for title, value in custom_ua_pairs:
+            if title not in self._ua_title_to_value_map:
+                display_titles.append(title)
+            self._ua_title_to_value_map[title] = value
 
-        logging.info(f"User-Agent dropdown model updated with {len(combined_uas)} items.")
+        self.http_user_agent_row.set_model(Gtk.StringList.new(display_titles))
+
+        if current_selection_text and current_selection_text in self._ua_title_to_value_map: # Check map instead of display_titles for selection
+            try:
+                idx = display_titles.index(current_selection_text) # Find in current display titles
+                self.http_user_agent_row.set_selected(idx)
+            except ValueError:
+                if display_titles: self.http_user_agent_row.set_selected(0)
+        elif display_titles:
+            self.http_user_agent_row.set_selected(0) # Default to "None" (index 0)
+
+        logging.info(f"User-Agent dropdown model updated with {len(display_titles)} titles.")
 
     # Note: Removed @staticmethod decorator
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -47,7 +47,8 @@ class Preferences(Adw.PreferencesWindow):
     http_special_row_color_button = Gtk.Template.Child("http_special_row_color_button")
 
     # Custom User Agent UI
-    new_custom_ua_entry = Gtk.Template.Child("new_custom_ua_entry")
+    new_custom_ua_title_entry = Gtk.Template.Child("new_custom_ua_title_entry")
+    new_custom_ua_value_entry = Gtk.Template.Child("new_custom_ua_value_entry")
     add_custom_ua_button = Gtk.Template.Child("add_custom_ua_button")
     custom_ua_list_container = Gtk.Template.Child("custom_ua_list_container")
 
@@ -97,8 +98,10 @@ class Preferences(Adw.PreferencesWindow):
         # Custom User Agent Signals
         if self.add_custom_ua_button:
             self.add_custom_ua_button.connect("clicked", self._on_add_custom_ua_clicked)
-        if self.new_custom_ua_entry:
-            self.new_custom_ua_entry.connect("entry-activated", self._on_add_custom_ua_clicked)
+        if self.new_custom_ua_title_entry:
+            self.new_custom_ua_title_entry.connect("entry-activated", self._on_add_custom_ua_clicked)
+        if self.new_custom_ua_value_entry:
+            self.new_custom_ua_value_entry.connect("entry-activated", self._on_add_custom_ua_clicked)
 
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._render_custom_ua_list())
 
@@ -299,59 +302,82 @@ class Preferences(Adw.PreferencesWindow):
             self.custom_ua_list_container.remove(child)
             child = self.custom_ua_list_container.get_first_child()
 
-        custom_uas = self.settings.get_strv("custom-user-agents")
-        if not custom_uas: # Should be an empty list by default, not None
-            custom_uas = []
+        variant = self.settings.get_value("custom-user-agents")
+        custom_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
 
-        for ua_string in custom_uas:
-            row = Adw.ActionRow(title=ua_string)
-            row.set_activatable(False) # Don't want the row itself to be activatable
+        for title, value in custom_ua_pairs:
+            row = Adw.ActionRow(title=title, subtitle=value) # Display title and value
+            row.set_activatable(False)
             remove_button = Gtk.Button(icon_name="edit-delete-symbolic", valign=Gtk.Align.CENTER)
             remove_button.add_css_class("flat")
-            remove_button.set_tooltip_text(f"Remove '{ua_string}'")
-            # Use a lambda that captures the ua_string for this iteration
-            remove_button.connect("clicked", lambda _btn, s=ua_string: self._on_remove_custom_ua_clicked(s))
+            remove_button.set_tooltip_text(f"Remove '{title}'")
+            # Pass the title (assuming titles are unique for removal)
+            remove_button.connect("clicked", lambda _btn, t=title: self._on_remove_custom_ua_clicked(t))
             row.add_suffix(remove_button)
-            row.set_activatable_widget(remove_button) # Makes the button part of row activation focus
+            row.set_activatable_widget(remove_button)
             self.custom_ua_list_container.append(row)
 
     def _on_add_custom_ua_clicked(self, _widget):
-        if not self.new_custom_ua_entry:
-            return
-        ua_text = self.new_custom_ua_entry.get_text().strip()
-        if not ua_text:
-            # Optionally show a small error/toast or just ignore
-            logging.info("Attempted to add empty custom User-Agent.")
+        if not self.new_custom_ua_title_entry or not self.new_custom_ua_value_entry:
             return
 
-        current_uas = list(self.settings.get_strv("custom-user-agents")) # Get a mutable copy
-        if ua_text in current_uas:
-            logging.info(f"Custom User-Agent '{ua_text}' already exists.")
-            # Optionally show a small error/toast
-            self.new_custom_ua_entry.set_text("") # Clear entry even if duplicate
+        title_text = self.new_custom_ua_title_entry.get_text().strip()
+        value_text = self.new_custom_ua_value_entry.get_text().strip()
+
+        if not title_text or not value_text:
+            logging.info("Attempted to add custom User-Agent with empty title or value.")
+            if not title_text and self.new_custom_ua_title_entry:
+                self.new_custom_ua_title_entry.add_css_class("error")
+            elif self.new_custom_ua_title_entry: # Check existence before removing class
+                 self.new_custom_ua_title_entry.remove_css_class("error")
+            if not value_text and self.new_custom_ua_value_entry:
+                self.new_custom_ua_value_entry.add_css_class("error")
+            elif self.new_custom_ua_value_entry: # Check existence before removing class
+                self.new_custom_ua_value_entry.remove_css_class("error")
             return
 
-        current_uas.append(ua_text)
-        if self.settings.set_strv("custom-user-agents", current_uas):
-            logging.info(f"Added custom User-Agent: {ua_text}")
-            self.new_custom_ua_entry.set_text("")
-            self._render_custom_ua_list() # Re-render the list
+        if self.new_custom_ua_title_entry: self.new_custom_ua_title_entry.remove_css_class("error")
+        if self.new_custom_ua_value_entry: self.new_custom_ua_value_entry.remove_css_class("error")
+
+        variant = self.settings.get_value("custom-user-agents")
+        current_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
+
+        existing_titles = [pair[0] for pair in current_ua_pairs]
+        if title_text in existing_titles:
+            logging.info(f"Custom User-Agent title '{title_text}' already exists.")
+            if self.new_custom_ua_title_entry:
+                 self.new_custom_ua_title_entry.add_css_class("error")
+            return
+        elif self.new_custom_ua_title_entry: # Check existence before removing class
+            self.new_custom_ua_title_entry.remove_css_class("error")
+
+        current_ua_pairs.append((title_text, value_text))
+        new_variant = GLib.Variant("a(ss)", current_ua_pairs)
+
+        if self.settings.set_value("custom-user-agents", new_variant):
+            logging.info(f"Added custom User-Agent: '{title_text}' -> '{value_text}'")
+            if self.new_custom_ua_title_entry: self.new_custom_ua_title_entry.set_text("")
+            if self.new_custom_ua_value_entry: self.new_custom_ua_value_entry.set_text("")
+            self._render_custom_ua_list()
         else:
-            logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {ua_text}")
-            # Optionally show an error to the user
+            logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {title_text}")
 
-    def _on_remove_custom_ua_clicked(self, ua_to_remove: str):
-        current_uas = list(self.settings.get_strv("custom-user-agents"))
-        if ua_to_remove in current_uas:
-            current_uas.remove(ua_to_remove)
-            if self.settings.set_strv("custom-user-agents", current_uas):
-                logging.info(f"Removed custom User-Agent: {ua_to_remove}")
-                self._render_custom_ua_list() # Re-render the list
+    def _on_remove_custom_ua_clicked(self, title_to_remove: str):
+        variant = self.settings.get_value("custom-user-agents")
+        current_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
+
+        original_length = len(current_ua_pairs)
+        updated_ua_pairs = [pair for pair in current_ua_pairs if pair[0] != title_to_remove]
+
+        if len(updated_ua_pairs) < original_length:
+            new_variant = GLib.Variant("a(ss)", updated_ua_pairs)
+            if self.settings.set_value("custom-user-agents", new_variant):
+                logging.info(f"Removed custom User-Agent with title: {title_to_remove}")
+                self._render_custom_ua_list()
             else:
-                logging.error(f"Failed to save custom User-Agent list to GSettings after removing: {ua_to_remove}")
-                # Optionally show an error
+                logging.error(f"Failed to save custom User-Agent list after removing title: {title_to_remove}")
         else:
-            logging.warning(f"Attempted to remove non-existent User-Agent: {ua_to_remove}")
+            logging.warning(f"Attempted to remove non-existent User-Agent with title: {title_to_remove}")
 
     def _select_combo_row_item(
         self, combo_row: Adw.ComboRow, setting_value: str, case_sensitive: bool = True


### PR DESCRIPTION
This major update revamps the User-Agent (UA) functionality:
- User-Agents are now stored and managed as (title, value) pairs, allowing user-friendly titles in dropdowns while using the full UA string for requests.
- A curated list of default UAs, including common browsers and several AI bot UAs (e.g., GPTBot, Googlebot, Bingbot), is now provided.

Key Changes:

1.  **Constants (`src/constants.py`):**
    *   `USER_AGENTS` is now a list of dictionaries, each containing
        "title" and "value" for the UA.
    *   Populated with new default browser and AI UAs.

2.  **GSettings Schema (`data/com.github.mclellac.woes.gschema.xml`):**
    *   The `custom-user-agents` key type changed from `as` (array of
        strings) to `a(ss)` (array of string pairs) to store
        (title, value).
    *   Summary and description updated accordingly.

3.  **Preferences UI (`src/gtk/preferences.ui`):**
    *   The "Custom User Agents" section now has separate `AdwEntryRow`
        fields for "Display Title" and "User-Agent String".
    *   The "Add User Agent" button is positioned below these entries.

4.  **Preferences Logic (`src/preferences.py`):**
    *   Updated to handle UA data as (title, value) pairs.
    *   `_render_custom_ua_list` displays UAs with titles and subtitles
        (full UA string) in `Adw.ActionRow`s.
    *   Logic for adding custom UAs now takes both title and value,
        validates for empty fields, and checks for duplicate titles.
    *   Removal is based on the unique title.
    *   GSettings interactions now use `get_value().unpack()` and
        `set_value()` with `GLib.Variant("a(ss)", ...)` for the
        `custom-user-agents` key.

5.  **HTTP Page (`src/http_page.py`):**
    *   `_update_user_agent_model` now populates a
        `_ua_title_to_value_map` dictionary.
    *   The User-Agent `Adw.ComboRow` displays only the titles.
    *   When a request is made, the selected title is used to look up
        the full UA string from the map.
    *   The "None" option correctly results in no UA header override.
    *   The dropdown list updates dynamically if custom UAs are changed
        in Preferences.

This provides a more flexible and user-friendly way to manage and select User-Agent strings for HTTP requests.