### PR TITLE
Fix: Correct GtkPaned child properties and remove binding workaround

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -21,12 +21,12 @@
             <property name="hexpand">true</property>
             <property name="wide-handle">true</property>
             <child> <!-- Pane 1 (Left) -->
+              <property name="shrink">false</property>
+              <property name="resize">true</property>
               <object class="GtkScrolledWindow" id="left_scrolled_pane">
                 <property name="hscrollbar-policy">never</property>
                 <property name="min-content-width">380</property>
                 <property name="vexpand">true</property>
-                <property name="shrink">false</property>
-                <property name="resize">true</property>
                 <child>
                   <object class="GtkBox" id="left_vbox_content">
                     <property name="orientation">vertical</property>
@@ -158,11 +158,11 @@
               </object>
             </child>
             <child> <!-- Pane 2 (Right) -->
+              <property name="shrink">false</property>
+              <property name="resize">true</property>
               <object class="GtkScrolledWindow" id="nmap_detail_scrolled_window">
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
-                <property name="shrink">false</property>
-                <property name="resize">true</property>
                 <child>
                   <object class="GtkBox" id="nmap_detail_box">
                     <property name="orientation">vertical</property>

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -120,46 +120,6 @@ class NmapPage(Gtk.Box):
         """
         super().__init__(**kwargs)
         logging.info("Initializing NmapPage...")
-
-        # Manual binding fallback for nmap_host_listbox
-        if self.nmap_host_listbox is None:
-            logging.warning("NmapPage: nmap_host_listbox is None after init_template(). Attempting manual retrieval.")
-            if self.left_vbox_content is not None: # This parent must be bound correctly by @Gtk.Template.Child
-                # According to nmap_page.ui, left_vbox_content's children are:
-                # 1. AdwPreferencesGroup (nmap_scan_parameters_group)
-                # 2. GtkListBox (nmap_host_listbox)
-                child = self.left_vbox_content.get_first_child()
-                if child is not None:
-                    listbox_candidate = child.get_next_sibling()
-                    if isinstance(listbox_candidate, Gtk.ListBox):
-                        # To be more certain, check the buildable ID
-                        buildable_id = None
-                        if isinstance(listbox_candidate, Gtk.Buildable):
-                            buildable_id = listbox_candidate.get_buildable_id()
-
-                        if buildable_id == "nmap_host_listbox":
-                            self.nmap_host_listbox = listbox_candidate
-                            logging.info("NmapPage: Successfully manually bound nmap_host_listbox via ID check.")
-                        elif listbox_candidate.get_buildable_id() is None: # Fallback if get_buildable_id() returns None but type is right
-                            self.nmap_host_listbox = listbox_candidate # Assign if type matches, assuming structure
-                            logging.warning("NmapPage: Manually bound nmap_host_listbox (type match, ID not confirmed as string 'nmap_host_listbox').")
-                        else:
-                            logging.warning(f"NmapPage: Found ListBox sibling, but its buildable_id is '{buildable_id}' not 'nmap_host_listbox'. Manual binding skipped.")
-                    elif listbox_candidate is not None:
-                        logging.warning(f"NmapPage: Sibling of AdwPreferencesGroup is not a Gtk.ListBox, but a {type(listbox_candidate)}. Cannot bind manually this way.")
-                    else:
-                        logging.warning("NmapPage: left_vbox_content's first child (AdwPreferencesGroup) has no sibling. Cannot find nmap_host_listbox this way.")
-                else:
-                    logging.warning("NmapPage: left_vbox_content has no children. Cannot find nmap_host_listbox this way.")
-            else:
-                logging.warning("NmapPage: self.left_vbox_content is None. Cannot attempt manual binding of nmap_host_listbox.")
-
-        if self.nmap_host_listbox is None:
-            # This log should be prominent if it happens, as it means the page will crash.
-            logging.critical("NmapPage: CRITICAL - nmap_host_listbox remains None after all binding attempts. Expect AttributeError.")
-        else:
-            logging.info("NmapPage: nmap_host_listbox appears to be bound.")
-
         self.results_by_host = {}
         self.nmap_target_listbox_store = Gio.ListStore(item_type=NmapItem)
         self.scanner = NmapScanner()


### PR DESCRIPTION
- Corrects the placement of `shrink` and `resize` properties in `nmap_page.ui`. These GtkPaned child properties were erroneously set on the GtkScrolledWindow widgets instead of their parent <child> tags within the GtkPaned. This error was identified via Cambalache warnings and likely caused GtkBuilder parsing issues.
- Removes the manual fallback binding logic for `nmap_host_listbox` from `NmapPage.__init__` in `nmap_page.py`. With the UI file corrected, the standard @Gtk.Template.Child binding is expected to work.

This should resolve the AttributeError related to `nmap_host_listbox` being None.