### PR TITLE
Fix: Correctly handle return value of Gio.Task.propagate_value

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -302,12 +302,9 @@ class WebScanPage(Adw.PreferencesPage):
         try:
             # Gio.Task.propagate_value() can raise a GLib.Error if the task itself
             # encountered an unhandled exception (e.g., was cancelled before returning a value).
-            # If successful, it returns a (bool, GObject.Value) tuple.
-            success_flag, actual_gobject_value = active_task.propagate_value()
-
-            # The GObject.Value holds the Python object returned by task.return_value()
-            # in the thread function, which is our 3-element tuple.
-            stdout, stderr_or_error_msg, error_type = actual_gobject_value.get_pyobject()
+            # On success, it directly returns the Python object passed to task.return_value().
+            returned_value = active_task.propagate_value()
+            stdout, stderr_or_error_msg, error_type = returned_value
 
             if error_type == "FileNotFoundError":
                 logger.exception("Nikto command not found. Ensure it's in PATH.")


### PR DESCRIPTION
The `Gio.Task.propagate_value()` method in PyGObject bindings directly returns the Python object that was passed to `task.return_value()` when the task completes successfully. If the task fails, it raises a `GLib.Error`.

This commit ensures that the return value from `propagate_value()` is directly unpacked as the expected 3-element tuple (stdout, stderr_or_error_msg, error_type), resolving the previously encountered AttributeError. This reverts an intermediate incorrect assumption that `propagate_value` returned a GObject.Value that needed explicit unwrapping via `.get_pyobject()`.