### PR TITLE
Fix: Remove -Format txt from Nikto command in webscan_page

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -220,7 +220,7 @@ class WebScanPage(Adw.PreferencesPage):
         if not target_url.startswith(("http://", "https://")):
             target_url = "http://" + target_url
 
-        nikto_command = ['nikto', '-h', target_url, '-Format', 'txt']
+        nikto_command = ['nikto', '-h', target_url]
 
         if force_ssl:
             nikto_command.append('-ssl')


### PR DESCRIPTION
The Nikto command was failing with "+ERROR: Output file format specified without a name" because `-Format txt` was included without a corresponding `-output <file>` directive.

When capturing Nikto's output from stdout (as done via subprocess.PIPE), explicitly setting `-Format txt` without `-o` is problematic. Nikto's default behavior when no output file is specified is to print plain text results to stdout.

This commit removes `-Format txt` from the `nikto_command` list, relying on Nikto's default stdout output, which is suitable for capture and display in the application.