### PR TITLE
refactor: Align notifications with GNOME HIG

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -197,16 +197,26 @@ class DNSPage(Adw.PreferencesPage):
         logger.debug(f"Performing DNS lookup for: {user_input}, type: {requested_record_type}")
 
         if not user_input:
-            self._show_error("Input cannot be empty.")
+            main_window = self.get_native()
+            if main_window and hasattr(main_window, 'show_toast'):
+                main_window.show_toast("Input cannot be empty.")
+            else:
+                logger.warning("Could not find main window or show_toast method for empty DNS input toast.")
+                self._show_error("Input cannot be empty.") # Fallback
             if self.dns_lookup_spinner:
                 self.dns_lookup_spinner.stop()
                 self.dns_lookup_spinner.set_visible(False)
             return
 
-        self._clear_error()
+        self._clear_error() # Clears banner and CSS error class
 
         if not self._is_valid_ip_or_domain(user_input):
-            self._show_error("Invalid IP address or domain name.")
+            main_window = self.get_native()
+            if main_window and hasattr(main_window, 'show_toast'):
+                main_window.show_toast("Invalid IP address or domain name.")
+            else:
+                logger.warning("Could not find main window or show_toast method for invalid DNS input toast.")
+                self._show_error("Invalid IP address or domain name.") # Fallback
             if self.dns_lookup_spinner:
                 self.dns_lookup_spinner.stop()
                 self.dns_lookup_spinner.set_visible(False)
@@ -233,13 +243,11 @@ class DNSPage(Adw.PreferencesPage):
         except dns.resolver.NXDOMAIN:
             self._show_error(f"Domain not found: {user_input} (NXDOMAIN)")
         except dns.resolver.NoAnswer:
-            # Determine which record type was actually attempted for the error message
-            record_type_for_error = (
-                "PTR" if self._is_ip_address(user_input) else requested_record_type
-            )
-            self._show_error(
-                f"No {record_type_for_error} records found for {user_input} (NoAnswer)"
-            )
+            # For NoAnswer, we want to display this information in the results area, not as an error banner.
+            # _display_result will handle showing "No records found".
+            # We pass an empty list to _display_result.
+            logger.info("No %s records found for %s (NoAnswer).", requested_record_type, user_input)
+            self._display_result([], user_input, requested_record_type, resolver.nameservers if hasattr(resolver, 'nameservers') else ["System default"])
         except dns.resolver.Timeout:
             self._show_error(f"DNS query timed out for {user_input}")
         except dns.exception.DNSException as e:  # Catch other DNS-specific exceptions
@@ -409,7 +417,13 @@ class DNSPage(Adw.PreferencesPage):
         self.dns_results_box_container.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
 
         if not result_records:
-            no_records_row = Adw.ActionRow(title="No records found for this query.")
+            no_records_message = f"No {record_type} records found for {domain_or_ip}."
+            if record_type == "PTR" and self._is_ip_address(domain_or_ip): # More specific for reverse lookups
+                 no_records_message = f"No PTR records found for IP address {domain_or_ip}."
+            elif record_type == "PTR": # Generic PTR if input wasn't an IP for some reason
+                 no_records_message = f"No PTR records found for {domain_or_ip}."
+
+            no_records_row = Adw.ActionRow(title=no_records_message)
             no_records_row.set_selectable(False)
             self.dns_results_box_container.append(no_records_row)
             return

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -5,11 +5,13 @@
   <requires lib="libadwaita" version="1.7"/>
   <template class="WoesWindow" parent="AdwApplicationWindow">
     <property name="content">
-      <object class="GtkBox" id="main_box">
-        <property name="halign">baseline-fill</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="AdwHeaderBar" id="header_bar">
+      <object class="AdwToastOverlay" id="toast_overlay">
+        <property name="child">
+          <object class="GtkBox" id="main_box">
+            <property name="halign">baseline-fill</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="AdwHeaderBar" id="header_bar">
             <property name="title-widget">
               <object class="AdwViewSwitcher" id="switcher_title">
                 <property name="halign">baseline-fill</property>
@@ -176,7 +178,9 @@
             <property name="stack">stack</property>
           </object>
         </child>
