### PR TITLE
Fix(nmap_page.ui): Balance horizontal expansion of Paned children

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -35,6 +35,7 @@
                 <property name="hscrollbar-policy">never</property>
                 <property name="min-content-width">300</property>
                 <property name="vexpand">true</property>
+                <property name="width-request">380</property>
                 <child>
                   <object class="GtkBox" id="left_vbox_content">
                     <property name="hexpand">true</property>
@@ -185,6 +186,7 @@
                 <property name="hexpand">true</property>
                 <property name="hexpand-set">true</property>
                 <property name="vexpand">true</property>
+                <property name="min-content-width">300</property>
                 <child>
                   <object class="GtkBox" id="nmap_detail_box">
                     <property name="hexpand">true</property>


### PR DESCRIPTION
Adjusted sizing properties for the child panes within the main GtkPaned in `src/gtk/nmap_page.ui` to achieve more balanced horizontal expansion.

- Restored `width-request` to `left_scrolled_pane` (set to 380px) to ensure it has a defined initial width and avoids being squished.
- Added `min-content-width` to `nmap_detail_scrolled_window` (set to 300px) to ensure the right pane also has a minimum defined width.

Both panes retain `hexpand="true"` and `hexpand-set="true"`, allowing them to grow and share additional horizontal space when the window is widened. This approach aims to resolve issues where the left pane was either squished or where there was excessive unfilled space, leading to better utilization of the available width.