### PR TITLE
Fix: AttributeError on host selection and add pre-scan scripts

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -456,7 +456,7 @@ class NmapPage(Adw.PreferencesPage):
             self._add_host_details_expander(host_data_dict, selected_target_key)
             self._add_ports_expander(host_data_dict, selected_target_key)
             self._add_os_expander(host_data_dict, selected_target_key)
-            self._add_raw_output_expander(item_obj.value, selected_target_key)
+            self._add_raw_output_expander(host_data_dict, selected_target_key)
 
         else:
             logging.warning("Could not retrieve NmapItem from selected row or item_obj is None.")
@@ -839,10 +839,28 @@ class NmapPage(Adw.PreferencesPage):
             # We'll display MAC as is.
             summary_lines.append(f"MAC Address: {mac}")
 
+        # Pre-scan script results
+        prescan_results = host_data_dict.get("prescript_results")
+        if prescan_results and isinstance(prescan_results, list):
+            summary_lines.append("\nPre-scan script results:")
+            for script_item in prescan_results:
+                if isinstance(script_item, dict):
+                    script_id = script_item.get("id", "N/A")
+                    script_output = script_item.get("output", "N/A")
+                    if script_output and isinstance(script_output, str):
+                        formatted_output = "\n".join(
+                            [f"|_ {script_id}: {line.strip()}" if i == 0 else f"|  {line.strip()}"
+                             for i, line in enumerate(script_output.strip().split('\n'))]
+                        )
+                        summary_lines.append(formatted_output)
+                    else:
+                        summary_lines.append(f"|_ {script_id}: (no output)")
+
+
         # Hostnames
         hostnames_list = host_data_dict.get("hostnames", [])
         if hostnames_list:
-            summary_lines.append("Hostnames:")
+            summary_lines.append("\nHostnames:") # Added newline for spacing if prescan exists
             for hn_entry in hostnames_list:
                 hn_type = hn_entry.get("type", "N/A")
                 hn_name = hn_entry.get("name", "N/A")

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -479,10 +479,15 @@ class NmapScanner:
 
         """
         all_results = {}
+        prescan_scripts_data = nm.scaninfo().get('prescript', [])
+        logging.debug("Pre-scan script data: %s", prescan_scripts_data)
+
         for host in nm.all_hosts():
             logging.debug("Processing results for host: %s", host)
             host_data = nm[host]
             plain_dict = self.to_plain_dict(host_data)
+            if prescan_scripts_data: # Only add if there's actual pre-scan data
+                plain_dict["prescript_results"] = prescan_scripts_data
             yaml_output = yaml.safe_dump(plain_dict, default_flow_style=False)
             all_results[host] = yaml_output
         return all_results


### PR DESCRIPTION
- Fixes an AttributeError in `_on_target_selected` that occurred because the raw YAML string was passed to `_add_raw_output_expander` instead of the parsed dictionary.
- Modifies `NmapScanner` to retrieve pre-scan script results (from `nm.scaninfo()['prescript']`) and adds them to the host data dictionary under the key "prescript_results".
- Updates `_generate_human_readable_host_summary` in `NmapPage` to display these pre-scan script results in a formatted, Nmap-like style (e.g., "|_ script_name: output").