-      </object>
+          </object> <!-- End of main_box -->
+        </property> <!-- End of AdwToastOverlay child property -->
+      </object> <!-- End of AdwToastOverlay -->
     </property>
     <property name="default-height">1000</property>
     <property name="default-width">1000</property>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -497,7 +497,13 @@ class HttpPage(Adw.PreferencesPage):
 
         if not self._is_valid_url(url):
             logger.warning("Invalid URL provided: %s (processed as: %s)", original_url, url)
-            self._display_error("Invalid URL format: Please enter a valid URL (e.g., https://example.com).")
+            main_window = self.get_native()
+            if main_window and hasattr(main_window, 'show_toast'):
+                main_window.show_toast("Invalid URL format. Please enter a valid URL (e.g., https://example.com).")
+            else:
+                # Fallback or log if main_window or show_toast is not available
+                logger.warning("Could not find main window or show_toast method to display invalid URL toast.")
+                self._display_error("Invalid URL format: Please enter a valid URL (e.g., https://example.com).") # Fallback to banner
             self._update_column_view_model(None) # Clear previous results
             return
 

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -201,10 +201,13 @@ class NmapPage(Gtk.Box):
         self._clear_error()
 
         if not self.scanner.validate_target_input(target):
-            self.nmap_target_entryrow.add_css_class("error")
-            self._display_error(
-                "Invalid target format. Please enter a valid IP, CIDR, or hostname."
-            )
+            # self.nmap_target_entryrow.add_css_class("error") # Removed for toast
+            main_window = self.get_native()
+            if main_window and hasattr(main_window, 'show_toast'):
+                main_window.show_toast("Invalid target format. Please enter a valid IP, CIDR, or hostname.")
+            else:
+                logger.warning("Could not find main window or show_toast method for invalid Nmap target toast.")
+                self._display_error("Invalid target format. Please enter a valid IP, CIDR, or hostname.") # Fallback
             return
         self.nmap_target_entryrow.remove_css_class("error")
 
@@ -345,7 +348,7 @@ class NmapPage(Gtk.Box):
                 ScanStatus.COMPLETE,
                 f"Scan complete for {original_target}. No hosts found or responsive.",
             )
-            self._display_error(f"No hosts found or responsive for target: {original_target}")
+            # self._display_error(f"No hosts found or responsive for target: {original_target}") # Removed
             self._clear_dynamic_details()
             self.nmap_detail_placeholder.set_title("No Responsive Hosts")
             self.nmap_detail_placeholder.set_description(

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -66,11 +66,21 @@ class WebScanPage(Adw.PreferencesPage):
             re.IGNORECASE,
         )
         if not target_url:
-            self._show_main_banner_error("Target URL cannot be empty.")
+            main_window = self.get_native()
+            if main_window and hasattr(main_window, 'show_toast'):
+                main_window.show_toast("Target URL cannot be empty.")
+            else:
+                logger.warning("Could not find main window or show_toast method for empty Webscan URL toast.")
+                self._show_main_banner_error("Target URL cannot be empty.") # Fallback
             return
 
         if not url_pattern.match(target_url):
-            self._show_main_banner_error("Invalid URL format. Please enter a valid URL.")
+            main_window = self.get_native()
+            if main_window and hasattr(main_window, 'show_toast'):
+                main_window.show_toast("Invalid URL format. Please enter a valid URL.")
+            else:
+                logger.warning("Could not find main window or show_toast method for invalid Webscan URL toast.")
+                self._show_main_banner_error("Invalid URL format. Please enter a valid URL.") # Fallback
             return
 
         buffer = self.results_textview.get_buffer()

--- a/src/window.py
+++ b/src/window.py
@@ -7,7 +7,7 @@ and integrates system font settings.
 import logging
 import platform
 import gi
