### PR TITLE
Refactor DNS page UI with Libadwaita enhancements

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -24,7 +24,8 @@ class DNSPage(Adw.PreferencesPage):
 
     __gtype_name__ = "DNSPage"
 
-    dns_ip_entryrow = Gtk.Template.Child("dns_ip_entryrow")
+    domain_entry = Gtk.Template.Child("domain_entry") # Changed from dns_ip_entryrow
+    dns_lookup_spinner = Gtk.Template.Child("dns_lookup_spinner") # Added spinner
     dns_apply_button = Gtk.Template.Child("dns_apply_button")
     dns_record_type_dropdown = Gtk.Template.Child("dns_record_type_dropdown")
     dns_results_scrolled_window = Gtk.Template.Child("dns_results_scrolled_window")
@@ -44,6 +45,11 @@ class DNSPage(Adw.PreferencesPage):
         )
         if self.dns_apply_button:
             self.dns_apply_button.set_use_underline(True)
+
+        # Initialize spinner state
+        if self.dns_lookup_spinner:
+            self.dns_lookup_spinner.set_spinning(False)
+            self.dns_lookup_spinner.set_visible(False)
 
         try:
             self.bold_tag = self.source_buffer.create_tag("bold", weight=Pango.Weight.BOLD)
@@ -67,7 +73,7 @@ class DNSPage(Adw.PreferencesPage):
 
     def _connect_signals(self) -> None:
         """Connect signals for UI elements to their respective handlers."""
-        self.dns_ip_entryrow.connect("entry-activated", self._on_entry_activated)
+        self.domain_entry.connect("entry-activated", self._on_entry_activated) # Changed from dns_ip_entryrow
         self.dns_apply_button.connect("clicked", self._on_entry_activated)
         self.dns_record_type_dropdown.connect("notify::selected", self._on_record_type_changed)
         if self.error_banner:
@@ -215,15 +221,25 @@ class DNSPage(Adw.PreferencesPage):
         Handles input validation, prepares the resolver, fetches records,
         and updates the UI with results or error messages.
         """
-        user_input = self.dns_ip_entryrow.get_text().strip()
+        if self.dns_lookup_spinner:
+            self.dns_lookup_spinner.set_visible(True)
+            self.dns_lookup_spinner.start()
+
+        user_input = self.domain_entry.get_text().strip() # Changed from dns_ip_entryrow
         if not user_input:
             self._show_error("Input cannot be empty.")
+            if self.dns_lookup_spinner:
+                self.dns_lookup_spinner.stop()
+                self.dns_lookup_spinner.set_visible(False)
             return
 
         self._clear_error()
 
         if not self._is_valid_ip_or_domain(user_input):
             self._show_error("Invalid IP address or domain name.")
+            if self.dns_lookup_spinner:
+                self.dns_lookup_spinner.stop()
+                self.dns_lookup_spinner.set_visible(False)
             return
 
         requested_record_type = self._get_selected_record_type()
@@ -267,6 +283,10 @@ class DNSPage(Adw.PreferencesPage):
                 exc_info=True,
             )
             self._show_error(f"An unexpected error occurred: {str(e)}")
+        finally:
+            if self.dns_lookup_spinner:
+                self.dns_lookup_spinner.stop()
+                self.dns_lookup_spinner.set_visible(False)
 
     def _get_selected_record_type(self) -> str:
         """Get the currently selected DNS record type from the dropdown.
