### PR TITLE
feat: Enhance About window and add page-specific shortcuts

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,11 +1,17 @@
 """Global constants for the Woes application."""
 import os
 
+from gi.repository import Gtk
+
 APP_ID = "com.github.mclellac.woes"
 RESOURCE_PREFIX = "/com/github/mclellac/woes/gtk"
 THEME_LIGHT = "style.css"
 THEME_DARK = "style-dark.css"
 VERSION = "0.2.0"
+APP_WEBSITE_URL = "https://github.com/mclellac/woes"
+APP_LICENSE_TYPE = Gtk.License.MIT_X11
+APP_DESCRIPTION = "A simple toolkit for web, nmap, and DNS scans."
+APP_ISSUES_URL = "https://github.com/mclellac/woes/issues"
 
 # PKGDATADIR would typically be set by the build system (e.g., Meson, Autotools)
 # This should match where Meson installs woes.gresource, which is typically

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -605,3 +605,15 @@ class DNSPage(Adw.PreferencesPage):
         return row
 
     # Removed _format_result_in_buffer
+
+    def trigger_lookup(self):
+        """Programmatically triggers the DNS 'Lookup' action.
+
+        This method is typically called by a global action/shortcut.
+        It simulates a click on the lookup button.
+        """
+        logger.debug("DNS lookup triggered by shortcut.")
+        if self.dns_apply_button and self.dns_apply_button.get_sensitive():
+            self.dns_apply_button.clicked()
+        else:
+            logger.warning("DNS lookup button not available or not sensitive, cannot trigger lookup.")

--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -72,18 +72,28 @@
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Fetch (HTTP Page)</property>
                 <property name="accelerator">&lt;Alt&gt;F</property>
+                <property name="action-name">app.page-action-http-fetch</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Scan (Nmap Page)</property>
                 <property name="accelerator">&lt;Alt&gt;S</property>
+                <property name="action-name">app.page-action-nmap-scan</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Lookup (DNS Page)</property>
                 <property name="accelerator">&lt;Alt&gt;L</property>
+                <property name="action-name">app.page-action-dns-lookup</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Scan (Webscan Page)</property>
+                <property name="accelerator">&lt;Alt&gt;W</property>
+                <property name="action-name">app.page-action-webscan-scan</property>
               </object>
             </child>
           </object>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -1430,3 +1430,15 @@ class HttpPage(Adw.PreferencesPage):
         factory.connect("bind", bind_func_internal)
 
         return factory
+
+    def trigger_fetch(self):
+        """Programmatically triggers the 'Fetch' action.
+
+        This method is typically called by a global action/shortcut.
+        It simulates a click on the fetch button.
+        """
+        logging.debug("HTTP fetch triggered by shortcut.")
+        if self.http_apply_button and self.http_apply_button.get_sensitive():
+            self.http_apply_button.clicked()
+        else:
+            logging.warning("HTTP fetch button not available or not sensitive, cannot trigger fetch.")

--- a/src/main.py
+++ b/src/main.py
@@ -10,9 +10,18 @@ from typing import Optional, List
 import gi
 gi.require_version("Gtk", "4.0")  # Moved require_version before repository imports
 gi.require_version("Adw", "1")    # Moved require_version before repository imports
-from gi.repository import Adw, Gio, GLib
+from gi.repository import Adw, Gio, GLib, Gtk
 
-from .constants import APP_ID, VERSION, RESOURCE_PREFIX, PKGDATADIR # Moved earlier for _load_gresources_early
+from .constants import (
+    APP_ID,
+    VERSION,
+    RESOURCE_PREFIX,
+    PKGDATADIR,
+    APP_WEBSITE_URL,
+    APP_LICENSE_TYPE,
+    APP_DESCRIPTION,
+    APP_ISSUES_URL,
+) # Moved earlier for _load_gresources_early
 
 # GResource loading must happen before any modules that use Gtk.Template are imported.
 def _load_gresources_early():
@@ -137,6 +146,12 @@ class WoesApplication(Adw.Application):
         self.create_action("switch-to-dns", self.switch_to_dns, ["<primary>3"])
         self.create_action("switch-to-webscan", self.switch_to_webscan, ["<primary>4"])
 
