### PR TITLE
Fix: AttributeError in Preferences and code cleanup

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -373,11 +373,10 @@ class DNSPage(Adw.PreferencesPage):
             dns_servers: A list of DNS servers that were used.
 
         """
-        logger.debug( # Added logger.debug
+        logger.debug(
             "Displaying %d results for %s (type %s) using servers %s.",
             len(result_records), domain_or_ip, record_type, dns_servers
         )
-        # The existing logging.info and logging.debug for individual records are good.
         logger.info(
             "Query for %s, type %s, using servers %s, returned %d records.",
             domain_or_ip,

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -11,7 +11,7 @@ import re
 import ssl
 import socket # Used by CustomDNSAdapter for IP family checks, not for patching.
 from enum import Enum
-from typing import Optional
+from typing import Optional, List # Added List
 
 import requests
 import requests.utils # For urlparse, urlunparse
@@ -1172,7 +1172,7 @@ class HttpPage(Adw.PreferencesPage):
         if self.http_entry_row.get_text().strip(): # Only re-fetch if there's a URL
             self._on_entry_row_activated(self.http_entry_row) # Pass any widget, it's unused by handler
 
-    def _update_column_view_model(self, header_items: Optional[list]) -> None: # Simplified type hint for diagnosis
+    def _update_column_view_model(self, header_items: Optional[List[HeaderItem]]) -> None: # Restored specific type hint
         """Update the Gtk.ColumnView's model (`Gio.ListStore`) with new header items.
 
         Clears existing items and populates the ListStore with the provided list.

--- a/src/main.py
+++ b/src/main.py
@@ -178,8 +178,7 @@ class WoesApplication(Adw.Application):
 
         """
         options = command_line.get_options_dict()
-        # This will call do_handle_local_options if options are present
-        if self.handle_local_options(options):
+        if self.handle_local_options(options): # do_handle_local_options is called by this
             logging.debug("Local options handled.")
 
         self.activate()

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -294,7 +294,7 @@ class NmapPage(Gtk.Box):
             custom_dns_server: Optional custom DNS server IP to use for the scan.
 
         """
