### PR TITLE
Fix: Correct NameError in HTTP page and refine comments

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -8,9 +8,9 @@ It also supports using a custom DNS server for domain resolution.
 import logging
 import re
 import ssl
-import socket  # Added for getaddrinfo patching
-from enum import Enum  # Added for HttpErrorType
-from typing import Optional, Any # Removed Tuple, Added Any
+import socket
+from enum import Enum
+from typing import Optional, Any
 
 import requests
 import requests.utils  # For urlparse
@@ -28,14 +28,10 @@ from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk
 
 from .constants import RESOURCE_PREFIX, USER_AGENTS, APP_ID
 
-# We might need urllib3.util.ssl_ later if ssl.CERT_REQUIRED needs resolving, but requests usually handles this.
-# from urllib3.util.ssl_ import resolve_cert_reqs
-
 
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 
-# Use direct import for urllib3.exceptions
 try:
     import urllib3.exceptions as urllib3_exceptions
 except ImportError:
@@ -104,7 +100,6 @@ class CustomSNIAdapter(HTTPAdapter):
 
         super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
 
-    # Note: If proxies are a concern, proxy_manager_for might also need overriding.
     # This implementation focuses on direct connections.
 
 
@@ -190,7 +185,7 @@ class HttpPage(Adw.PreferencesPage):
         self.current_http_task = None
         self._current_header_items = []
         self._http_task_data_for_thread = {}
-        self._ua_title_to_value_map = {} # Initialize the map
+        self._ua_title_to_value_map = {}
 
         self.settings = Gio.Settings(schema_id=APP_ID)
         self._header_key_color = self.settings.get_string("http-output-header-key-color")
@@ -226,7 +221,7 @@ class HttpPage(Adw.PreferencesPage):
         self._clear_error()
         self._hide_results()
 
-        self._update_user_agent_model() # Initial population
+        self._update_user_agent_model()
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._update_user_agent_model())
 
         if self.http_apply_button:
@@ -275,7 +270,6 @@ class HttpPage(Adw.PreferencesPage):
                 if clipboard:
                     clipboard.set_text(text_to_copy)
                     logger.info("Headers copied to clipboard successfully.")
-                    # Example: self.show_toast(Adw.Toast(title="Headers copied to clipboard")) # type: ignore
                 else:
                     logger.warning("Failed to get default clipboard.")
             except Exception as e:  # pylint: disable=broad-except
@@ -325,7 +319,7 @@ class HttpPage(Adw.PreferencesPage):
             "url": url,
             "use_akamai_pragma": self.http_pragma_switch_row.get_active(),
             "host_header": host_header,
-            "user_agent": user_agent,
+            "user_agent": user_agent_to_send,
             "custom_dns_server": custom_dns_server,
         }
         task = Gio.Task.new(self, None, self._fetch_headers_task_done_cb, None)
@@ -1029,7 +1023,7 @@ class HttpPage(Adw.PreferencesPage):
         if self.http_entry_row.get_text().strip():
             self._on_entry_row_activated(self.http_entry_row)
 
-    def _update_column_view_model(self, header_items: Optional[Any]) -> None: # Temporarily simplified to Optional[Any]
+    def _update_column_view_model(self, header_items: Optional[list[HeaderItem]]) -> None:
         """Update the Gtk.ColumnView's model with new header items.
 
         Clears existing items and populates the ListStore with the provided list.
@@ -1124,11 +1118,15 @@ class HttpPage(Adw.PreferencesPage):
             self._update_column_view_model(self._current_header_items)
 
     def _update_user_agent_model(self):
+        """Update the User-Agent dropdown model.
+
+        Clears and repopulates the User-Agent title-to-value map and
+        the dropdown model (Gtk.StringList) with default and custom User-Agents.
+        Preserves selection if possible.
+        """
         if not self.http_user_agent_row:
             return
 
-        # Ensure the map is initialized (e.g., in __init__)
-        # self._ua_title_to_value_map is already initialized in __init__
         self._ua_title_to_value_map.clear()
 
         current_selection_text = None
@@ -1145,38 +1143,37 @@ class HttpPage(Adw.PreferencesPage):
         self._ua_title_to_value_map[none_title] = None # Represents no UA header override
 
         # Default UAs from constants.py
-        for ua_dict in USER_AGENTS: # USER_AGENTS is now list of {"title": ..., "value": ...}
+        for ua_dict in USER_AGENTS:
             title = ua_dict.get("title")
             value = ua_dict.get("value")
-            if title and value:
-                if title not in self._ua_title_to_value_map:
+            if title and value: # Basic check for valid entry
+                if title not in self._ua_title_to_value_map: # Add to display list only if new title
                     display_titles.append(title)
-                self._ua_title_to_value_map[title] = value
+                self._ua_title_to_value_map[title] = value # Always update map
 
         # Custom UAs from GSettings
         variant = self.settings.get_value("custom-user-agents")
-        # Ensure variant is not None and is of the correct type 'a(ss)' before unpacking
         custom_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
 
         for title, value in custom_ua_pairs:
-            if title not in self._ua_title_to_value_map:
+            if title not in self._ua_title_to_value_map: # Add to display list only if new title
                 display_titles.append(title)
-            self._ua_title_to_value_map[title] = value
+            self._ua_title_to_value_map[title] = value # Custom can override default in map
 
         self.http_user_agent_row.set_model(Gtk.StringList.new(display_titles))
 
-        if current_selection_text and current_selection_text in self._ua_title_to_value_map: # Check map instead of display_titles for selection
+        # Restore selection
+        if current_selection_text and current_selection_text in self._ua_title_to_value_map:
             try:
-                idx = display_titles.index(current_selection_text) # Find in current display titles
+                idx = display_titles.index(current_selection_text)
                 self.http_user_agent_row.set_selected(idx)
-            except ValueError:
+            except ValueError: # Should not happen if current_selection_text in map and display_titles is consistent
                 if display_titles: self.http_user_agent_row.set_selected(0)
         elif display_titles:
-            self.http_user_agent_row.set_selected(0) # Default to "None" (index 0)
+            self.http_user_agent_row.set_selected(0)
 
         logging.info(f"User-Agent dropdown model updated with {len(display_titles)} titles.")
 
-    # Note: Removed @staticmethod decorator
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:
         """Create a Gtk.SignalListItemFactory for a column in the Gtk.ColumnView.
 

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -68,11 +68,10 @@ class Preferences(Adw.PreferencesWindow):
         self.load_preferences()
 
     def load_ui(self):