+        # Page-specific actions
+        self.create_action("page-action-http-fetch", self.on_page_action_http_fetch, ["<Alt>F"])
+        self.create_action("page-action-nmap-scan", self.on_page_action_nmap_scan, ["<Alt>S"])
+        self.create_action("page-action-dns-lookup", self.on_page_action_dns_lookup, ["<Alt>L"])
+        self.create_action("page-action-webscan-scan", self.on_page_action_webscan_scan, ["<Alt>W"])
+
     def do_handle_local_options(self, options: GLib.VariantDict) -> int:
         """Handle local command-line options.
 
@@ -240,6 +255,75 @@ class WoesApplication(Adw.Application):
         else:
             logging.warning("Cannot switch to webscan_page: window or stack not available.")
 
+    def on_page_action_http_fetch(self, *_args):
+        """Handle the 'page-action-http-fetch' action."""
+        if not self.win or not hasattr(self.win, "stack"):
+            logging.warning("HTTP fetch action: Window or stack not available.")
+            return
+
+        page_name = self.win.stack.get_visible_child_name()
+        page_object = self.win.stack.get_visible_child()
+
+        if page_name == "http" and page_object:
+            if hasattr(page_object, "trigger_fetch"):
+                page_object.trigger_fetch()
+            else:
+                logging.warning("HTTP page object does not have a 'trigger_fetch' method.")
+        elif page_name == "http": # Implies page_object is None
+            logging.warning("HTTP page object is None, cannot trigger fetch.")
+        # No warning if it's not the HTTP page, as the action is specific
+
+    def on_page_action_nmap_scan(self, *_args):
+        """Handle the 'page-action-nmap-scan' action."""
+        if not self.win or not hasattr(self.win, "stack"):
+            logging.warning("Nmap scan action: Window or stack not available.")
+            return
+
+        page_name = self.win.stack.get_visible_child_name()
+        page_object = self.win.stack.get_visible_child()
+
+        if page_name == "nmap" and page_object:
+            if hasattr(page_object, "trigger_scan"):
+                page_object.trigger_scan()
+            else:
+                logging.warning("Nmap page object does not have a 'trigger_scan' method.")
+        elif page_name == "nmap": # Implies page_object is None
+            logging.warning("Nmap page object is None, cannot trigger scan.")
+
+    def on_page_action_dns_lookup(self, *_args):
+        """Handle the 'page-action-dns-lookup' action."""
+        if not self.win or not hasattr(self.win, "stack"):
+            logging.warning("DNS lookup action: Window or stack not available.")
+            return
+
+        page_name = self.win.stack.get_visible_child_name()
+        page_object = self.win.stack.get_visible_child()
+
+        if page_name == "dns" and page_object:
+            if hasattr(page_object, "trigger_lookup"):
+                page_object.trigger_lookup()
+            else:
+                logging.warning("DNS page object does not have a 'trigger_lookup' method.")
+        elif page_name == "dns": # Implies page_object is None
+            logging.warning("DNS page object is None, cannot trigger lookup.")
+
+    def on_page_action_webscan_scan(self, *_args):
+        """Handle the 'page-action-webscan-scan' action."""
+        if not self.win or not hasattr(self.win, "stack"):
+            logging.warning("Webscan scan action: Window or stack not available.")
+            return
+
+        page_name = self.win.stack.get_visible_child_name()
+        page_object = self.win.stack.get_visible_child()
+
+        if page_name == "webscan" and page_object:
+            if hasattr(page_object, "trigger_scan"):
+                page_object.trigger_scan()
+            else:
+                logging.warning("Webscan page object does not have a 'trigger_scan' method.")
+        elif page_name == "webscan": # Implies page_object is None
+            logging.warning("Webscan page object is None, cannot trigger scan.")
+
     def on_about_action(self, _widget: Gio.SimpleAction, _param: Optional[GLib.Variant]):
         """Handle the 'about' action activation.
 
