### PR TITLE
Fix: Attempt to resolve nmap_host_listbox binding by binding parent

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -103,10 +103,14 @@ class NmapPage(Gtk.Box):
     # Error Banner
     error_banner = Gtk.Template.Child("error_banner")
 
+    # Left pane content box
+    left_vbox_content = Gtk.Template.Child("left_vbox_content")
+
     # AdwOverlaySplitView and its children (nmap_split_view removed)
-    nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")
+    nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox") # nmap_host_listbox is inside left_vbox_content
     nmap_detail_box = Gtk.Template.Child("nmap_detail_box")
     nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
+
 
     def __init__(self, **kwargs):
         """Initialize the NmapPage.


### PR DESCRIPTION
Adds an explicit Gtk.Template.Child binding for `left_vbox_content` in the NmapPage Python class. This Gtk.Box is the direct parent of `nmap_host_listbox` in the UI template.

This is an attempt to ensure that the widget hierarchy is fully resolved by GtkBuilder, hopefully allowing `nmap_host_listbox` to be successfully bound and preventing the persistent AttributeError ('NoneType' object has no attribute 'bind_model').