### PR TITLE
Fix(window.ui): Allow NmapPage to expand horizontally

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -33,8 +33,10 @@
         </child>
         <child>
           <object class="AdwViewStack" id="stack">
-            <property name="vexpand">True</property>
-            <property name="vexpand-set">True</property>
+            <property name="hexpand">true</property>
+            <property name="hexpand-set">true</property>
+            <property name="vexpand">true</property>
+            <property name="vexpand-set">true</property>
             <child>
               <object class="AdwViewStackPage" id="http_page">
                 <property name="child">
@@ -75,26 +77,21 @@
                     <property name="description">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
                     <property name="icon-name" bind-source="nmap_page" bind-property="icon-name" bind-flags="sync-create"/>
                     <property name="title" bind-source="nmap_page" bind-property="title" bind-flags="sync-create">Port Scanning</property>
-                    <property name="vexpand">True</property>
-                    <property name="vexpand-set">True</property>
+                    <property name="vexpand">true</property>
+                    <property name="vexpand-set">true</property>
                     <child>
-                      <object class="AdwClampScrollable">
-                        <property name="maximum-size">1400</property>
-                        <property name="unit">px</property>
-                        <property name="vexpand">True</property>
+                      <object class="GtkBox" id="NmapPage">
+                        <property name="height-request">1000</property>
+                        <property name="hexpand">true</property>
+                        <property name="hexpand-set">true</property>
+                        <property name="valign">center</property>
+                        <property name="vexpand">true</property>
+                        <property name="vexpand-set">true</property>
                         <child>
-                          <object class="GtkBox" id="NmapPage">
-                            <property name="height-request">1000</property>
-                            <property name="hexpand">True</property>
-                            <property name="hexpand-set">True</property>
-                            <property name="valign">center</property>
-                            <property name="vexpand">True</property>
-                            <property name="vexpand-set">True</property>
-                            <child>
-                              <object class="NmapPage">
-                                <property name="vexpand">True</property>
-                              </object>
-                            </child>
+                          <object class="NmapPage">
+                            <property name="hexpand">true</property>
+                            <property name="hexpand-set">true</property>
+                            <property name="vexpand">true</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
I modified `src/gtk/window.ui` to address issues preventing the NmapPage from expanding horizontally within the AdwViewSwitcher context.

Key changes:
- Set `hexpand="true"` and `hexpand-set="true"` on the AdwViewStack (id="stack") to allow the stack itself to grow horizontally.
- Removed the AdwClampScrollable that was wrapping the NmapPage. This clamp was imposing a maximum width restriction.
- Set `hexpand="true"` and `hexpand-set="true"` on the NmapPage instance to ensure it utilizes available horizontal space.

These changes remove external limitations on the NmapPage's width, allowing it to properly expand when the application window is resized. This should enable the internal layout of NmapPage (e.g., its GtkPaned) to function across a wider area.