### PR TITLE
Refactor: Centralize user notifications via utility functions

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -12,6 +12,7 @@ from gi.repository import Adw, Gio, Gtk, Pango, GObject
 from typing import Tuple, Sequence, Any, List, Dict
 
 from .constants import APP_ID, RESOURCE_PREFIX
+from .utils import show_global_error, show_global_toast
 
 
 gi.require_version("Adw", "1")
@@ -196,12 +197,10 @@ class DNSPage(Adw.PreferencesPage):
         logger.debug(f"Performing DNS lookup for: {user_input}, type: {requested_record_type}")
 
         if not user_input:
-            main_window = self.get_native()
-            if main_window and hasattr(main_window, 'show_toast'):
-                main_window.show_toast("Input cannot be empty.")
-            else:
-                logger.warning("Could not find main window or show_toast method for empty DNS input toast.")
-                self._show_error("Input cannot be empty.") # Fallback
+            show_global_toast(self, "Input cannot be empty.")
+            main_window = self.get_native() # Still need to check for fallback condition
+            if not (main_window and hasattr(main_window, 'show_toast')):
+                show_global_error(self, "Input cannot be empty.")
             if self.dns_lookup_spinner:
                 self.dns_lookup_spinner.stop()
                 self.dns_lookup_spinner.set_visible(False)
@@ -210,12 +209,10 @@ class DNSPage(Adw.PreferencesPage):
         self._clear_error() # Clears banner and CSS error class
 
         if not self._is_valid_ip_or_domain(user_input):
-            main_window = self.get_native()
-            if main_window and hasattr(main_window, 'show_toast'):
-                main_window.show_toast("Invalid IP address or domain name.")
-            else:
-                logger.warning("Could not find main window or show_toast method for invalid DNS input toast.")
-                self._show_error("Invalid IP address or domain name.") # Fallback
+            show_global_toast(self, "Invalid IP address or domain name.")
+            main_window = self.get_native() # Still need to check for fallback condition
+            if not (main_window and hasattr(main_window, 'show_toast')):
+                show_global_error(self, "Invalid IP address or domain name.")
             if self.dns_lookup_spinner:
                 self.dns_lookup_spinner.stop()
                 self.dns_lookup_spinner.set_visible(False)
@@ -240,7 +237,7 @@ class DNSPage(Adw.PreferencesPage):
             self._display_result(result_data, user_input, actual_type_used, resolver.nameservers)
 
         except dns.resolver.NXDOMAIN:
-            self._show_error(f"Domain not found: {user_input} (NXDOMAIN)")
+            show_global_error(self, f"Domain not found: {user_input} (NXDOMAIN)")
         except dns.resolver.NoAnswer:
             # For NoAnswer, we want to display this information in the results area, not as an error banner.
             # _display_result will handle showing "No records found".
@@ -248,17 +245,17 @@ class DNSPage(Adw.PreferencesPage):
             logger.info("No %s records found for %s (NoAnswer).", requested_record_type, user_input)
             self._display_result([], user_input, requested_record_type, resolver.nameservers if hasattr(resolver, 'nameservers') else ["System default"])
         except dns.resolver.Timeout:
-            self._show_error(f"DNS query timed out for {user_input}")
+            show_global_error(self, f"DNS query timed out for {user_input}")
         except dns.exception.DNSException as e:  # Catch other DNS-specific exceptions
             logger.exception("DNS lookup failed for %s, type %s:", user_input, requested_record_type)
-            self._show_error(f"DNS Error: {str(e)}")
+            show_global_error(self, f"DNS Error: {str(e)}")
         except Exception as e:  # pylint: disable=broad-except
             logger.exception(
                 "Unexpected error during DNS lookup for %s, type %s:",
                 user_input,
                 requested_record_type,
             )