-        logger.debug( # Added logger.debug
+        logger.debug(
             "_run_nmap_scan_task started for target: %s with options - OSScan:%s, AllPorts:%s, Script:%s, Ver:%s, NoPing:%s, Time:%s, CustomDNS:%s",
             target, os_fingerprinting, all_ports, script_name, service_version_detection, no_ping_scan, timing_template, custom_dns_server
         )

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -255,7 +255,7 @@ class NmapScanner:
             logger.info("Using custom DNS server for Nmap scan: %s", custom_dns_server.strip())
 
         nmap_args_list.extend(["-oX", "-", target])  # XML output to stdout, target last
-        logger.debug("Built Nmap arguments: %s", nmap_args_list) # Already present, changed to logger
+        logger.debug("Built Nmap arguments: %s", nmap_args_list)
         return nmap_args_list
 
     def _execute_nmap_command(
@@ -294,7 +294,7 @@ class NmapScanner:
                 )
             final_command_parts = [nmap_path] + nmap_args_list[1:]
 
-        logger.info( # Already present, changed to logger
+        logger.info(
             "Executing Nmap command (first few parts): %s...",
             " ".join(shlex.quote(part) for part in final_command_parts[:4]),
         )
@@ -309,7 +309,7 @@ class NmapScanner:
             )
             return process.stdout, process.stderr, process.returncode
         except Exception as e_subproc:
-            logger.exception("Subprocess execution failed for Nmap:") # Changed to logger.exception
+            logger.exception("Subprocess execution failed for Nmap:")
             raise PortScannerError(f"Nmap subprocess execution failed: {e_subproc}") from e_subproc
 
     def _parse_nmap_error_message(
@@ -372,7 +372,7 @@ class NmapScanner:
         timing_template: str = "T3",
         custom_dns_server: Optional[str] = None,
     ) -> nmap.PortScanner:
-        logger.debug( # Added logger.debug
+        logger.debug(
             "run_nmap_scan called with target: %s, OS:%s, AllPorts:%s, Script:%s, Ver:%s, NoPing:%s, Time:%s, DNS:%s",
             target, os_fingerprinting, scan_all_ports, selected_script, service_version, no_ping, timing_template, custom_dns_server
         )
@@ -446,7 +446,7 @@ class NmapScanner:
                 )
                 self.nm.analyse_nmap_xml_scan(nmap_xml_output=nmap_xml_output)
             except PortScannerError as e_parse:
-                logger.exception("Failed to parse Nmap XML output:") # Changed to logger.exception
+                logger.exception("Failed to parse Nmap XML output:")
                 logger.debug(
                     "Problematic Nmap XML Output (full, on parse error):\n%s", nmap_xml_output
                 )
@@ -457,17 +457,17 @@ class NmapScanner:
             return self.nm
 
         except FileNotFoundError as e_fnf:
-            logger.exception("Nmap execution prerequisite not found:") # Changed to logger.exception
+            logger.exception("Nmap execution prerequisite not found:")
             raise PortScannerError(f"Nmap execution prerequisite not found: {e_fnf}") from e_fnf
         except NotImplementedError as e_ni:
-            logger.exception("Privilege escalation not implemented for this platform:") # Changed to logger.exception
+            logger.exception("Privilege escalation not implemented for this platform:")
             raise PortScannerError(
                 f"Privilege escalation not implemented for this platform: {e_ni}"
             ) from e_ni
         except PortScannerError: # Specific re-raise, keep as is or add logger.debug if needed
             raise
         except Exception as e_unexpected: # General catch-all
-            logger.exception( # Changed to logger.exception
+            logger.exception(
                 "An unexpected error occurred during the Nmap scan process:"
             )
             raise PortScannerError(
@@ -487,7 +487,7 @@ class NmapScanner:
             YAML strings representing the scan results for that host.
 
         """
-        logger.debug(f"Converting Nmap results to YAML for {len(nm.all_hosts())} hosts.") # Added logger.debug
+        logger.debug(f"Converting Nmap results to YAML for {len(nm.all_hosts())} hosts.")
         all_results = {}
         prescan_scripts_data = nm.scaninfo().get('prescript', [])
         logger.debug("Pre-scan script data: %s", prescan_scripts_data)
@@ -515,7 +515,7 @@ class NmapScanner:
             A plain dictionary or list representation of the input data.
 
         """
-        logger.debug(f"to_plain_dict called with data of type: {type(data)}") # Added logger.debug
+        logger.debug(f"to_plain_dict called with data of type: {type(data)}")
         if isinstance(data, nmap.PortScannerHostDict):
             return {k: self.to_plain_dict(v) for k, v in data.items()}
         if isinstance(data, list):  # R1705 (no-else-return makes this an if)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -4,12 +4,6 @@ Provides UI for adjusting font scaling, theme, source view style schemes,
 custom DNS server, and HTTP output colors. Interacts with GSettings to
 load and save these preferences.
 """
-"""Manages the application's preferences window and settings.
-
-Provides UI for adjusting font scaling, theme, source view style schemes,
-custom DNS server, and HTTP output colors. Interacts with GSettings to
-load and save these preferences.
-"""
 import logging
 import re
 from typing import Optional # Added for type hinting
@@ -69,18 +63,33 @@ class Preferences(Adw.PreferencesWindow):
         self.load_preferences()
 
         # Handle dnspython absence for DNS server entry
-        if http_dns_module is None:
-            if self.dns_server_entryrow:
-                self.dns_server_entryrow.set_sensitive(False)
-                self.dns_server_entryrow.set_subtitle("Requires 'dnspython' library to be installed.")
-                # Consider also disabling prefs_dns_apply_button if it makes sense
-                # if self.prefs_dns_apply_button:
-                # self.prefs_dns_apply_button.set_sensitive(False)
-            logging.info("'dnspython' not found; Custom DNS server entry in preferences is disabled.")
+        if self.dns_server_entryrow: # Ensure the row object exists
+            if hasattr(self.dns_server_entryrow, "set_subtitle"):
+                if http_dns_module is None:
+                    self.dns_server_entryrow.set_sensitive(False)
+                    self.dns_server_entryrow.set_subtitle("Requires 'dnspython' library to be installed.")
+                    self.dns_server_entryrow.set_tooltip_text("Custom DNS functionality is disabled because the 'dnspython' library is not installed.")
+                    if self.prefs_dns_apply_button: self.prefs_dns_apply_button.set_sensitive(False)
+                else:
+                    self.dns_server_entryrow.set_sensitive(True)
+                    self.dns_server_entryrow.set_subtitle("") # Clear subtitle
+                    self.dns_server_entryrow.set_tooltip_text("Enter your custom DNS server IP address. Leave empty to use system default.")
+                    if self.prefs_dns_apply_button: self.prefs_dns_apply_button.set_sensitive(True)
+                logging.info(
+                    "'dnspython' status: %s. Custom DNS server entry in preferences updated.",
+                    "found" if http_dns_module else "not found"
+                )
+            else:
+                logging.warning("Adw.EntryRow 'dns_server_entryrow' does not have 'set_subtitle' method. Using tooltip fallback.")
+                if http_dns_module is None:
+                    self.dns_server_entryrow.set_sensitive(False)
+                    self.dns_server_entryrow.set_tooltip_text("Custom DNS disabled: 'dnspython' library not found. Install it for this feature.")
+                    if self.prefs_dns_apply_button: self.prefs_dns_apply_button.set_sensitive(False)
+                else:
+                    self.dns_server_entryrow.set_sensitive(True)
+                    self.dns_server_entryrow.set_tooltip_text("Enter custom DNS server IP. Leave empty for system default.")
         else:
-            if self.dns_server_entryrow:
-                 # Ensure subtitle is cleared if dnspython IS available (e.g., if it was installed later)
-                self.dns_server_entryrow.set_subtitle("")
+            logging.error("'dns_server_entryrow' template child not found during __init__.")
 
 
     def load_ui(self):

--- a/src/simple_gi_test.py
+++ b/src/simple_gi_test.py
@@ -9,16 +9,12 @@ import gi
 try:
     # Attempt to load GLib first as it's fundamental
     gi.require_version("GLib", "2.0")
-    # from gi.repository import GLib # No longer used
 
     gi.require_version("Gio", "2.0")
-    # from gi.repository import Gio # No longer used
 
     gi.require_version("Gtk", "4.0")
-    # from gi.repository import Gtk # No longer used
 
     gi.require_version("Adw", "1")
-    # from gi.repository import Adw # No longer used
 
 except Exception:  # pylint: disable=broad-except
     # If this script were for actual use, error handling (e.g., logging) would go here.

--- a/src/tests/test_http_page.py
+++ b/src/tests/test_http_page.py
@@ -7,7 +7,7 @@ import importlib
 import inspect
 import time
 import logging
-from typing import Optional, List, Any # For type hints
+from typing import Optional, List, Any
 import re
 import enum  # Required for FallbackHttpErrorType
 import socket  # For AF_INET, AF_INET6 constants if needed in test mocks

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -7,6 +7,7 @@ import os
 
 from unittest.mock import MagicMock
 
+# Mock gi repository modules before other src imports that might depend on them
 sys.modules["gi"] = MagicMock()
 sys.modules["gi.repository"] = MagicMock()
 gi_repo_mock = sys.modules["gi.repository"]
@@ -16,7 +17,6 @@ setattr(gi_repo_mock, "Gtk", MagicMock())
 setattr(gi_repo_mock, "GObject", MagicMock())
 setattr(gi_repo_mock, "GtkSource", MagicMock())
 setattr(gi_repo_mock, "Pango", MagicMock())
-
 
 current_script_path = os.path.abspath(__file__)
 tests_dir = os.path.dirname(current_script_path)

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -5,11 +5,6 @@ and display the results.
 """
 import subprocess
 import re
-"""Defines the WebScan page for the Woes application.
-
-This page provides a simple interface to run Nikto scans against a target URL
-and display the results.
-"""
 import logging
 logger = logging.getLogger(__name__)
 from typing import Optional # Added for type hinting
@@ -264,13 +259,3 @@ class WebScanPage(Adw.PreferencesPage):
             logger.warning("Could not find main window or show_error method to display: %s", message)
 
     # Removed on_error_banner_dismiss_clicked method
-    # def on_error_banner_dismiss_clicked(self, _widget: Adw.Banner, *_args):
-    #     """Handle the dismissal of the error banner.
-    #
-    #     Args:
-    #     ----
-    #         _widget: The Adw.Banner or its dismiss button.
-    #         *_args: Additional arguments (unused).
-    #
-    #     """
-    #     self.error_banner_webscan.set_revealed(False)


### PR DESCRIPTION
This commit addresses two main points:

1.  **Fix AttributeError in src/preferences.py**:
    - Resolved an `AttributeError: 'EntryRow' object has no attribute 'set_subtitle'` that occurred when opening the Preferences dialog.
    - The code now checks if `dns_server_entryrow` has the `set_subtitle` attribute before calling it.
    - If `set_subtitle` is not available (e.g., due to an unexpected issue), a warning is logged, and `set_tooltip_text` is used as a fallback to convey necessary information about the `dnspython` dependency for the custom DNS server feature.
    - The sensitivity of the row and its 'Apply' button is also correctly managed based on `dnspython`'s availability.

2.  **Remove Unnecessary Comments**:
    - Cleaned up Python files across the `src/` and `src/tests/` directories by removing commented-out code, meta-comments (like old TODOs or redundant explanations), and other superfluous comments that did not add value to understanding the code.
    - Useful comments explaining complex logic, design decisions, and docstrings were retained.