### PR TITLE
Fix: Remove invalid 'subtitle' property from AdwEntryRow in Webscan UI

### DIFF
--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -56,7 +56,6 @@
             <child>
               <object class="AdwEntryRow" id="maxtime_entry_row">
                 <property name="title">Max Scan Time (seconds)</property>
-                <property name="subtitle">Pass -maxtime &lt;seconds&gt; to Nikto (e.g., 60 or 60s)</property>
                 <property name="input-purpose">number</property> <!-- Hint for numeric input -->
               </object>
             </child>


### PR DESCRIPTION
I removed the 'subtitle' property from the AdwEntryRow widget (id="maxtime_entry_row") in src/gtk/webscan_page.ui. AdwEntryRow does not support the 'subtitle' property, and its presence caused a Gtk-CRITICAL error during widget template instantiation.

This error prevented other Gtk.Template.Child widgets from being properly initialized, leading to a subsequent AttributeError when trying to connect signals to them (e.g., self.url_entry.connect).

This commit resolves both the Gtk-CRITICAL error and the AttributeError.