-            self._show_error(f"An unexpected error occurred: {str(e)}")
+            show_global_error(self, f"An unexpected error occurred: {str(e)}")
         finally:
             if self.dns_lookup_spinner:
                 self.dns_lookup_spinner.stop()
@@ -275,22 +272,6 @@ class DNSPage(Adw.PreferencesPage):
         model = self.dns_record_type_dropdown.get_model()
         selected_index = self.dns_record_type_dropdown.get_selected()
         return model.get_string(selected_index)
-
-    def _show_error(self, message: str):
-        """Display an error message in the UI banner and style the entry row.
-
-        Args:
-        ----
-            message: The error message to display.
-
-        """
-        self.domain_entry.add_css_class("error")
-        main_window = self.get_native()
-        if main_window and hasattr(main_window, 'show_error'):
-            main_window.show_error(message)
-        else:
-            logger.warning("Could not find main window or show_error method to display: %s", message)
-
 
     def _clear_error(self):
         """Clear any existing error messages from the UI banner and entry row styling."""

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -28,6 +28,7 @@ import gi
 from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk, Pango
 
 from .constants import RESOURCE_PREFIX, USER_AGENTS, APP_ID
+from .utils import show_global_error, show_global_toast
 
 
 gi.require_version("Adw", "1")
@@ -560,15 +561,11 @@ class HttpPage(Adw.PreferencesPage):
 
         if not self._is_valid_url(url):
             logger.warning("Invalid URL provided: %s (processed as: %s)", original_url, url)
-            main_window = self.get_native()
-            if main_window and hasattr(main_window, "show_toast"):
-                main_window.show_toast("Invalid URL format. Please enter a valid URL (e.g., https://example.com).")
-            else:
-                # Fallback or log if main_window or show_toast is not available
-                logger.warning("Could not find main window or show_toast method to display invalid URL toast.")
-                self._display_error(
-                    "Invalid URL format: Please enter a valid URL (e.g., https://example.com)."
-                )  # Fallback to banner
+            toast_message = "Invalid URL format. Please enter a valid URL (e.g., https://example.com)."
+            show_global_toast(self, toast_message)
+            main_window = self.get_native() # Still need to check for fallback condition
+            if not (main_window and hasattr(main_window, "show_toast")):
+                show_global_error(self, toast_message)
             self._update_column_view_model(None)
             return
 
@@ -1124,7 +1121,7 @@ class HttpPage(Adw.PreferencesPage):
                     type(actual_list_of_responses),
                     actual_list_of_responses,
                 )