-        """Connect signals for UI elements and bind GSettings for color preferences.
+        """Connect signals for UI elements.
 
-        This method sets up connections for various combo rows and buttons
-        to their respective handler functions. It also directly binds the 'text'
-        property of color entry rows to GSettings keys.
+        This method sets up connections for various UI elements to their
+        respective handler functions, and initializes GSettings listeners.
         """
         self.font_scale_combo_row.connect("notify::selected", self.on_font_scale_changed)
         self.theme_combo_row.connect("notify::selected", self.on_theme_preference_changed)
@@ -150,7 +149,7 @@ class Preferences(Adw.PreferencesWindow):
             if self.dns_server_entryrow:
                 self.dns_server_entryrow.add_css_class("error")
             error_message = "Invalid IPv4 address for DNS server."
-            logging.error(f"Invalid custom DNS server IP address provided: {dns_server}") # Use f-string
+            logging.error(f"Invalid custom DNS server IP address provided: {dns_server}")
 
             self.preferences_error_banner.set_title(error_message)
             self.preferences_error_banner.set_revealed(True)
@@ -179,7 +178,7 @@ class Preferences(Adw.PreferencesWindow):
         """
         self.preferences_error_banner.set_revealed(False)
         target_entry_row = entry_row_widget if entry_row_widget else self.dns_server_entryrow
-        if target_entry_row: # Check if it exists
+        if target_entry_row:
             target_entry_row.remove_css_class("error")
         return GLib.SOURCE_REMOVE # Suitable for GLib.timeout_add
 
@@ -208,7 +207,7 @@ class Preferences(Adw.PreferencesWindow):
                 return False
         return True
 
-    def on_font_scale_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec): # Changed GLib.ParamSpec to GObject.ParamSpec
+    def on_font_scale_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
         """Handle changes in the font scale preference ComboRow.
 
         Saves the selected font scaling percentage string to GSettings.
@@ -225,7 +224,7 @@ class Preferences(Adw.PreferencesWindow):
             self.settings.set_string("font-scaling-percentage", selected_scale_str)
             logging.debug("Font scaling preference set to %s.", selected_scale_str)
 
-    def on_theme_preference_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec): # Corrected to GObject.ParamSpec
+    def on_theme_preference_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
         """Handle changes in the theme preference ComboRow.
 
         Saves the selected theme name string (e.g., "Light", "Dark") to GSettings.
@@ -245,7 +244,7 @@ class Preferences(Adw.PreferencesWindow):
                 selected_theme_str,
             )
 
