### PR TITLE
Refactor(nmap_page.ui): Remove width-request from left pane

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -35,7 +35,6 @@
                 <property name="hscrollbar-policy">never</property>
                 <property name="min-content-width">300</property>
                 <property name="vexpand">true</property>
-                <property name="width-request">400</property>
                 <child>
                   <object class="GtkBox" id="left_vbox_content">
                     <property name="hexpand">true</property>


### PR DESCRIPTION
I removed the `width-request="400"` property from the `left_scrolled_pane` in `src/gtk/nmap_page.ui`.

This change allows the GtkPaned widget to distribute available horizontal space more dynamically between its left and right panes when the window is widened. The sizing of the left pane will now rely on its `min-content-width="300"` and its `hexpand="true"` property, along with the expansion needs of its content.

This is intended to address feedback regarding unfilled horizontal space when the application window is resized, aiming for a more effective use of the available width by both panes.