@@ -251,16 +335,37 @@ class WoesApplication(Adw.Application):
             _param: Optional GLib.Variant parameter (unused).
 
         """
-        about = Adw.AboutWindow(
-            transient_for=self.props.active_window,
+        about = self._create_about_window()
+        # Ensure there's an active window before making it transient for
+        # In a typical application flow, active_window would be the main WoesWindow.
+        # For testing, it might be None if do_activate wasn't fully run,
+        # or if a dummy window needs to be set on the application.
+        if self.props.active_window:
+            about.set_transient_for(self.props.active_window)
+        about.present()
+
+    def _create_about_window(self) -> Adw.AboutWindow:
+        """Helper method to create and configure the Adw.AboutWindow.
+
+        Returns
+        -------
+            Adw.AboutWindow: The configured About Window.
+        """
+        # Note: 'transient_for' is typically set by the caller (on_about_action)
+        # if an active window exists. If direct testing _create_about_window,
+        # transient_for might be None unless a window is explicitly managed for the test.
+        return Adw.AboutWindow(
             application_name="woes",
             application_icon=APP_ID,
             developer_name="Carey McLelland",
             version=self.version,
             developers=["Carey McLelland"],
             copyright="© 2025 Carey McLelland",
+            website=APP_WEBSITE_URL,
+            license_type=APP_LICENSE_TYPE,
+            comments=APP_DESCRIPTION,
+            issue_url=APP_ISSUES_URL,
         )
-        about.present()
 
     def on_preferences_action(self, _widget: Gio.SimpleAction, _param: Optional[GLib.Variant]):
         """Handle the 'preferences' action activation.

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -945,3 +945,15 @@ class NmapPage(Gtk.Box):
             summary_lines.append("No OS data available.")
 
         return "\n".join(summary_lines)
+
+    def trigger_scan(self):
+        """Programmatically triggers the Nmap 'Scan' action.
+
+        This method is typically called by a global action/shortcut.
+        It simulates a click on the scan button.
+        """
+        logger.debug("Nmap scan triggered by shortcut.")
+        if self.nmap_apply_button and self.nmap_apply_button.get_sensitive():
+            self.nmap_apply_button.clicked()
+        else:
+            logger.warning("Nmap scan button not available or not sensitive, cannot trigger scan.")

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -11,13 +11,22 @@ from unittest.mock import MagicMock
 sys.modules["gi"] = MagicMock()
 sys.modules["gi.repository"] = MagicMock()
 gi_repo_mock = sys.modules["gi.repository"]
-setattr(gi_repo_mock, "Adw", MagicMock())
-setattr(gi_repo_mock, "Gio", MagicMock())
-setattr(gi_repo_mock, "Gtk", MagicMock())
-setattr(gi_repo_mock, "GObject", MagicMock())
+Adw = MagicMock()
+Gio = MagicMock()
+Gtk = MagicMock()
+GObject = MagicMock() # Added GObject mock explicitly for clarity if needed by WoesApplication init
+setattr(gi_repo_mock, "Adw", Adw)
+setattr(gi_repo_mock, "Gio", Gio)
+setattr(gi_repo_mock, "Gtk", Gtk)
+setattr(gi_repo_mock, "GObject", GObject)
 setattr(gi_repo_mock, "GtkSource", MagicMock())
 setattr(gi_repo_mock, "Pango", MagicMock())
 
+# Mock Gtk.License specifically for APP_LICENSE_TYPE
+Gtk.License = MagicMock()
+Gtk.License.MIT_X11 = "MIT_X11_Mocked" # Mock the specific license type
+
+# Ensure project root is in sys.path for src imports
 current_script_path = os.path.abspath(__file__)
 tests_dir = os.path.dirname(current_script_path)
 src_dir = os.path.dirname(tests_dir)
@@ -26,9 +35,18 @@ project_root = os.path.dirname(src_dir)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+# Now import WoesApplication and constants after mocks are set up
+from src.main import WoesApplication
+from src.constants import (
+    APP_WEBSITE_URL,
+    APP_LICENSE_TYPE, # This will be the mocked Gtk.License.MIT_X11
+    APP_DESCRIPTION,
+    APP_ISSUES_URL
+)
+
 
 class TestMainAppArgs(unittest.TestCase):
-    @patch("src.main.logging.basicConfig")
+    @patch("src.main.logging.basicConfig") # Keep this patch for TestMainAppArgs
     def test_no_arguments_logging_info(self, mock_basic_config):
         """Test that logging.INFO is set when no arguments are passed."""
         test_argv = ["main.py"]
@@ -62,6 +80,58 @@ class TestMainAppArgs(unittest.TestCase):
         test_argv = ["main.py", "--unknown-arg"]
         with self.assertRaises(SystemExit):
             parse_arguments_and_setup_logging(test_argv)