-from gi.repository import Adw, Gdk, Gio, Gtk, GLib, GObject # Added GObject
+from gi.repository import Adw, Gdk, Gio, Gtk, GLib, GObject, AdwToastOverlay, AdwToast # Added GObject
 
 from .constants import (
     APP_ID,
@@ -41,6 +41,7 @@ class WoesWindow(Adw.ApplicationWindow):
     switcher_title = Gtk.Template.Child("switcher_title")
     stack = Gtk.Template.Child("stack")
     main_error_banner = Gtk.Template.Child("main_error_banner")
+    toast_overlay = Gtk.Template.Child("toast_overlay")
 
     def __init__(self, **kwargs):
         """Initialize the WoesWindow.
@@ -122,6 +123,7 @@ class WoesWindow(Adw.ApplicationWindow):
         """
         if self.main_error_banner:
             self.main_error_banner.set_title(message)
+            self.main_error_banner.add_css_class("error")
             self.main_error_banner.set_revealed(True)
             logging.info("Main error banner shown with message: %s", message)
         else:
@@ -130,6 +132,7 @@ class WoesWindow(Adw.ApplicationWindow):
     def hide_error(self):
         """Hides the main error banner and clears its title."""
         if self.main_error_banner:
+            self.main_error_banner.remove_css_class("error")
             self.main_error_banner.set_revealed(False)
             self.main_error_banner.set_title("") # Clear title
             logging.info("Main error banner hidden.")
@@ -271,3 +274,28 @@ class WoesWindow(Adw.ApplicationWindow):
 
         """
         logging.debug("Switched to page: %s", self.stack.get_visible_child_name())
+
+    def show_toast(self, title: str, priority: Adw.ToastPriority = Adw.ToastPriority.NORMAL, timeout: int = 2):
+        """Displays an AdwToast message.
+
+        Args:
+        ----
+            title: The message to display in the toast.
+            priority: The priority of the toast (e.g., Adw.ToastPriority.NORMAL, Adw.ToastPriority.HIGH).
+            timeout: Duration in seconds for the toast to be visible. Default is 2 seconds.
+                     A value of 0 means it will stay until dismissed.
+        """
+        if not self.toast_overlay:
+            logging.warning("ToastOverlay not found, cannot display toast: %s", title)
+            # Fallback to banner if toast system isn't available for some reason
+            # self.show_error(f"Toast (fallback): {title}") # Optional: consider if fallback is desired
+            return
+
+        toast = Adw.Toast.new(title)
+        toast.set_priority(priority)
+        toast.set_timeout(timeout) # Set timeout in seconds
+        # toast.set_action_name("app.example-action") # Optional: if toast needs an action button
+        # toast.set_button_label("Example")         # Optional: label for the action button
+
+        self.toast_overlay.add_toast(toast)
+        logging.info("Toast shown: %s (Priority: %s, Timeout: %s)", title, priority, timeout)


### PR DESCRIPTION
This commit refactors the application's notification system (banners and toasts) to better align with the GNOME Human Interface Guidelines.

Key changes include:

1.  **Toast Implementation:**
    *   Added an `AdwToastOverlay` to the main window.
    *   Implemented a `WoesWindow.show_toast()` method for displaying
        short, less intrusive messages.

2.  **Refactored Notification Usage:**
    *   Input validation errors (e.g., invalid URL/target format, empty
        input) now use `AdwToast` messages instead of the main error banner.
        This applies to the HTTP, Nmap, DNS, and Webscan pages.
    *   "No results" scenarios, such as Nmap finding no hosts or DNS
        returning no answer (NoAnswer), are now handled with in-page UI
        updates (e.g., status messages or placeholder updates within the
        respective page) instead of using the main error banner or toasts.
    *   Critical operational errors (e.g., network timeouts, command not
        found, actual scan failures, NXDOMAIN) continue to use the
        main `AdwBanner` for app-wide visibility.

3.  **Banner Styling:**
    *   The main error banner (`main_error_banner` in `WoesWindow`) now
        has the `.error` CSS class applied when shown via `show_error()`,
        ensuring it is styled appropriately for error messages according
        to Adwaita conventions. The class is removed when the banner is hidden.

4.  **Button Styling Review:**
    *   Confirmed that primary action buttons (e.g., "Fetch", "Scan",
        "Lookup") on each page already utilize the `.suggested-action`
        CSS class, and destructive actions like "Clear Results" use
        `.destructive-action`, aligning with HIG recommendations. No changes
        were needed here.

These changes aim to provide a more consistent and user-friendly notification experience, reserving prominent banners for significant issues and using toasts or in-page messages for less critical feedback.