### PR TITLE
fix: Correct signal name for Gtk.Entry in DNSPage

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -79,7 +79,7 @@ class DNSPage(Adw.PreferencesPage):
 
     def _connect_signals(self) -> None:
         """Connect signals for UI elements to their respective handlers."""
-        self.domain_entry.connect("entry-activated", self._on_entry_activated) # Changed from dns_ip_entryrow
+        self.domain_entry.connect("activate", self._on_entry_activated) # Changed signal from "entry-activated" to "activate"
         self.dns_apply_button.connect("clicked", self._on_entry_activated)
         self.dns_record_type_dropdown.connect("notify::selected", self._on_record_type_changed)
         if self.error_banner:


### PR DESCRIPTION
I corrected the signal name for the domain_entry (Gtk.Entry) widget in the DNSPage's `_connect_signals` method from "entry-activated" to "activate".

The "entry-activated" signal name was incorrect for a Gtk.Entry widget, causing a TypeError upon application startup. The "activate" signal is the correct one to use for when you activate the entry (e.g., by pressing Enter).

This change addresses the traceback you reported.
Due to persistent environment issues (PyGObject/gi import error), full interactive testing of this fix was not possible, but the correction aligns with GTK signal conventions.