### PR TITLE
Refactor: Bold HTTP headers and remove extraneous comments

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -31,119 +31,119 @@ USER_AGENTS = [
         "title": "Edge (Windows)",
         "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
     },
-    { # Updated
+    {
         "title": "OpenAI GPTBot",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.1; +https://openai.com/gptbot"
     },
-    { # New
+    {
         "title": "OpenAI SearchBot",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot"
     },
-    { # New
+    {
         "title": "OpenAI ChatGPT-User (Legacy)",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot"
     },
-    { # New
+    {
         "title": "OpenAI ChatGPT-User",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/2.0; +https://openai.com/bot"
     },
-    { # Updated and Renamed
+    {
         "title": "Google-Extended",
         "value": "Mozilla/5.0 (compatible; Google-Extended/1.0; +http://www.google.com/bot.html)"
     },
-    { # Retained
+    {
         "title": "Googlebot (Smartphone)",
         "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
     },
-    { # Updated and Renamed
+    {
         "title": "Anthropic ClaudeBot (Chat)",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ClaudeBot/1.0; +claudebot@anthropic.com"
     },
-    { # New
+    {
         "title": "Anthropic AI (Generic)",
         "value": "Mozilla/5.0 (compatible; anthropic-ai/1.0; +http://www.anthropic.com/bot.html)"
     },
-    { # New
+    {
         "title": "Anthropic Claude-Web",
         "value": "Mozilla/5.0 (compatible; claude-web/1.0; +http://www.anthropic.com/bot.html)"
     },
-    { # Retained
+    {
         "title": "Microsoft Bingbot",
         "value": "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)"
     },
-    { # Retained (specific one)
-        "title": "AppleBot (Specific)", # Clarified title for the specific one
+    {
+        "title": "AppleBot (Specific)",
         "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15 (AppleBot/0.1)"
     },
-    { # New
+    {
         "title": "AppleBot (Generic)",
         "value": "Mozilla/5.0 (compatible; Applebot/1.0; +http://www.apple.com/bot.html)"
     },
-    { # New
+    {
         "title": "Applebot-Extended",
         "value": "Mozilla/5.0 (compatible; Applebot-Extended/1.0; +http://www.apple.com/bot.html)"
     },
-    { # New
+    {
         "title": "PerplexityAI Bot",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot"
     },
-    { # New
+    {
         "title": "PerplexityAI User",
         "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; Perplexity-User/1.0; +https://www.perplexity.ai/useragent"
     },
-    { # New
+    {
         "title": "Amazonbot",
         "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)"
     },
-    { # New
+    {
         "title": "Meta FacebookBot",
         "value": "Mozilla/5.0 (compatible; FacebookBot/1.0; +http://www.facebook.com/bot.html)"
     },
-    { # New
+    {
         "title": "Meta External Agent",
         "value": "Mozilla/5.0 (compatible; meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler))"
     },
-    { # New
+    {
         "title": "LinkedInBot",
         "value": "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)"
     },
-    { # New
+    {
         "title": "ByteDance Bytespider",
         "value": "Mozilla/5.0 (compatible; Bytespider/1.0; +http://www.bytedance.com/bot.html)"
     },
-    { # New
+    {
         "title": "DuckDuckGo DuckAssistBot",
         "value": "Mozilla/5.0 (compatible; DuckAssistBot/1.0; +http://www.duckduckgo.com/bot.html)"
     },
-    { # New
+    {
         "title": "Cohere AI Bot",
         "value": "Mozilla/5.0 (compatible; cohere-ai/1.0; +http://www.cohere.ai/bot.html)"
     },
-    { # New
+    {
         "title": "Allen Institute AI2Bot",
         "value": "Mozilla/5.0 (compatible; AI2Bot/1.0; +http://www.allenai.org/crawler)"
     },
-    { # New
+    {
         "title": "Common Crawl CCBot",
         "value": "Mozilla/5.0 (compatible; CCBot/1.0; +http://www.commoncrawl.org/bot.html)"
     },
-    { # New
+    {
         "title": "Diffbot",
         "value": "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729; Diffbot/0.1; +http://www.diffbot.com)"
     },
-    { # New
+    {
         "title": "Omgili Bot",
         "value": "Mozilla/5.0 (compatible; omgili/1.0; +http://www.omgili.com/bot.html)"
     },
-    { # New
+    {
         "title": "TimpiBot",
         "value": "Timpibot/0.8 (+http://www.timpi.io)"
     },
-    { # New
+    {
         "title": "You.com YouBot",
         "value": "Mozilla/5.0 (compatible; YouBot (+http://www.you.com))"
     },
-    { # New
+    {
         "title": "MistralAI User",
         "value": "Mozilla/5.0 (compatible; MistralAI-User/1.0; +https://mistral.ai/bot)"
     }

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -1244,7 +1244,7 @@ class HttpPage(Adw.PreferencesPage):
                     self._header_key_color if attr_name == "key" else self._header_value_color
                 )
                 escaped_text = GLib.markup_escape_text(text_to_display)
-                label.set_markup(f"<span foreground='{color_to_use}'>{escaped_text}</span>")
+                label.set_markup(f"<b><span foreground='{color_to_use}'>{escaped_text}</span></b>")
 
         factory.connect("setup", setup_func)
         factory.connect("bind", bind_func_internal)


### PR DESCRIPTION
This commit implements two main changes based on your feedback:

1.  **Bold HTTP Headers:**
    *   Modified `src/http_page.py` in the `_create_factory` method.
    *   The Pango markup for rendering HTTP header keys and values
        (non-special rows) in the results view has been updated to
        wrap the text in `<b>` tags, making them appear bold.
        This improves readability of the header information.

2.  **Comment Cleanup:**
    *   Removed inline developer notes (e.g., `# New`, `# Updated`)
        from the `USER_AGENTS` list in `src/constants.py`.
        This adheres to the policy of only using docstrings or
        comments for complex/non-obvious code.

These changes enhance the UI presentation of HTTP headers and ensure the codebase maintains a clean commenting style.