### PR TITLE
Fix: Correctly unpack tuple from Gio.Task.propagate_value

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -301,10 +301,14 @@ class WebScanPage(Adw.PreferencesPage):
 
         try:
             # Gio.Task.propagate_value() can raise a GLib.Error if the task itself
-            # encountered an unhandled exception (e.g., was cancelled before returning a value).
-            # On success, it directly returns the Python object passed to task.return_value().
-            returned_value = active_task.propagate_value()
-            stdout, stderr_or_error_msg, error_type = returned_value
+            # encountered an unhandled exception.
+            # On success, it returns a 2-tuple. The first element's role is secondary
+            # here as critical errors are caught by GLib.Error.
+            # The second element is the actual payload (our 3-element tuple)
+            # passed to task.return_value() in the thread.
+            _intermediate_tuple_from_propagate = active_task.propagate_value()
+            _status_or_bool, actual_payload_tuple = _intermediate_tuple_from_propagate
+            stdout, stderr_or_error_msg, error_type = actual_payload_tuple
 
             if error_type == "FileNotFoundError":
                 logger.exception("Nikto command not found. Ensure it's in PATH.")


### PR DESCRIPTION
The Gio.Task.propagate_value() method in the PyGObject bindings returns a 2-element tuple: (success_boolean, payload_object) when no GLib.Error is raised. The payload_object is the actual Python object originally passed to task.return_value().

Previous attempts to unpack this return value were incorrect, leading first to a ValueError (expecting 3 elements, got 2) and then to an AttributeError (by trying to call .get_pyobject() on what was already the payload_object).

This commit implements the correct two-step unpacking:
1. Unpack the 2-element tuple from propagate_value().
2. Unpack the payload_object (which is our 3-element tuple for webscan) from the second element of the 2-tuple.

This resolves the persistent ValueError and correctly retrieves the scan results or error information from the asynchronous task.