### PR TITLE
Fix: Correct Gio.Task.propagate_value usage in webscan_page

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -319,7 +319,7 @@ class WebScanPage(Adw.PreferencesPage):
             # This will raise a GLib.Error if the task itself failed fundamentally,
             # but our thread function is designed to return values, not set GLib.Error.
             # However, it's good practice to keep the try-except GLib.Error for robustness.
-            returned_value = active_task.propagate_value(async_result_obj)
+            returned_value = active_task.propagate_value()
             stdout, stderr_or_error_msg, error_type = returned_value
 
             if error_type == "FileNotFoundError":


### PR DESCRIPTION
The method Gio.Task.propagate_value() in PyGObject is an instance method that should be called without arguments. It returns the value set by task.return_value() directly (or raises a GLib.Error if the task failed).

The previous code was incorrectly passing the async_result_obj (which is the task itself) as an argument to propagate_value(), leading to a TypeError: Gio.Task.propagate_value() takes exactly 1 argument (2 given).

This commit corrects the call to active_task.propagate_value() by removing the erroneous argument.