### PR TITLE
fix: Remove inadvertently added meta-comments

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -8,7 +8,7 @@ gi.require_version("Gtk", "4.0")
 class Helper:
     """A helper class to add keyboard shortcuts (Ctrl+C) and context menu functionality
     (right-click to copy) to a Gtk.ColumnView widget.
-    """ # Removed the extra blank line that was here, ensuring only one before description if it were multi-line (it's not here)
+    """
 
     def __init__(self, widget, parent_window):
         """Initialize the Helper class.
@@ -29,7 +29,7 @@ class Helper:
     def setup_keyboard_shortcut(self):
         """Set up a keyboard shortcut (Ctrl+C) for copying selected content
         from the Gtk.ColumnView to the clipboard.
-        """ # Removed the extra blank line that was here
+        """
         key_controller = Gtk.EventControllerKey()
         key_controller.connect("key-pressed", self.on_key_pressed)
         self.widget.add_controller(key_controller)

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ from .constants import APP_ID, VERSION, RESOURCE_PREFIX, PKGDATADIR
 
 
 def _load_gresources_early():
-    """Load GResources."""  # Changed docstring to imperative mood
+    """Load GResources."""
     resource_file_path = os.path.join(PKGDATADIR, "woes.gresource")
     logging.info(
         "Attempting to load GResource file from: %s (derived from PKGDATADIR: %s)",

--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -5,10 +5,9 @@ and GtkSourceView style schemes. It interacts with GSettings to retrieve
 system and application-specific style configurations.
 """
 import logging
-# Removed duplicated docstring
 import re
 import platform
-from typing import Optional, Tuple # Added Tuple
+from typing import Optional, Tuple
 
 import gi
 gi.require_version("Adw", "1")
@@ -28,7 +27,7 @@ HIGH_CONTRAST_KEY = "high-contrast"
 
 def _get_linux_font_preferences(
     base_font_size_pt: float,
-) -> Tuple[Optional[str], float]: # Changed to typing.Tuple
+) -> Tuple[Optional[str], float]:
     """Get font preferences from GNOME settings on Linux.
 
     Retrieves font family and size from `org.gnome.desktop.interface` schema.
@@ -104,7 +103,6 @@ def _get_app_font_scaling(app_settings: Gio.Settings) -> float:
                 "Could not parse app font-scaling-percentage: '%s', defaulting to 100%%.",
                 font_scale_percentage_str,
             )
-            # parsed_app_percentage is already 100.0
     else:
         logging.warning(
             "Could not parse app font-scaling-percentage: '%s', defaulting to 100%%.",

--- a/src/window.py
+++ b/src/window.py
@@ -40,7 +40,7 @@ class WoesWindow(Adw.ApplicationWindow):
 
     switcher_title = Gtk.Template.Child("switcher_title")
     stack = Gtk.Template.Child("stack")
-    main_error_banner = Gtk.Template.Child("main_error_banner") # Added banner
+    main_error_banner = Gtk.Template.Child("main_error_banner")
 
     def __init__(self, **kwargs):
         """Initialize the WoesWindow.
@@ -88,7 +88,7 @@ class WoesWindow(Adw.ApplicationWindow):
                     "Could not connect to GNOME interface settings (%s): %s. "
                     "System font integration will be limited.",
                     GNOME_INTERFACE_SCHEMA,
-                    e, # Log the exception
+                    e,
                 )
             # Optionally, initialize and connect to GNOME_A11Y_SCHEMA here if needed for high-contrast etc.
 
@@ -106,10 +106,10 @@ class WoesWindow(Adw.ApplicationWindow):
 
         if self.main_error_banner:
             self.main_error_banner.connect("button-clicked", self._on_main_error_banner_dismissed)
-            self.hide_error() # Ensure it's hidden on startup by default
+            self.hide_error()
 
     def _on_main_error_banner_dismissed(self, _banner=None, _data=None):
-        """Handle dismissal of the main error banner.""" # Corrected docstring
+        """Handle dismissal of the main error banner."""
         self.hide_error()
 
     def show_error(self, message: str):


### PR DESCRIPTION
This commit removes several unhelpful comments that were accidentally introduced during the previous code cleanup pass (commit related to branch `code-cleanup-batch1-3`).

The removed comments were meta-commentary about the changes being made (e.g., "# Fixed docstring", "# Removed old code") rather than comments explaining the code's logic. Their removal ensures that comments in the codebase are purposeful and contribute to understanding the code itself.

Files affected:
- src/main.py
- src/window.py
- src/style_utils.py
- src/helper.py