-    def on_source_style_scheme_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec): # Ensure this is GObject.ParamSpec and distinct
+    def on_source_style_scheme_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
         """Handle changes in the source style scheme preference ComboRow.
 
         Saves the selected style scheme name string to GSettings.
@@ -274,13 +273,15 @@ class Preferences(Adw.PreferencesWindow):
         return f"#{red:02x}{green:02x}{blue:02x}"
 
     def on_http_color_changed(self, button: Gtk.ColorDialogButton, _gparam: GObject.ParamSpec, gsettings_key: str):
+        """Handle RGBA color change from a Gtk.ColorDialogButton and save as hex."""
         rgba = button.get_rgba()
         if rgba:
-            color_hex_string = self._rgba_to_hex(rgba) # Use the new helper
-            self.settings.set_string(gsettings_key, color_hex_string) # Save hex string
-            logging.debug(f"HTTP color for {gsettings_key} set to hex: {color_hex_string}") # Update log
+            color_hex_string = self._rgba_to_hex(rgba)
+            self.settings.set_string(gsettings_key, color_hex_string)
+            logging.debug(f"HTTP color for {gsettings_key} set to hex: {color_hex_string}")
 
     def _load_color_button_preference(self, button: Gtk.ColorDialogButton, gsettings_key: str):
+        """Load a color from GSettings (stored as hex) and apply to Gtk.ColorDialogButton."""
         color_string = self.settings.get_string(gsettings_key)
         if color_string:
             color = Gdk.RGBA()
@@ -293,6 +294,12 @@ class Preferences(Adw.PreferencesWindow):
                 logging.warning(f"Failed to parse color string '{color_string}' for GSettings key '{gsettings_key}': {e}.")
 
     def _render_custom_ua_list(self):
+        """Clear and repopulate the list of custom User-Agents in the UI.
+
+        Retrieves User-Agent pairs (title, value) from GSettings,
+        creates an Adw.ActionRow for each, and adds them to the
+        custom_ua_list_container. Each row includes a remove button.
+        """
         if not self.custom_ua_list_container:
             return
 
@@ -318,6 +325,13 @@ class Preferences(Adw.PreferencesWindow):
             self.custom_ua_list_container.append(row)
 
     def _on_add_custom_ua_clicked(self, _widget):
+        """Handle the 'Add User Agent' button click or entry activation.
+
+        Retrieves text from the title and value entry fields.
+        If both are non-empty and the title is unique, adds the new
+        User-Agent pair to GSettings and updates the UI list.
+        Provides visual feedback for empty fields or duplicate titles.
+        """
         if not self.new_custom_ua_title_entry or not self.new_custom_ua_value_entry:
             return
 
@@ -328,11 +342,11 @@ class Preferences(Adw.PreferencesWindow):
             logging.info("Attempted to add custom User-Agent with empty title or value.")
             if not title_text and self.new_custom_ua_title_entry:
                 self.new_custom_ua_title_entry.add_css_class("error")
-            elif self.new_custom_ua_title_entry: # Check existence before removing class
+            elif self.new_custom_ua_title_entry:
                  self.new_custom_ua_title_entry.remove_css_class("error")
             if not value_text and self.new_custom_ua_value_entry:
                 self.new_custom_ua_value_entry.add_css_class("error")
-            elif self.new_custom_ua_value_entry: # Check existence before removing class
+            elif self.new_custom_ua_value_entry:
                 self.new_custom_ua_value_entry.remove_css_class("error")
             return
 
@@ -348,7 +362,7 @@ class Preferences(Adw.PreferencesWindow):
             if self.new_custom_ua_title_entry:
                  self.new_custom_ua_title_entry.add_css_class("error")
             return
-        elif self.new_custom_ua_title_entry: # Check existence before removing class
+        elif self.new_custom_ua_title_entry:
             self.new_custom_ua_title_entry.remove_css_class("error")
 
         current_ua_pairs.append((title_text, value_text))
@@ -363,6 +377,11 @@ class Preferences(Adw.PreferencesWindow):
             logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {title_text}")
 
     def _on_remove_custom_ua_clicked(self, title_to_remove: str):
+        """Handle the click of a 'remove' button for a custom User-Agent.
+
+        Removes the User-Agent pair identified by title_to_remove from
+        GSettings and updates the UI list.
+        """
         variant = self.settings.get_value("custom-user-agents")
         current_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
 


### PR DESCRIPTION
This commit addresses two main points:

1.  **Fix NameError in `src/http_page.py`:**
    *   In the `_on_entry_row_activated` method, I corrected a `NameError`
        where an undefined `user_agent` variable was used instead of
        `user_agent_to_send` when populating the data for the
        HTTP request.

2.  **Refine Code Comments:**
    *   I reviewed and updated comments across `src/constants.py`,
        `src/preferences.py`, and `src/http_page.py`.
    *   I removed redundant, low-effort, or historical comments that
        no longer added value (e.g., comments stating the obvious,
        commented-out code, simple developer notes like "# Use f-string").
    *   I added missing docstrings to several methods in `src/preferences.py`
        (related to color management and custom User-Agent list handling)
        and `src/http_page.py` (`_update_user_agent_model`).
    *   I corrected a type hint in `src/http_page.py`.

These changes ensure the User-Agent functionality works correctly without runtime errors and improve the overall code quality and maintainability through better commenting practices.