@@ -288,13 +308,13 @@ class DNSPage(Adw.PreferencesPage):
             message: The error message to display.
 
         """
-        self.dns_ip_entryrow.add_css_class("error")
+        self.domain_entry.add_css_class("error") # Changed from dns_ip_entryrow
         self.error_banner.set_title(message)
         self.error_banner.set_revealed(True)
 
     def _clear_error(self):
         """Clear any existing error messages from the UI banner and entry row styling."""
-        self.dns_ip_entryrow.remove_css_class("error")
+        self.domain_entry.remove_css_class("error") # Changed from dns_ip_entryrow
         self.error_banner.set_revealed(False)
         self.error_banner.set_title("")
 

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -7,43 +7,73 @@
     <property name="title" translatable="yes">DNS Lookup</property>
     <property name="icon-name">org.gnome.Epiphany-symbolic</property>
     <child>
-      <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Lookup Parameters</property>
+      <object class="AdwClamp">
         <child>
-          <object class="AdwEntryRow" id="dns_ip_entryrow">
-            <property name="input-purpose">url</property>
-            <property name="title" translatable="yes">Domain or IP Address</property>
-            <property name="tooltip-text" translatable="yes">Enter a domain name or an IP address for reverse lookup</property>
-            <property name="activates-default">True</property>
-            <child type="suffix">
-              <object class="GtkButton" id="dns_apply_button">
-                <property name="label" translatable="yes">_Lookup</property>
-                <property name="valign">center</property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
+          <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Lookup Parameters</property>
+            <child>
+              <object class="AdwActionRow" id="dns_ip_entryrow">
+                <property name="title" translatable="yes">Domain or IP Address</property>
+                <property name="tooltip-text" translatable="yes">Enter a domain name or an IP address for reverse lookup</property>
+                <child>
+                  <object class="GtkEntry" id="domain_entry">
+                    <property name="hexpand">True</property>
+                    <property name="valign">center</property>
+                    <!-- Consider adding placeholder-text -->
+                  </object>
+                </child>
+                <child type="suffix">
+                  <object class="GtkSpinner" id="dns_lookup_spinner">
+                    <property name="spinning">False</property>
+                    <property name="visible">False</property>
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+                <child type="suffix">
+                  <object class="GtkButton" id="dns_apply_button">
+                    <property name="label" translatable="yes">_Lookup</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwComboRow" id="dns_record_type_dropdown">
+                <property name="icon-name">preferences-system-network-symbolic</property>
+                <property name="model">
+                  <object class="GtkStringList" id="dns_record_type_list">
+                    <property name="strings">A</property> <!-- Default selection -->
+                    <items>
+                      <item>AAAA</item>
+                      <item>TXT</item>
+                      <item>CNAME</item>
+                      <item>MX</item>
+                      <item>NS</item>
+                      <item>PTR</item> <!-- Added PTR for completeness, though it's auto-selected for IPs -->
+                    </items>
+                  </object>
+                </property>
+                <property name="selected">0</property>
+                <property name="title" translatable="yes">Record Type</property>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="AdwComboRow" id="dns_record_type_dropdown">
-            <property name="icon-name">preferences-system-network-symbolic</property>
-            <property name="model">
-              <object class="GtkStringList" id="dns_record_type_list">
-                <property name="strings">A</property> <!-- Default selection -->
-                <items>
-                  <item>AAAA</item>
-                  <item>TXT</item>
-                  <item>CNAME</item>
-                  <item>MX</item>
-                  <item>NS</item>
-                  <item>PTR</item> <!-- Added PTR for completeness, though it's auto-selected for IPs -->
-                </items>
+          <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Results</property>
+            <property name="description" translatable="yes">DNS lookup results will appear below.</property>
+            <child>
+              <object class="GtkScrolledWindow" id="dns_results_scrolled_window">
+                <property name="min-content-height">300</property> <!-- Ensure it has some minimum height -->
+                <property name="vexpand">True</property> <!-- Allow it to expand vertically -->
+                <property name="hexpand">True</property> <!-- Allow it to expand horizontally -->
+                <!-- GtkSourceView will be added here from code -->
               </object>
-            </property>
-            <property name="selected">0</property>
-            <property name="title" translatable="yes">Record Type</property>
+            </child>
           </object>
         </child>
       </object>
@@ -54,20 +84,6 @@
         <property name="revealed">False</property> <!-- Initially hidden -->
         <property name="title"></property> <!-- Title will be set from code -->
         <signal name="button-clicked" handler="_on_error_banner_dismiss"/>
-      </object>
-    </child>
-    <child>
-      <object class="AdwPreferencesGroup">
-        <property name="title" translatable="yes">Results</property>
-        <property name="description" translatable="yes">DNS lookup results will appear below.</property>
-        <child>
-          <object class="GtkScrolledWindow" id="dns_results_scrolled_window">
-            <property name="min-content-height">300</property> <!-- Ensure it has some minimum height -->
-            <property name="vexpand">True</property> <!-- Allow it to expand vertically -->
-            <property name="hexpand">True</property> <!-- Allow it to expand horizontally -->
-            <!-- GtkSourceView will be added here from code -->
-          </object>
-        </child>
       </object>
     </child>
   </template>


### PR DESCRIPTION
This commit introduces several Libadwaita-focused improvements to the DNS lookup page:

- Replaced Adw.EntryRow with Adw.ActionRow for the domain/IP input.
  - A Gtk.Entry widget is now nested within this Adw.ActionRow to handle text input, as Adw.ActionRow itself does not provide a direct text input method.
- Added a Gtk.Spinner to the Adw.ActionRow to provide visual feedback during DNS lookups.
  - The spinner is controlled from `dns_page.py`, activating before a lookup and deactivating upon completion or error.
- Wrapped the main content of the DNS page (PreferencesGroups) in an Adw.Clamp for better responsiveness across various window sizes.
- Updated `dns_page.py` to manage the new Gtk.Entry for input and to control the visibility and spinning state of the Gtk.Spinner.

NOTE: Full testing of these changes was unfortunately blocked by a persistent Python environment issue related to PyGObject (`gi` module import error). The changes are based on the planned UI enhancements and code logic, but could not be validated through application execution.