### PR TITLE
fix: Correct Adw.PreferencesPage structure in DNSPage UI

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -7,74 +7,70 @@
     <property name="title" translatable="yes">DNS Lookup</property>
     <property name="icon-name">org.gnome.Epiphany-symbolic</property>
     <child>
-      <object class="AdwClamp">
+      <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Lookup Parameters</property>
         <child>
-          <object class="AdwPreferencesGroup">
-            <property name="title" translatable="yes">Lookup Parameters</property>
+          <object class="AdwActionRow" id="dns_ip_entryrow">
+            <property name="title" translatable="yes">Domain or IP Address</property>
+            <property name="tooltip-text" translatable="yes">Enter a domain name or an IP address for reverse lookup</property>
             <child>
-              <object class="AdwActionRow" id="dns_ip_entryrow">
-                <property name="title" translatable="yes">Domain or IP Address</property>
-                <property name="tooltip-text" translatable="yes">Enter a domain name or an IP address for reverse lookup</property>
-                <child>
-                  <object class="GtkEntry" id="domain_entry">
-                    <property name="hexpand">True</property>
-                    <property name="valign">center</property>
-                    <!-- Consider adding placeholder-text -->
-                  </object>
-                </child>
-                <child type="suffix">
-                  <object class="GtkSpinner" id="dns_lookup_spinner">
-                    <property name="spinning">False</property>
-                    <property name="visible">False</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
-                <child type="suffix">
-                  <object class="GtkButton" id="dns_apply_button">
-                    <property name="label" translatable="yes">_Lookup</property>
-                    <property name="valign">center</property>
-                    <style>
-                      <class name="suggested-action"/>
-                    </style>
-                  </object>
-                </child>
+              <object class="GtkEntry" id="domain_entry">
+                <property name="hexpand">True</property>
+                <property name="valign">center</property>
+                <!-- Consider adding placeholder-text -->
               </object>
             </child>
-            <child>
-              <object class="AdwComboRow" id="dns_record_type_dropdown">
-                <property name="icon-name">preferences-system-network-symbolic</property>
-                <property name="model">
-                  <object class="GtkStringList" id="dns_record_type_list">
-                    <property name="strings">A</property> <!-- Default selection -->
-                    <items>
-                      <item>AAAA</item>
-                      <item>TXT</item>
-                      <item>CNAME</item>
-                      <item>MX</item>
-                      <item>NS</item>
-                      <item>PTR</item> <!-- Added PTR for completeness, though it's auto-selected for IPs -->
-                    </items>
-                  </object>
-                </property>
-                <property name="selected">0</property>
-                <property name="title" translatable="yes">Record Type</property>
+            <child type="suffix">
+              <object class="GtkSpinner" id="dns_lookup_spinner">
+                <property name="spinning">False</property>
+                <property name="visible">False</property>
+                <property name="valign">center</property>
+              </object>
+            </child>
+            <child type="suffix">
+              <object class="GtkButton" id="dns_apply_button">
+                <property name="label" translatable="yes">_Lookup</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup">
-            <property name="title" translatable="yes">Results</property>
-            <property name="description" translatable="yes">DNS lookup results will appear below.</property>
-            <child>
-              <object class="GtkBox" id="dns_results_box_container">
-                <property name="orientation">vertical</property>
-                <property name="vexpand">True</property>
-                <property name="hexpand">True</property>
-                <property name="spacing">6</property> <!-- Optional: add some spacing between dynamic rows -->
-                <!-- Dynamically populated DNS result rows will be added here -->
+          <object class="AdwComboRow" id="dns_record_type_dropdown">
+            <property name="icon-name">preferences-system-network-symbolic</property>
+            <property name="model">
+              <object class="GtkStringList" id="dns_record_type_list">
+                <property name="strings">A</property> <!-- Default selection -->
+                <items>
+                  <item>AAAA</item>
+                  <item>TXT</item>
+                  <item>CNAME</item>
+                  <item>MX</item>
+                  <item>NS</item>
+                  <item>PTR</item> <!-- Added PTR for completeness, though it's auto-selected for IPs -->
+                </items>
               </object>
-            </child>
+            </property>
+            <property name="selected">0</property>
+            <property name="title" translatable="yes">Record Type</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesGroup">
+        <property name="title" translatable="yes">Results</property>
+        <property name="description" translatable="yes">DNS lookup results will appear below.</property>
+        <child>
+          <object class="GtkBox" id="dns_results_box_container">
+            <property name="orientation">vertical</property>
+            <property name="vexpand">True</property>
+            <property name="hexpand">True</property>
+            <property name="spacing">6</property> <!-- Optional: add some spacing between dynamic rows -->
+            <!-- Dynamically populated DNS result rows will be added here -->
           </object>
         </child>
       </object>


### PR DESCRIPTION
I corrected the widget hierarchy in `src/gtk/dns_page.ui` for the DNSPage. An `Adw.Clamp` widget was incorrectly wrapping the `Adw.PreferencesGroup` elements that constituted the main content of the `Adw.PreferencesPage`.

This incorrect nesting likely caused the "Lookup Parameters" group (containing the input fields and dropdown) to not render as expected.

The fix involves:
- Removing the `Adw.Clamp` that was acting as a wrapper around the groups.
- Ensuring that the "Lookup Parameters" `Adw.PreferencesGroup`, the "Results" `Adw.PreferencesGroup`, and the `Adw.Banner` are all direct children of the `DNSPage` template (which is an `Adw.PreferencesPage`).
- I reordered these direct children to a more standard sequence: Lookup Parameters, Results, then the Banner.

This change restores the standard structure for an `Adw.PreferencesPage`, which should allow it to correctly manage and display its child groups.

Due to persistent environment issues (PyGObject/gi import error), full interactive testing of this UI fix was not possible. The correction is based on Adwaita UI principles and addressing your observation of missing input widgets.