+
+
+# Patch _load_gresources_early for WoesApplication tests to prevent file system access
+@patch("src.main._load_gresources_early", MagicMock())
+class TestAppFeatures(unittest.TestCase):
+    def setUp(self):
+        """Set up for test methods."""
+        # We need to ensure that the application doesn't try to create actual windows
+        # or interact with GTK event loop in tests.
+        # The existing mocks for gi.repository.Gtk and Adw should help.
+        # WoesApplication.__init__ calls super().__init__ which might try to connect to DBus.
+        # We might need to patch Gio.Application.get_default() or similar if it causes issues.
+        with patch.object(Gio.Application, "get_default", return_value=None):
+             # Mock settings to prevent GSettings access errors
+            with patch("src.main.Gio.Settings.new") as mock_settings_new:
+                mock_settings_instance = MagicMock()
+                mock_settings_new.return_value = mock_settings_instance
+                # Add mock methods for any GSettings calls made during WoesApplication init if necessary
+                # e.g., mock_settings_instance.get_string.return_value = "some_default_value"
+                self.app = WoesApplication()
+
+    def test_about_window_details(self):
+        """Test that the About Window has the correct enhanced details."""
+        # The _create_about_window method doesn't require an active window to be set on the app
+        # for just creating the AboutWindow instance.
+        # transient_for would be set by on_about_action if an active_window exists.
+        about_window = self.app._create_about_window()
+
+        self.assertIsNotNone(about_window)
+        self.assertEqual(about_window.get_website(), APP_WEBSITE_URL)
+        # APP_LICENSE_TYPE is Gtk.License.MIT_X11. The mock setup makes Gtk.License.MIT_X11 a string.
+        self.assertEqual(about_window.get_license_type(), Gtk.License.MIT_X11)
+        self.assertEqual(about_window.get_comments(), APP_DESCRIPTION)
+        self.assertEqual(about_window.get_issue_url(), APP_ISSUES_URL)
+
+    def test_page_action_accelerators(self):
+        """Test that page-specific actions are registered with correct accelerators."""
+        expected_actions = {
+            "app.page-action-http-fetch": "<Alt>F",
+            "app.page-action-nmap-scan": "<Alt>S",
+            "app.page-action-dns-lookup": "<Alt>L",
+            "app.page-action-webscan-scan": "<Alt>W",
+        }
+
+        for full_action_name, expected_accelerator in expected_actions.items():
+            action_name_without_prefix = full_action_name.split(".", 1)[1]
+            action = self.app.lookup_action(action_name_without_prefix)
+            self.assertIsNotNone(action, f"Action '{action_name_without_prefix}' not found.")
+
+            accels = self.app.get_accels_for_action(full_action_name)
+            self.assertIn(expected_accelerator, accels,
+                          f"Expected accelerator '{expected_accelerator}' not found for action '{full_action_name}'. Found: {accels}")
 
 
 if __name__ == "__main__":

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -259,3 +259,15 @@ class WebScanPage(Adw.PreferencesPage):
             logger.warning("Could not find main window or show_error method to display: %s", message)
 
     # Removed on_error_banner_dismiss_clicked method
+
+    def trigger_scan(self):
+        """Programmatically triggers the WebScan 'Scan' action.
+
+        This method is typically called by a global action/shortcut.
+        It simulates a click on the scan button.
+        """
+        logger.debug("Webscan scan triggered by shortcut.")
+        if self.scan_button and self.scan_button.get_sensitive():
+            self.scan_button.clicked()
+        else:
+            logger.warning("Webscan scan button not available or not sensitive, cannot trigger scan.")


### PR DESCRIPTION
This commit introduces several improvements:

1.  **Enhanced About Window:**
    *   The About window now includes the application's website URL,
        license type (MIT), a brief description, and a link to the
        project's issue tracker.
    *   Relevant constants for these details have been added to
        `src/constants.py`.
    *   `src/main.py` was updated to populate these new fields in the
        `Adw.AboutWindow`.

2.  **New Keyboard Shortcuts for Page Actions:**
    *   Added keyboard shortcuts for primary actions on each page:
        *   HTTP Page (Fetch): Alt+F
        *   Nmap Page (Scan): Alt+S
        *   DNS Page (Lookup): Alt+L
        *   Webscan Page (Scan): Alt+W (newly added)
    *   Defined corresponding actions (`app.page-action-<type>-<action>`)
        in `src/main.py`.
    *   Updated `src/gtk/help-overlay.ui` to include these actions and
        the new shortcut for the Webscan page.
    *   Implemented `trigger_<action>` methods in each respective page
        module (`http_page.py`, `nmap_page.py`, `dns_page.py`,
        `webscan_page.py`) to enable these shortcuts.

3.  **Testing:**
    *   Added basic unit tests in `src/tests/test_main.py` to:
        *   Verify the new information is correctly displayed in the
          About window.
        *   Ensure the new page-specific actions are registered with the
          correct accelerators.
    *   Refactored `WoesApplication.on_about_action` in `src/main.py`
      to facilitate easier testing of the AboutWindow properties.