### PR TITLE
Fix: Ensure error banner dismiss buttons work on Nmap and DNS pages

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -70,6 +70,8 @@ class DNSPage(Adw.PreferencesPage):
         self.dns_ip_entryrow.connect("entry-activated", self._on_entry_activated)
         self.dns_apply_button.connect("clicked", self._on_entry_activated)
         self.dns_record_type_dropdown.connect("notify::selected", self._on_record_type_changed)
+        if self.error_banner:
+            self.error_banner.connect("button-clicked", self._on_error_banner_dismiss)
 
     def _on_source_style_scheme_setting_changed(self, _settings: Gio.Settings, key: str):
         """Handle changes to the 'source-style-scheme' GSettings key.

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -190,6 +190,8 @@ class NmapPage(Gtk.Box):
         self.nmap_target_entryrow.connect("entry-activated", self._on_target_activate)
         self.nmap_apply_button.connect("clicked", self._on_target_activate)
         self.nmap_host_listbox.connect("row-selected", self._on_target_selected)
+        if self.error_banner:
+            self.error_banner.connect("button-clicked", self._on_error_banner_dismiss)
 
     def _on_target_activate(self, entry_row: Adw.EntryRow):
         target = self.nmap_target_entryrow.get_text().strip()


### PR DESCRIPTION
I explicitly connected the 'button-clicked' signal for the AdwBanner (id='error_banner') to the '_on_error_banner_dismiss' handler method in both `nmap_page.py` and `dns_page.py`.

Previously, these pages relied on the UI file's <signal handler="..."> attribute for this connection, which appeared to be not working, causing the dismiss buttons to be unresponsive. Adding the explicit `.connect()` call in the Python code ensures the signal is properly handled and the error banners can be dismissed by you.