-                self._display_error(
+                show_global_error(self,
                     f"Failed to process task result (unexpected data structure: "
                     f"{type(actual_list_of_responses).__name__}). Please check logs."
                 )
@@ -1140,7 +1137,7 @@ class HttpPage(Adw.PreferencesPage):
             display_message = (
                 e.message.replace("<b>", "").replace("</b>", "") if e.message else "An unknown error occurred."
             )
-            self._display_error(display_message)
+            show_global_error(self, display_message)
             if hasattr(self, "http_entry_row") and self.http_entry_row:
                 self.http_entry_row.add_css_class("error")  # Style entry as erroneous
             self._update_column_view_model(None)
@@ -1153,7 +1150,7 @@ class HttpPage(Adw.PreferencesPage):
             elif str(e):  # Fallback to string representation of the exception
                 error_message = str(e)
 
-            self._display_error(error_message)
+            show_global_error(self, error_message)
             if hasattr(self, "http_entry_row") and self.http_entry_row:
                 self.http_entry_row.add_css_class("error")
             self._update_column_view_model(None)
@@ -1294,27 +1291,6 @@ class HttpPage(Adw.PreferencesPage):
         """Make the HTTP results group invisible."""
         if self.http_results_group:  # Check if it exists
             self.http_results_group.set_visible(False)
-
-    def _display_error(self, message: str) -> None:
-        """Display an error message in the main window's error banner.
-
-        Also adds an 'error' CSS class to the URL entry row and hides any existing results.
-
-        Args:
-        ----
-            message: The error message string to display.
-
-        """
-        main_window = self.get_native()  # Get the top-level window (WoesWindow)
-        if main_window and hasattr(main_window, "show_error"):
-            main_window.show_error(message)  # Call show_error method on WoesWindow
-        else:
-            # Fallback or log if WoesWindow or show_error is not found
-            logger.warning("Could not find main window or its 'show_error' method to display: %s", message)
-
-        if self.http_entry_row:  # Check if it exists
-            self.http_entry_row.add_css_class("error")
-        self._hide_results()  # Hide results section when an error occurs
 
     def _clear_error(self) -> None:
         """Clear any displayed error messages from the main window's banner.

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -18,7 +18,7 @@ import nmap
 from .constants import APP_ID, RESOURCE_PREFIX
 from .nmap_scanner import NmapScanner, ScanStatus
 from .style_utils import apply_source_style_scheme
-from .utils import create_source_view
+from .utils import create_source_view, show_global_error, show_global_toast
 
 
 gi.require_version("Adw", "1")
@@ -198,13 +198,16 @@ class NmapPage(Gtk.Box):
         self._clear_error()
 
         if not self.scanner.validate_target_input(target):
-            # self.nmap_target_entryrow.add_css_class("error") # Removed for toast
+            # self.nmap_target_entryrow.add_css_class("error") # Kept commented as per subtask notes
+            message = "Invalid target format. Please enter a valid IP, CIDR, or hostname."
             main_window = self.get_native()
             if main_window and hasattr(main_window, 'show_toast'):
-                main_window.show_toast("Invalid target format. Please enter a valid IP, CIDR, or hostname.")
+                show_global_toast(self, message)
             else:
-                logger.warning("Could not find main window or show_toast method for invalid Nmap target toast.")
-                self._display_error("Invalid target format. Please enter a valid IP, CIDR, or hostname.") # Fallback
+                # The original code logged a warning here, but show_global_error will log one if it also fails.
+                # If show_global_toast was attempted but main_window/show_toast wasn't available,
+                # show_global_toast itself logs a warning. Then we fall back to show_global_error.
+                show_global_error(self, message) # Fallback
             return
         self.nmap_target_entryrow.remove_css_class("error")
 
@@ -377,7 +380,7 @@ class NmapPage(Gtk.Box):
 
         """
         logger.debug("Handling Nmap scan error for target %s: %s", target, error_message)
-        self._display_error(f"Error scanning {target}: {error_message}")
+        show_global_error(self, f"Error scanning {target}: {error_message}")
         self._set_scan_status(ScanStatus.FAILED, f"Scan failed for {target}")
 
     def _on_target_selected(self, _listbox: Gtk.ListBox, row: Gtk.ListBoxRow | None):
@@ -767,22 +770,6 @@ class NmapPage(Gtk.Box):
     def _on_error_banner_dismiss(self, _banner: Adw.Banner, *_args):
         """Handle dismissal of the error banner by clearing the error state."""
         self._clear_error()
-
-
-    def _display_error(self, message: str):
-        """Display an error message using the main window's banner.
-
-        Args:
-        ----
-            message: The error message to display.
-
-        """
-        main_window = self.get_native()
-        if main_window and hasattr(main_window, 'show_error'):
-            main_window.show_error(message)
-        else:
-            logger.warning("Could not find main window or show_error method to display: %s", message)
-
 
     def _clear_error(self):
         """Clear any displayed error message using the main window's banner."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,10 +2,13 @@
 import logging
 from typing import Tuple
 import gi
-from gi.repository import Gtk, GtkSource
+from gi.repository import Gtk, GtkSource, Adw
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("GtkSource", "5")
+gi.require_version("Adw", "1") # Added for Adw.ToastPriority
+
+logger = logging.getLogger(__name__)
 
 
 def create_source_view(language_name: str = "txt") -> Tuple[GtkSource.View, GtkSource.Buffer]:
@@ -31,7 +34,7 @@ def create_source_view(language_name: str = "txt") -> Tuple[GtkSource.View, GtkS
     language = language_manager.get_language(language_name)
 
     if language is None:
-        logging.warning(
+        logger.warning(
             "GtkSourceView language '%s' not found. Falling back to a plain buffer.",
             language_name,
         )
@@ -53,3 +56,60 @@ def create_source_view(language_name: str = "txt") -> Tuple[GtkSource.View, GtkS
     source_view.set_vexpand(True)
 
     return source_view, source_buffer
+
+
+def show_global_error(widget: Gtk.Widget, message: str):
+    """Display a global error message using the main window's error banner.
+
+    Args:
+    ----
+        widget: A Gtk.Widget (typically 'self' from a page object) to get the native window.
+        message: The error message string to display.
+    """
+    try:
+        main_window = widget.get_native()
+        if main_window and hasattr(main_window, 'show_error'):
+            main_window.show_error(message)
+            logger.error(f"Global error displayed via main window: {message}")
+        else:
+            logger.warning(
+                "Could not find main window or show_error method to display global error: %s",
+                message
+            )
+    except Exception as e: # pylint: disable=broad-except
+        logger.exception(
+            "An unexpected error occurred while trying to show global error '%s': %s",
+            message, e
+        )
+
+
+def show_global_toast(
+    widget: Gtk.Widget,
+    message: str,
+    timeout: int = 2,
+    priority: Adw.ToastPriority = Adw.ToastPriority.NORMAL
+):
+    """Display a global toast message using the main window's toast overlay.
+
+    Args:
+    ----
+        widget: A Gtk.Widget (typically 'self' from a page object) to get the native window.
+        message: The toast message string to display.
+        timeout: Duration in seconds for the toast to be visible. Defaults to 2.
+        priority: The priority of the toast. Defaults to Adw.ToastPriority.NORMAL.
+    """
+    try:
+        main_window = widget.get_native()
+        if main_window and hasattr(main_window, 'show_toast'):
+            main_window.show_toast(message, priority=priority, timeout=timeout)
+            logger.info(f"Global toast shown via main window: {message}")
+        else:
+            logger.warning(
+                "Could not find main window or show_toast method to display global toast: %s",
+                message
+            )
+    except Exception as e: # pylint: disable=broad-except
+        logger.exception(
+            "An unexpected error occurred while trying to show global toast '%s': %s",
+            message, e
+        )

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -13,6 +13,7 @@ import gi
 from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, GtkSource # Added Gdk and GtkSource
 
 from .constants import RESOURCE_PREFIX
+from .utils import show_global_error, show_global_toast
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -143,21 +144,23 @@ class WebScanPage(Adw.PreferencesPage):
             re.IGNORECASE,
         )
         if not target_url:
+            # Attempt to show a toast.
+            show_global_toast(self, "Target URL cannot be empty.")
+            # If the toast mechanism itself isn't available (e.g., no main_window or show_toast method),
+            # the original code would fall back to _show_main_banner_error.
+            # We replicate this by calling show_global_error under the same conditions.
             main_window = self.get_native()
-            if main_window and hasattr(main_window, 'show_toast'):
-                main_window.show_toast("Target URL cannot be empty.")
-            else:
-                logger.warning("Could not find main window or show_toast method for empty Webscan URL toast.")
-                self._show_main_banner_error("Target URL cannot be empty.")
+            if not (main_window and hasattr(main_window, 'show_toast')):
+                show_global_error(self, "Target URL cannot be empty.")
             return
 
         if not url_pattern.match(target_url):
+            # Attempt to show a toast.
+            show_global_toast(self, "Invalid URL format. Please enter a valid URL.")
+            # Fallback to error banner if the toast mechanism isn't available.
             main_window = self.get_native()
-            if main_window and hasattr(main_window, 'show_toast'):
-                main_window.show_toast("Invalid URL format. Please enter a valid URL.")
-            else:
-                logger.warning("Could not find main window or show_toast method for invalid Webscan URL toast.")
-                self._show_main_banner_error("Invalid URL format. Please enter a valid URL.")
+            if not (main_window and hasattr(main_window, 'show_toast')):
+                show_global_error(self, "Invalid URL format. Please enter a valid URL.")
             return
 
         buffer = self.results_textview.get_buffer()
@@ -313,17 +316,17 @@ class WebScanPage(Adw.PreferencesPage):
             if error_type == "FileNotFoundError":
                 logger.exception("Nikto command not found. Ensure it's in PATH.")
                 user_message = "Nikto command not found. Please ensure Nikto is installed and in your system's PATH."
-                self._show_main_banner_error(user_message)
+                show_global_error(self, user_message)
                 self._update_textview("", f"Error: {user_message}")
             elif error_type == "TimeoutExpired":
                 logger.exception(f"Nikto scan for {target_url} timed out.")
                 user_message = f"Scan for {target_url} timed out after 5 minutes."
-                self._show_main_banner_error(user_message)
+                show_global_error(self, user_message)
                 self._update_textview("", f"Error: {user_message}")
             elif error_type == "Exception":
                 logger.exception(f"An unexpected error occurred during Nikto scan task for {target_url}:")
                 user_message = "An unexpected error occurred during the scan. Please check the application logs for more details."
-                self._show_main_banner_error(user_message)
+                show_global_error(self, user_message)
                 self._update_textview("", user_message)
             else:
                 self._update_textview(stdout, stderr_or_error_msg)
@@ -331,7 +334,7 @@ class WebScanPage(Adw.PreferencesPage):
         except GLib.Error:
             logger.exception(f"GLib.Error during scan task finalization for {target_url}:")
             user_message = "A task finalization error occurred. Please check the application logs for more details."
-            self._show_main_banner_error(user_message)
+            show_global_error(self, user_message)
             self._update_textview("", user_message)
         finally:
             self.scan_button.set_sensitive(True)
@@ -360,22 +363,6 @@ class WebScanPage(Adw.PreferencesPage):
         scroll_adj = self.results_textview.get_parent().get_vadjustment()
         if scroll_adj:
             scroll_adj.set_value(scroll_adj.get_upper() - scroll_adj.get_page_size())
-
-    def _show_main_banner_error(self, message: str):
-        """Display an error message in the main window's error banner.
-
-        Args:
-        ----
-            message: The error message to display.
-
-        """
-        logger.error("Displaying error: %s", message)
-        main_window = self.get_native()
-        if main_window and hasattr(main_window, 'show_error'):
-            main_window.show_error(message)
-        else:
-            logger.warning("Could not find main window or show_error method to display: %s", message)
-
 
     def trigger_scan(self):
         """Programmatically triggers the WebScan 'Scan' action.


### PR DESCRIPTION
This commit introduces notification utilities in `src/utils.py` (`show_global_error`, `show_global_toast`) and refactors page modules (`webscan_page.py`, `dns_page.py`, `http_page.py`, `nmap_page.py`) to use them.

Changes include:
- Added `show_global_error` and `show_global_toast` to `utils.py` to handle interactions with the main window's error banner and toasts, including logging.
- Removed page-specific local error display methods (e.g., `_show_main_banner_error`, `_display_error`, `_show_error`) from the page classes.
- Updated callsites in these pages to use the new utility functions, passing `self` (the page instance) as the widget context.
- Streamlined logging related to notifications, as it's now handled within the utility functions.
- Page-specific `_clear_error` methods were generally kept if they handled more than just hiding the global banner (e.g., CSS class removal on input fields).

This refactoring reduces code duplication, improves consistency in how notifications are displayed, and centralizes the notification logic for easier maintenance.