### PR TITLE
Refactor: Remove non-essential comments

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 0.91.3 -->
 <interface>
-  <!-- interface-name nmap_page.ui -->
   <requires lib="gtk" version="4.10"/>
   <requires lib="libadwaita" version="1.4"/>
   <template class="NmapPage" parent="GtkBox">
@@ -28,7 +26,6 @@
             <property name="vexpand">true</property>
             <property name="wide-handle">true</property>
             <child>
-              <!-- Pane 1 (Left) -->
               <object class="GtkScrolledWindow" id="left_scrolled_pane">
                 <property name="hexpand">true</property>
                 <property name="hexpand-set">true</property>
@@ -181,7 +178,6 @@
               </object>
             </child>
             <child>
-              <!-- Pane 2 (Right) -->
               <object class="GtkScrolledWindow" id="nmap_detail_scrolled_window">
                 <property name="hexpand">true</property>
                 <property name="hexpand-set">true</property>

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -1,9 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 0.96.1 -->
 <interface>
-  <!-- interface-name window.ui -->
-  <!-- interface-copyright (c) 2025 -->
-  <!-- interface-authors Carey McLelland <careymclelland@gmail.com> -->
   <requires lib="gio" version="2.44"/>
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>

--- a/src/main.py
+++ b/src/main.py
@@ -3,11 +3,6 @@
 Handles application initialization, GResource loading, command-line option parsing,
 and launching the main application window and services.
 """
-"""Main application module for Woes.
-
-Handles application initialization, GResource loading, command-line option parsing,
-and launching the main application window and services.
-"""
 import sys
 import os
 import logging
@@ -100,7 +95,7 @@ class WoesApplication(Adw.Application):
         logging.info("WoesApplication.__init__ entered")
         self.version = version
         self.debug_enabled = False
-        self.win = None  # Initialized here
+        self.win = None
 
         # Configure basic logging. If --debug is passed, it will be reconfigured.
         logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -4,18 +4,6 @@ This page allows users to configure and run Nmap scans against specified targets
 Results are displayed in a structured way, with hosts listed and detailed
 information (ports, OS, etc.) shown in expandable sections.
 """
-"""Defines the Nmap scanning page for the Woes application.
-
-This page allows users to configure and run Nmap scans against specified targets.
-Results are displayed in a structured way, with hosts listed and detailed
-information (ports, OS, etc.) shown in expandable sections.
-"""
-"""Defines the Nmap scanning page for the Woes application.
-
-This page allows users to configure and run Nmap scans against specified targets.
-Results are displayed in a structured way, with hosts listed and detailed
-information (ports, OS, etc.) shown in expandable sections.
-"""
 import logging
 import re
 from typing import Optional # Removed List as it's not used
@@ -88,7 +76,6 @@ class NmapPage(Gtk.Box):
 
     __gtype_name__ = "NmapPage"
 
-    # Scan Parameters Group
     nmap_target_entryrow = Gtk.Template.Child("nmap_target_entryrow")
     nmap_apply_button = Gtk.Template.Child("nmap_apply_button")
     nmap_fingerprint_switchrow = Gtk.Template.Child("nmap_fingerprint_switchrow")
@@ -100,13 +87,10 @@ class NmapPage(Gtk.Box):
     status_row = Gtk.Template.Child("status_row")
     scan_spinner = Gtk.Template.Child("scan_spinner")
 
-    # Error Banner
     error_banner = Gtk.Template.Child("error_banner")
 
-    # Left pane content box
     left_vbox_content = Gtk.Template.Child("left_vbox_content")
 
-    # AdwOverlaySplitView and its children (nmap_split_view removed)
     nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox") # nmap_host_listbox is inside left_vbox_content
     nmap_detail_box = Gtk.Template.Child("nmap_detail_box")
     nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
@@ -178,7 +162,6 @@ class NmapPage(Gtk.Box):
             self.nmap_target_listbox_store, self._create_target_listbox_row
         )
 
-        # self.nmap_split_view.set_show_sidebar(True) # Removed as nmap_split_view is gone
         self.nmap_detail_placeholder.set_visible(True)
 
         child = self.nmap_detail_box.get_first_child()
@@ -218,7 +201,6 @@ class NmapPage(Gtk.Box):
                 "Invalid target format. Please enter a valid IP, CIDR, or hostname."
             )
             return
-        # R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it
         self.nmap_target_entryrow.remove_css_class("error")
 
         if not target:
@@ -907,7 +889,6 @@ class NmapPage(Gtk.Box):
                                 port_str += f" (reason: {p_reason})"
                             ports_data.append(port_str)
 
-                        # Port-level script output
                         if port_scripts := port_info.get("script"):
                             if isinstance(port_scripts, dict):
                                 for script_id, script_output in port_scripts.items():

--- a/src/window.py
+++ b/src/window.py
@@ -212,7 +212,6 @@ class WoesWindow(Adw.ApplicationWindow):
         to apply them.
         """
         try:
-            # font_scale_pref_str = self.settings.get_string("font-scaling-percentage") # No longer needed here
             theme_pref = self.settings.get_string("theme-preference")
 
             apply_font_size(self.settings)


### PR DESCRIPTION
I've cleaned up comments across several UI and Python files to improve code clarity and readability, in accordance with the new comment policy.

Files affected:
- src/gtk/window.ui
- src/gtk/nmap_page.ui
- src/nmap_page.py
- src/window.py
- src/main.py

Removed comments include:
- Auto-generated comments from UI design tools.
- Redundant or obvious statements.
- Obsolete commented-out code or refactoring notes.

Preserved comments include:
- Docstrings (module, class, function/method).
- Explanations for complex, non-obvious, or historical code sections.
- Linter directives.
- Comments clarifying important design choices or formatting.