### PR TITLE
Fix: Correct Gio.Task result retrieval in WebScanPage

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -200,7 +200,11 @@ class WebScanPage(Adw.PreferencesPage):
             target_url = self._temp_scan_data.get("target_url", target_url)
 
         try:
-            stdout, stderr_or_error_msg, error_type = task.run_in_thread_finish(result)
+            # This will raise a GLib.Error if the task itself failed fundamentally,
+            # but our thread function is designed to return values, not set GLib.Error.
+            # However, it's good practice to keep the try-except GLib.Error for robustness.
+            returned_value = task.propagate_value(result)
+            stdout, stderr_or_error_msg, error_type = returned_value
 
             if error_type == "FileNotFoundError":
                 logger.exception("Nikto command not found. Ensure it's in PATH.")


### PR DESCRIPTION
I replaced the incorrect `task.run_in_thread_finish(result)` call with `task.propagate_value(result)` in the `_on_scan_task_done` method of `src/webscan_page.py`.

This resolves an AttributeError that occurred because `run_in_thread_finish` is not a valid method for Gio.Task. The `propagate_value` method is the correct way to retrieve the value set by `task.return_value()` from the thread where the work was performed.