### PR TITLE
fix: Correct persistent SyntaxError at end of nmap_page.py

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -956,5 +956,3 @@ class NmapPage(Gtk.Box):
             self.nmap_apply_button.clicked()
         else:
             logger.warning("Nmap scan button not available or not sensitive, cannot trigger scan.")
-
-```


### PR DESCRIPTION
This commit definitively resolves a persistent SyntaxError that was occurring at the end of `src/nmap_page.py`. The error was caused by stray characters being inadvertently written to the file during previous automated modifications.

I have carefully truncated the file to ensure it ends precisely with the last valid line of Python code, removing all trailing spurious characters. This ensures the file is now syntactically correct.