### PR TITLE
Refactor: Centralize input validation logic

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -1,7 +1,7 @@
 """Defines the DNS lookup page for the Woes application."""
 import logging
 logger = logging.getLogger(__name__)
-import re
+import re # Keep for existing _is_valid_ip_or_domain if not fully replaced by utils initially
 
 import dns.resolver
 import dns.reversename
@@ -12,7 +12,7 @@ from gi.repository import Adw, Gio, Gtk, Pango, GObject
 from typing import Tuple, Sequence, Any, List, Dict
 
 from .constants import APP_ID, RESOURCE_PREFIX
-from .utils import show_global_error, show_global_toast
+from .utils import show_global_error, show_global_toast, is_valid_ip, is_valid_domain
 
 
 gi.require_version("Adw", "1")
@@ -70,48 +70,15 @@ class DNSPage(Adw.PreferencesPage):
         except Exception: # pylint: disable=broad-except
             logger.exception("Error copying to clipboard:")
 
-
-    def _is_ip_address(self, input_str: str) -> bool:
-        """Check if the input string is a valid IP address (IPv4 or IPv6).
-
-        Args:
-        ----
-            input_str: The string to check.
-
-        Returns:
-        -------
-            True if the string is a valid IP address, False otherwise.
-
-        """
-        try:
-            dns.reversename.from_address(input_str)
-            return True
-        except dns.exception.SyntaxError:
-            return False
+    # _is_ip_address method is removed. Callsites will use utils.is_valid_ip.
 
     def _is_valid_ip_or_domain(self, input_str: str) -> bool:
-        """Validate whether the input string is a syntactically valid IP address or domain name.
-
-        Args:
-        ----
-            input_str: The string to validate.
-
-        Returns:
-        -------
-            True if the string is a valid IP address or domain name, False otherwise.
-
+        """Validate whether the input string is a syntactically valid IP address or domain name
+        using utility functions.
         """
-        # Basic regex for IPv4, not covering all edge cases but good for quick check.
-        # For more robust validation, specific libraries might be better but this is for UI feedback.
-        ip_pattern = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
-        # Basic domain pattern: starts with a letter or digit, can contain hyphens (not at start/end),
-        # and ends with a TLD of at least 2 letters.
-        domain_pattern = re.compile(
-            r"^(?=.{1,253}$)(?!-)([A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,63}$"
-        )
-        is_ip = bool(ip_pattern.match(input_str))
-        is_domain = bool(domain_pattern.match(input_str))
-        return is_ip or is_domain
+        if not input_str: # Utility functions also check for empty, but good to be explicit.
+            return False
+        return is_valid_ip(input_str) or is_valid_domain(input_str)
 
     def _on_entry_activated(self, _widget: Gtk.Widget):
         """Handle DNS entry activation (e.g., pressing Enter or clicking Apply).
@@ -176,7 +143,7 @@ class DNSPage(Adw.PreferencesPage):
         """
         logger.debug(f"Fetching DNS records for: {user_input}, type: {requested_record_type}")
         actual_record_type = requested_record_type
-        if self._is_ip_address(user_input):
+        if is_valid_ip(user_input): # Use new util function
             actual_record_type = "PTR"  # Override to PTR for IP addresses
 
         parsed_records = self._lookup_record(user_input, actual_record_type, resolver)
@@ -208,7 +175,7 @@ class DNSPage(Adw.PreferencesPage):
 
         self._clear_error() # Clears banner and CSS error class
 
-        if not self._is_valid_ip_or_domain(user_input):
+        if not self._is_valid_ip_or_domain(user_input): # This now uses new utils
             show_global_toast(self, "Invalid IP address or domain name.")
             main_window = self.get_native() # Still need to check for fallback condition
             if not (main_window and hasattr(main_window, 'show_toast')):
@@ -227,7 +194,7 @@ class DNSPage(Adw.PreferencesPage):
             )
 
             # If an IP was given, _fetch_dns_records used PTR. Update dropdown to reflect this.
-            if self._is_ip_address(user_input) and actual_type_used == "PTR":
+            if is_valid_ip(user_input) and actual_type_used == "PTR": # Use new util function
                 model = self.dns_record_type_dropdown.get_model()
                 for i in range(model.get_n_items()):
                     if model.get_string(i) == "PTR":
@@ -239,17 +206,14 @@ class DNSPage(Adw.PreferencesPage):
         except dns.resolver.NXDOMAIN:
             show_global_error(self, f"Domain not found: {user_input} (NXDOMAIN)")
         except dns.resolver.NoAnswer:
-            # For NoAnswer, we want to display this information in the results area, not as an error banner.
-            # _display_result will handle showing "No records found".
-            # We pass an empty list to _display_result.
             logger.info("No %s records found for %s (NoAnswer).", requested_record_type, user_input)
             self._display_result([], user_input, requested_record_type, resolver.nameservers if hasattr(resolver, 'nameservers') else ["System default"])
         except dns.resolver.Timeout:
             show_global_error(self, f"DNS query timed out for {user_input}")
-        except dns.exception.DNSException as e:  # Catch other DNS-specific exceptions
+        except dns.exception.DNSException as e:
             logger.exception("DNS lookup failed for %s, type %s:", user_input, requested_record_type)
             show_global_error(self, f"DNS Error: {str(e)}")
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             logger.exception(
                 "Unexpected error during DNS lookup for %s, type %s:",
                 user_input,
@@ -262,13 +226,7 @@ class DNSPage(Adw.PreferencesPage):
                 self.dns_lookup_spinner.set_visible(False)
 
     def _get_selected_record_type(self) -> str:
-        """Get the currently selected DNS record type from the dropdown.
-
-        Returns
-        -------
-            The selected record type as a string (e.g., "A", "MX").
-
-        """
+        """Get the currently selected DNS record type from the dropdown."""
         model = self.dns_record_type_dropdown.get_model()
         selected_index = self.dns_record_type_dropdown.get_selected()
         return model.get_string(selected_index)
@@ -284,58 +242,30 @@ class DNSPage(Adw.PreferencesPage):
 
     @staticmethod
     def _lookup_record(domain_or_ip: str, record_type_str: str, resolver: dns.resolver.Resolver) -> List[Dict[str, Any]]:
-        """Look up DNS records using the provided resolver and parse them.
-
-        Args:
-        ----
-            domain_or_ip: The domain name or IP address to query.
-            record_type_str: The DNS record type string (e.g., "A", "MX", "PTR").
-            resolver: The DNS resolver instance.
-
-        Returns:
-        -------
-            A list of dictionaries, where each dictionary represents a parsed DNS record.
-
-        Raises:
-        ------
-            dns.resolver.NXDOMAIN: If the domain does not exist.
-            dns.resolver.NoAnswer: If no records of the requested type exist.
-            dns.resolver.Timeout: If the query times out.
-            dns.exception.DNSException: For other DNS-related errors.
-
-        """
-        # Let DNSExceptions propagate
+        """Look up DNS records using the provided resolver and parse them."""
         if record_type_str == "PTR":
             query_name = dns.reversename.from_address(domain_or_ip)
         else:
             query_name = domain_or_ip
 
         answer = resolver.resolve(query_name, record_type_str)
-
         parsed_records: List[Dict[str, Any]] = []
         for rdata in answer:
             record: Dict[str, Any] = {
                 'name': answer.qname.to_text(),
-                'ttl': rdata.ttl if hasattr(rdata, 'ttl') else answer.response.answer[0].ttl,  # SOA might not have ttl on rdata itself
+                'ttl': rdata.ttl if hasattr(rdata, 'ttl') else answer.response.answer[0].ttl,
                 'class': dns.rdataclass.to_text(rdata.rdclass),
                 'type': dns.rdatatype.to_text(rdata.rdtype)
             }
-
-            if rdata.rdtype == dns.rdatatype.A:
-                record['address'] = rdata.address
-            elif rdata.rdtype == dns.rdatatype.AAAA:
-                record['address'] = rdata.address
-            elif rdata.rdtype == dns.rdatatype.CNAME:
-                record['target'] = rdata.target.to_text()
+            if rdata.rdtype == dns.rdatatype.A: record['address'] = rdata.address
+            elif rdata.rdtype == dns.rdatatype.AAAA: record['address'] = rdata.address
+            elif rdata.rdtype == dns.rdatatype.CNAME: record['target'] = rdata.target.to_text()
             elif rdata.rdtype == dns.rdatatype.MX:
                 record['preference'] = rdata.preference
                 record['exchange'] = rdata.exchange.to_text()
-            elif rdata.rdtype == dns.rdatatype.TXT:
-                record['texts'] = [s.decode('utf-8', 'replace') for s in rdata.strings]  # Assuming strings are UTF-8
-            elif rdata.rdtype == dns.rdatatype.NS:
-                record['target'] = rdata.target.to_text()
-            elif rdata.rdtype == dns.rdatatype.PTR:
-                record['target'] = rdata.target.to_text()
+            elif rdata.rdtype == dns.rdatatype.TXT: record['texts'] = [s.decode('utf-8', 'replace') for s in rdata.strings]
+            elif rdata.rdtype == dns.rdatatype.NS: record['target'] = rdata.target.to_text()
+            elif rdata.rdtype == dns.rdatatype.PTR: record['target'] = rdata.target.to_text()
             elif rdata.rdtype == dns.rdatatype.SOA:
                 record['mname'] = rdata.mname.to_text()
                 record['rname'] = rdata.rname.to_text()
@@ -344,76 +274,34 @@ class DNSPage(Adw.PreferencesPage):
                 record['retry'] = rdata.retry
                 record['expire'] = rdata.expire
                 record['minimum'] = rdata.minimum
-            else:
-                record['data'] = rdata.to_text()  # For unhandled types
-
+            else: record['data'] = rdata.to_text()
             parsed_records.append(record)
         return parsed_records
 
     def _display_result(self, result_records: List[Dict[str, Any]], domain_or_ip: str, record_type: str, dns_servers: Sequence[Any]):
-        """Display the DNS lookup results in the UI.
-
-        Args:
-        ----
-            result_records: The list of parsed DNS record dictionaries.
-            domain_or_ip: The domain or IP that was queried.
-            record_type: The record type used for the query.
-            dns_servers: A list of DNS servers that were used.
-
-        """
-        logger.debug(
-            "Displaying %d results for %s (type %s) using servers %s.",
-            len(result_records), domain_or_ip, record_type, dns_servers
-        )
-        logger.info(
-            "Query for %s, type %s, using servers %s, returned %d records.",
-            domain_or_ip,
-            record_type,
-            dns_servers,
-            len(result_records)
-        )
-        for rec in result_records:
-            logger.debug("Record: %s", rec)
-
-
-        while (child := self.dns_results_box_container.get_first_child()):
-            self.dns_results_box_container.remove(child)
-
-
-        query_info_row = Adw.ActionRow(
-            title=f"Query: {domain_or_ip}",
-            subtitle=f"Record type queried: {record_type}"
-        )
+        """Display the DNS lookup results in the UI."""
+        logger.debug("Displaying %d results for %s (type %s) using servers %s.", len(result_records), domain_or_ip, record_type, dns_servers)
+        logger.info("Query for %s, type %s, using servers %s, returned %d records.", domain_or_ip, record_type, dns_servers, len(result_records))
+        for rec in result_records: logger.debug("Record: %s", rec)
+        while (child := self.dns_results_box_container.get_first_child()): self.dns_results_box_container.remove(child)
+        query_info_row = Adw.ActionRow(title=f"Query: {domain_or_ip}", subtitle=f"Record type queried: {record_type}")
         query_info_row.set_selectable(False)
         self.dns_results_box_container.append(query_info_row)
-
-        servers_info_row = Adw.ActionRow(
-            title="DNS Servers Used",
-            subtitle=", ".join(map(str, dns_servers)) if dns_servers else "System default"
-        )
+        servers_info_row = Adw.ActionRow(title="DNS Servers Used", subtitle=", ".join(map(str, dns_servers)) if dns_servers else "System default")
         servers_info_row.set_selectable(False)
         self.dns_results_box_container.append(servers_info_row)
-
         self.dns_results_box_container.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
-
         if not result_records:
             no_records_message = f"No {record_type} records found for {domain_or_ip}."
-            if record_type == "PTR" and self._is_ip_address(domain_or_ip): # More specific for reverse lookups
-                 no_records_message = f"No PTR records found for IP address {domain_or_ip}."
-            elif record_type == "PTR": # Generic PTR if input wasn't an IP for some reason
-                 no_records_message = f"No PTR records found for {domain_or_ip}."
-
+            if record_type == "PTR" and is_valid_ip(domain_or_ip): no_records_message = f"No PTR records found for IP address {domain_or_ip}."
+            elif record_type == "PTR": no_records_message = f"No PTR records found for {domain_or_ip}."
             no_records_row = Adw.ActionRow(title=no_records_message)
             no_records_row.set_selectable(False)
             self.dns_results_box_container.append(no_records_row)
             return
-
         for record_data in result_records:
             row = self._create_record_row(record_data)
-            if row:
-                self.dns_results_box_container.append(row)
-
-    # --- Start of new helper methods for _create_record_row ---
+            if row: self.dns_results_box_container.append(row)
 
     def _build_address_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ActionRow:
         """Builds a UI row for A or AAAA DNS records."""
@@ -421,16 +309,13 @@ class DNSPage(Adw.PreferencesPage):
         row.add_prefix(Gtk.Image(icon_name="network-wired-symbolic"))
         address_value = str(record_data.get('address', 'N/A'))
         address_label = Gtk.Label(label=address_value, halign=Gtk.Align.START, selectable=True)
-
         copy_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_button.set_valign(Gtk.Align.CENTER)
         copy_button.set_tooltip_text(f"Copy Address: {address_value}")
         copy_button.connect("clicked", lambda _btn, text=address_value, w=row: DNSPage._copy_to_clipboard(text, w))
-
         suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         suffix_box.append(address_label)
         suffix_box.append(copy_button)
-
         summary_a = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {address_value}"
         copy_full_button_a = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_full_button_a.set_valign(Gtk.Align.CENTER)
@@ -445,23 +330,18 @@ class DNSPage(Adw.PreferencesPage):
         """Builds a UI row for CNAME, NS, or PTR DNS records."""
         row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type}, {base_subtitle}")
         icon_name = "emblem-shared-symbolic"
-        if record_type == "NS":
-            icon_name = "network-server-symbolic"
-        elif record_type == "PTR":
-            icon_name = "system-search-symbolic"
+        if record_type == "NS": icon_name = "network-server-symbolic"
+        elif record_type == "PTR": icon_name = "system-search-symbolic"
         row.add_prefix(Gtk.Image(icon_name=icon_name))
         target_value = str(record_data.get('target', 'N/A'))
         target_label = Gtk.Label(label=target_value, halign=Gtk.Align.START, selectable=True)
-
         copy_button_target = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_button_target.set_valign(Gtk.Align.CENTER)
         copy_button_target.set_tooltip_text(f"Copy Target: {target_value}")
         copy_button_target.connect("clicked", lambda _btn, text=target_value, w=row: DNSPage._copy_to_clipboard(text, w))
-
         suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         suffix_box.append(target_label)
         suffix_box.append(copy_button_target)
-
         summary_cname_ns_ptr = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {target_value}"
         copy_full_button_cname = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_full_button_cname.set_valign(Gtk.Align.CENTER)
@@ -474,27 +354,22 @@ class DNSPage(Adw.PreferencesPage):
 
     def _build_mx_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow:
         """Builds a UI row for MX DNS records."""
-        # record_type param is not strictly needed here if we assume it's "MX", but kept for consistency
         row = Adw.ExpanderRow(title=name, subtitle=f"MX Record ({base_subtitle})")
         row.add_prefix(Gtk.Image(icon_name="mail-send-receive-symbolic"))
         exchange_value = str(record_data.get('exchange', 'N/A'))
         preference_value = str(record_data.get('preference', 'N/A'))
-
         mx_detail_row_title_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         mx_detail_row_title_box.append(Gtk.Label(label=exchange_value, halign=Gtk.Align.START, selectable=True))
-
         copy_button_exchange = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_button_exchange.set_valign(Gtk.Align.CENTER)
         copy_button_exchange.set_tooltip_text(f"Copy Exchange: {exchange_value}")
         copy_button_exchange.connect("clicked", lambda _btn, text=exchange_value, w=row: DNSPage._copy_to_clipboard(text, w))
         mx_detail_row_title_box.append(copy_button_exchange)
-
         mx_detail_row = Adw.ActionRow(subtitle=f"Preference: {preference_value}")
         mx_detail_row.add_prefix(mx_detail_row_title_box)
-        mx_detail_row.set_selectable(True) # Note: inner row is selectable
+        mx_detail_row.set_selectable(True)
         row.add_row(mx_detail_row)
         row.set_expanded(True)
-
         summary_mx = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} MX {preference_value} {exchange_value}"
         copy_full_mx_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_full_mx_button.set_valign(Gtk.Align.CENTER)
@@ -505,30 +380,24 @@ class DNSPage(Adw.PreferencesPage):
 
     def _build_txt_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow:
         """Builds a UI row for TXT DNS records."""
-        # record_type param is not strictly needed here if we assume it's "TXT", but kept for consistency
         row = Adw.ExpanderRow(title=name, subtitle=f"TXT Records ({base_subtitle})")
         row.add_prefix(Gtk.Image(icon_name="document-properties-symbolic"))
         texts = record_data.get('texts', [])
-        if not texts:
-             row.add_row(Adw.ActionRow(title="No text data.", selectable=False))
+        if not texts: row.add_row(Adw.ActionRow(title="No text data.", selectable=False))
         for text_string in texts:
             text_label = Gtk.Label(label=text_string, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
-
             copy_button_segment = Gtk.Button.new_from_icon_name("content-copy-symbolic")
             copy_button_segment.set_valign(Gtk.Align.CENTER)
             copy_button_segment.set_tooltip_text("Copy Text Segment")
             copy_button_segment.connect("clicked", lambda _btn, text=text_string, w=row: DNSPage._copy_to_clipboard(text, w))
-
             text_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
             text_box.append(text_label)
             text_box.append(copy_button_segment)
-
             text_action_row = Adw.ActionRow()
             text_action_row.add_prefix(text_box)
             text_action_row.set_selectable(False)
             row.add_row(text_action_row)
         row.set_expanded(True) if texts else row.set_expanded(False)
-
         texts_str_summary = " ".join([f'"{s}"' for s in texts])
         summary_txt = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} TXT {texts_str_summary}"
         copy_full_txt_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
@@ -540,39 +409,24 @@ class DNSPage(Adw.PreferencesPage):
 
     def _build_soa_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow:
         """Builds a UI row for SOA DNS records."""
-        # record_type param is not strictly needed here if we assume it's "SOA", but kept for consistency
         row = Adw.ExpanderRow(title=name, subtitle=f"SOA Record ({base_subtitle})")
         row.add_prefix(Gtk.Image(icon_name="document-settings-symbolic"))
-        mname_val = str(record_data.get('mname', 'N/A'))
-        rname_val = str(record_data.get('rname', 'N/A'))
-        serial_val = str(record_data.get('serial', 'N/A'))
-        refresh_val = str(record_data.get('refresh', 'N/A'))
-        retry_val = str(record_data.get('retry', 'N/A'))
-        expire_val = str(record_data.get('expire', 'N/A'))
-        minimum_val = str(record_data.get('minimum', 'N/A'))
-
-        soa_fields = [
-            ("MNAME", mname_val), ("RNAME", rname_val), ("Serial", serial_val),
-            ("Refresh", refresh_val), ("Retry", retry_val), ("Expire", expire_val),
-            ("Minimum TTL", minimum_val)
-        ]
+        mname_val, rname_val, serial_val, refresh_val, retry_val, expire_val, minimum_val = (str(record_data.get(k, 'N/A')) for k in ['mname','rname','serial','refresh','retry','expire','minimum'])
+        soa_fields = [("MNAME",mname_val), ("RNAME",rname_val), ("Serial",serial_val), ("Refresh",refresh_val), ("Retry",retry_val), ("Expire",expire_val), ("Minimum TTL",minimum_val)]
         for field_name_str, field_value in soa_fields:
             field_label = Gtk.Label(label=field_value, halign=Gtk.Align.START, selectable=True)
             copy_button_field = Gtk.Button.new_from_icon_name("content-copy-symbolic")
             copy_button_field.set_valign(Gtk.Align.CENTER)
             copy_button_field.set_tooltip_text(f"Copy {field_name_str}: {field_value}")
             copy_button_field.connect("clicked", lambda _btn, text=field_value, w=row: DNSPage._copy_to_clipboard(text, w))
-
             suffix_box_soa_field = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
             suffix_box_soa_field.append(field_label)
             suffix_box_soa_field.append(copy_button_field)
-
             soa_field_row = Adw.ActionRow(title=field_name_str)
             soa_field_row.add_suffix(suffix_box_soa_field)
             soa_field_row.set_selectable(False)
             row.add_row(soa_field_row)
         row.set_expanded(True)
-
         summary_soa = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} SOA {mname_val} {rname_val} {serial_val} {refresh_val} {retry_val} {expire_val} {minimum_val}"
         copy_full_soa_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_full_soa_button.set_valign(Gtk.Align.CENTER)
@@ -587,16 +441,13 @@ class DNSPage(Adw.PreferencesPage):
         row.add_prefix(Gtk.Image(icon_name="help-question-symbolic"))
         data_value = str(record_data.get('data', 'N/A'))
         data_label = Gtk.Label(label=data_value, halign=Gtk.Align.START, selectable=True, wrap=True)
-
         copy_button_data = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_button_data.set_valign(Gtk.Align.CENTER)
         copy_button_data.set_tooltip_text(f"Copy Data: {data_value}")
         copy_button_data.connect("clicked", lambda _btn, text=data_value, w=row: DNSPage._copy_to_clipboard(text, w))
-
         suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         suffix_box.append(data_label)
         suffix_box.append(copy_button_data)
-
         summary_data = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {data_value}"
         copy_full_button_data = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         copy_full_button_data.set_valign(Gtk.Align.CENTER)
@@ -607,42 +458,25 @@ class DNSPage(Adw.PreferencesPage):
         row.set_selectable(False)
         return row
 
-    # --- End of new helper methods ---
-
     def _create_record_row(self, record_data: Dict[str, Any]) -> Gtk.Widget | None:
         """Create a UI row for a single DNS record dictionary."""
         record_type = record_data.get('type', '').upper()
         name = record_data.get('name', 'N/A')
-        ttl = record_data.get('ttl', '') # Extracted for base_subtitle, but also used in summaries
-        rd_class_str = record_data.get('class', '') # Extracted for base_subtitle, also used in summaries
-
+        ttl = record_data.get('ttl', '')
+        rd_class_str = record_data.get('class', '')
         base_subtitle = f"Class: {rd_class_str}, TTL: {ttl}"
-
-        if record_type in ("A", "AAAA"):
-            return self._build_address_record_row(record_data, name, base_subtitle, record_type)
-        elif record_type in ("CNAME", "NS", "PTR"):
-            return self._build_cname_ns_ptr_record_row(record_data, name, base_subtitle, record_type)
-        elif record_type == "MX":
-            return self._build_mx_record_row(record_data, name, base_subtitle, record_type)
-        elif record_type == "TXT":
-            return self._build_txt_record_row(record_data, name, base_subtitle, record_type)
-        elif record_type == "SOA":
-            return self._build_soa_record_row(record_data, name, base_subtitle, record_type)
-        elif record_data.get('data'): # For generic types
-            return self._build_generic_record_row(record_data, name, base_subtitle, record_type)
+        if record_type in ("A", "AAAA"): return self._build_address_record_row(record_data, name, base_subtitle, record_type)
+        elif record_type in ("CNAME", "NS", "PTR"): return self._build_cname_ns_ptr_record_row(record_data, name, base_subtitle, record_type)
+        elif record_type == "MX": return self._build_mx_record_row(record_data, name, base_subtitle, record_type)
+        elif record_type == "TXT": return self._build_txt_record_row(record_data, name, base_subtitle, record_type)
+        elif record_type == "SOA": return self._build_soa_record_row(record_data, name, base_subtitle, record_type)
+        elif record_data.get('data'): return self._build_generic_record_row(record_data, name, base_subtitle, record_type)
         else:
             logger.warning("Could not create row for unknown record_data type or missing data field: %s (Type: %s)", record_data, record_type)
             return None
 
-
     def trigger_lookup(self):
-        """Programmatically triggers the DNS 'Lookup' action.
-
-        This method is typically called by a global action/shortcut.
-        It simulates a click on the lookup button.
-        """
+        """Programmatically triggers the DNS 'Lookup' action."""
         logger.debug("DNS lookup triggered by shortcut.")
-        if self.dns_apply_button and self.dns_apply_button.get_sensitive():
-            self.dns_apply_button.clicked()
-        else:
-            logger.warning("DNS lookup button not available or not sensitive, cannot trigger lookup.")
+        if self.dns_apply_button and self.dns_apply_button.get_sensitive(): self.dns_apply_button.clicked()
+        else: logger.warning("DNS lookup button not available or not sensitive, cannot trigger lookup.")

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -7,11 +7,11 @@ It also supports using a custom DNS server for domain resolution via a custom HT
 
 # pylint: disable=too-many-lines
 import logging
-import re
+import re # Keep re for now, _ensure_scheme might use it implicitly via requests.utils or other parts.
 import ssl
 import socket  # Used by CustomDNSAdapter for IP family checks, not for patching.
 from enum import Enum
-from typing import Optional, List
+from typing import Optional, List # Keep List for other type hints if any
 
 import requests
 import requests.utils  # For urlparse, urlunparse
@@ -28,7 +28,7 @@ import gi
 from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk, Pango
 
 from .constants import RESOURCE_PREFIX, USER_AGENTS, APP_ID
-from .utils import show_global_error, show_global_toast
+from .utils import show_global_error, show_global_toast, is_valid_url
 
 
 gi.require_version("Adw", "1")
@@ -37,169 +37,60 @@ gi.require_version("Gtk", "4.0")
 try:
     import urllib3.exceptions as urllib3_exceptions
 except ImportError:
-    # If urllib3 is not available at all (should not happen with requests installed)
-    # Define dummy classes for isinstance checks to not fail.
     class _DummyUrllib3Exception(Exception):
         pass
-
-    urllib3_exceptions = type(
-        "urllib3_exceptions",
-        (),
-        {
-            "MaxRetryError": _DummyUrllib3Exception,
-            "NewConnectionError": _DummyUrllib3Exception,
-        },
-    )
+    urllib3_exceptions = type("urllib3_exceptions", (), {
+        "MaxRetryError": _DummyUrllib3Exception,
+        "NewConnectionError": _DummyUrllib3Exception,
+    })
     logging.warning("Could not import urllib3.exceptions. Connection refused detection might be limited.")
 
 
 class CustomDNSAdapter(HTTPAdapter):
-    """A custom HTTPAdapter for `requests` that enables custom DNS resolution and SNI handling.
-
-    This adapter intercepts requests to:
-    1.  Resolve the hostname using a specified custom DNS server if `dnspython` is available.
-        If resolution occurs, the request URL is internally modified to use the resolved IP address
-        for the connection, while the original hostname is saved for SNI and Host header purposes.
-    2.  Configure Server Name Indication (SNI) for HTTPS connections:
-        - If a hostname was resolved to an IP, the original hostname is used for SNI.
-        - If the request URL is already an IP address, a `default_sni` (typically from the
-          user's 'Host' header input) can be used for SNI.
-    3.  Set `assert_hostname` for `urllib3`'s connection pool to ensure the SSL certificate
-        is validated against the correct hostname (either the original or the specified SNI).
-
-    If custom DNS is not used or resolution fails, it behaves like a standard HTTPAdapter.
-    """
-
+    """A custom HTTPAdapter for `requests` that enables custom DNS resolution and SNI handling."""
     def __init__(self, *args, custom_dns_server: Optional[str] = None, default_sni: Optional[str] = None, **kwargs):
-        """Initialize the CustomDNSAdapter.
-
-        Args:
-        ----
-            *args: Positional arguments to pass to the parent HTTPAdapter.
-            custom_dns_server: IP address of the custom DNS server. If None, or if `dns` (dnspython)
-                               module is unavailable, system DNS will be used.
-            default_sni: The hostname to use for SNI and certificate validation if the request URL
-                         is already an IP address. This is typically derived from the user's
-                         'Host' header input.
-            **kwargs: Keyword arguments to pass to the parent HTTPAdapter.
-
-        """
         self.custom_dns_server = custom_dns_server
         self.default_sni_for_ip_url = default_sni
-        self._resolved_sni: Optional[str] = None  # SNI derived from hostname resolution by this adapter.
+        self._resolved_sni: Optional[str] = None
         self.resolved_ip_cache = {}
         super().__init__(*args, **kwargs)
 
     def _resolve_hostname_to_ip(self, hostname: str) -> Optional[str]:
-        """Resolve a hostname using the custom DNS server.
-
-        Attempts to resolve AAAA records first, then A records.
-
-        Args:
-        ----
-            hostname: The hostname to resolve.
-
-        Returns:
-        -------
-            The first resolved IP address (preferring IPv6) as a string, or None if
-            resolution fails, custom DNS is not configured, or `dnspython` is unavailable.
-
-        """
         if not self.custom_dns_server or not dns:
-            logger.debug(
-                "CustomDNSAdapter: Skipping custom DNS (server: %s, dnspython available: %s) for %s.",
-                self.custom_dns_server,
-                bool(dns),
-                hostname,
-            )
+            logger.debug("CustomDNSAdapter: Skipping custom DNS for %s.", hostname)
             return None
-
-        logger.info(
-            "CustomDNSAdapter: Attempting to resolve '%s' using DNS server %s", hostname, self.custom_dns_server
-        )
+        logger.info("CustomDNSAdapter: Attempting to resolve '%s' using DNS server %s", hostname, self.custom_dns_server)
         resolver = dns.resolver.Resolver()
         resolver.nameservers = [self.custom_dns_server]
-        resolver.timeout = 2.0  # Short timeout for DNS resolution
-        resolver.lifetime = 2.0  # Total time for resolution attempt including retries
-
+        resolver.timeout = 2.0
+        resolver.lifetime = 2.0
         ips: list[str] = []
         try:
-            for rdtype in ("AAAA", "A"):  # Prefer AAAA (IPv6) if available
+            for rdtype in ("AAAA", "A"):
                 try:
                     answers = resolver.resolve(hostname, rdtype)
-                    for rdata in answers:
-                        ips.append(rdata.address)
-                    if ips:  # Found records of the current type
-                        break
+                    for rdata in answers: ips.append(rdata.address)
+                    if ips: break
                 except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-                    logger.debug(
-                        "CustomDNSAdapter: No %s records found for %s via %s.", rdtype, hostname, self.custom_dns_server
-                    )
+                    logger.debug("CustomDNSAdapter: No %s records for %s via %s.", rdtype, hostname, self.custom_dns_server)
                 except dns.exception.DNSException as e:
-                    logger.warning(
-                        "CustomDNSAdapter: DNS %s query for %s via %s failed: %s",
-                        rdtype,
-                        hostname,
-                        self.custom_dns_server,
-                        e,
-                    )
-
+                    logger.warning("CustomDNSAdapter: DNS %s query for %s via %s failed: %s", rdtype, hostname, self.custom_dns_server, e)
             if ips:
                 selected_ip = ips[0]
-                logger.info(
-                    "CustomDNSAdapter: Resolved '%s' to %s (using %s).", hostname, selected_ip, self.custom_dns_server
-                )
+                logger.info("CustomDNSAdapter: Resolved '%s' to %s (using %s).", hostname, selected_ip, self.custom_dns_server)
                 return selected_ip
-            logger.warning(
-                "CustomDNSAdapter: No AAAA or A records found for %s via %s.", hostname, self.custom_dns_server
-            )
-        except Exception as e:  # pylint: disable=broad-except
-            logger.error(
-                "CustomDNSAdapter: Unexpected error during custom DNS resolution for %s: %s", hostname, e, exc_info=True
-            )
+            logger.warning("CustomDNSAdapter: No AAAA or A records for %s via %s.", hostname, self.custom_dns_server)
+        except Exception as e:
+            logger.error("CustomDNSAdapter: Unexpected error during DNS resolution for %s: %s", hostname, e, exc_info=True)
         return None
 
-    def send(
-        self,
-        request: requests.models.PreparedRequest,
-        stream: bool = False,
-        timeout: Optional[float] = None,
-        verify: bool = True,
-        cert: Optional[tuple[str, str] | str] = None,
-        proxies=None,
-    ):
-        """Override HTTPAdapter.send method.
-
-        This method is called by `requests.Session` to send a `PreparedRequest`.
-        It performs custom DNS resolution if applicable before the request is actually sent.
-        If a hostname is resolved to an IP:
-        - The `request.url` is updated to use the IP for the connection.
-        - `self._resolved_sni` is set to the original hostname for SNI and cert validation.
-        The Host header in `request.headers` should remain the original hostname.
-
-        Args:
-        ----
-            request: The `PreparedRequest` to send.
-            stream: Whether to stream the response content.
-            timeout: Request timeout.
-            verify: Whether to verify SSL certificates.
-            cert: Client-side certificate.
-            proxies: Proxies to use for the request.
-
-        Returns:
-        -------
-            The response from `super().send()`.
-
-        """
+    def send(self, request: requests.models.PreparedRequest, stream: bool = False, timeout: Optional[float] = None, verify: bool = True, cert: Optional[tuple[str, str] | str] = None, proxies=None):
         parsed_url = requests.utils.urlparse(request.url)
         original_hostname = parsed_url.hostname
-        self._resolved_sni = None  # Reset for each request
-
-        # Determine if the original hostname in the URL is already an IP address.
+        self._resolved_sni = None
         is_original_hostname_ip = False
         if original_hostname:
             try:
-                # Check if it's a valid IP address (IPv4 or IPv6)
                 socket.inet_pton(socket.AF_INET, original_hostname)
                 is_original_hostname_ip = True
             except socket.error:
@@ -208,178 +99,74 @@ class CustomDNSAdapter(HTTPAdapter):
                     is_original_hostname_ip = True
                 except socket.error:
                     is_original_hostname_ip = False
-
         if original_hostname and not is_original_hostname_ip and self.custom_dns_server and dns:
             resolved_ip = self._resolve_hostname_to_ip(original_hostname)
             if resolved_ip:
-                # Store original hostname for SNI and certificate validation
                 self._resolved_sni = original_hostname
                 self.resolved_ip_cache[original_hostname] = resolved_ip
-
-                # request.url is NOT modified here.
-                # The resolved IP will be used by get_connection.
-                logger.info(
-                    "CustomDNSAdapter.send: Original request URL %s will be used. Connection will target resolved IP %s (SNI will be: %s)",
-                    request.url, # This is still the original URL
-                    resolved_ip,
-                    self._resolved_sni,
-                )
-
-        # The actual SNI value to be used by init_poolmanager is determined there based on
-        # self._resolved_sni or self.default_sni_for_ip_url.
+                logger.info("CustomDNSAdapter.send: Original URL %s. Connection to IP %s (SNI: %s)", request.url, resolved_ip, self._resolved_sni)
         return super().send(request, stream, timeout, verify, cert, proxies)
 
     def get_connection(self, url: str, proxies=None):
-        # url here is the original request.url
         parsed_url = requests.utils.urlparse(url)
         original_hostname = parsed_url.hostname
-
         resolved_ip_for_connection = None
-        # Check cache only if custom DNS is enabled for this adapter instance and dnspython is available
         if self.custom_dns_server and dns and original_hostname and original_hostname in self.resolved_ip_cache:
             resolved_ip_for_connection = self.resolved_ip_cache[original_hostname]
-
         if resolved_ip_for_connection:
-            logger.info(
-                "CustomDNSAdapter.get_connection: Using resolved IP %s for connection to original host %s (URL: %s)",
-                resolved_ip_for_connection,
-                original_hostname,
-                url
-            )
-
-            conn_url_parts = list(parsed_url[:]) # Make a mutable copy
+            logger.info("CustomDNSAdapter.get_connection: Using resolved IP %s for host %s (URL: %s)", resolved_ip_for_connection, original_hostname, url)
+            conn_url_parts = list(parsed_url[:])
             new_netloc = resolved_ip_for_connection
-            if parsed_url.port:
-                new_netloc += f":{parsed_url.port}"
-            conn_url_parts[1] = new_netloc # Index 1 is 'netloc'
-
-            # Ensure scheme is present for urlunparse
-            if not conn_url_parts[0]: # If scheme is empty
-                conn_url_parts[0] = "https" if parsed_url.scheme == "https" else "http"
-
+            if parsed_url.port: new_netloc += f":{parsed_url.port}"
+            conn_url_parts[1] = new_netloc
+            if not conn_url_parts[0]: conn_url_parts[0] = "https" if parsed_url.scheme == "https" else "http"
             connection_target_url = requests.utils.urlunparse(conn_url_parts)
-
-            logger.debug(
-                "CustomDNSAdapter.get_connection: PoolManager will connect to IP-based URL: %s (SNI via _resolved_sni: %s)",
-                connection_target_url,
-                self._resolved_sni
-            )
-            # self._resolved_sni (original hostname) is set in send()
-            # init_poolmanager uses _resolved_sni to set server_hostname for new pools.
+            logger.debug("CustomDNSAdapter.get_connection: PoolManager to connect to: %s (SNI: %s)", connection_target_url, self._resolved_sni)
             return self.poolmanager.connection_from_url(connection_target_url)
-        else:
-            logger.debug(
-                "CustomDNSAdapter.get_connection: Proceeding with default connection for URL: %s. Cache miss or custom DNS not used for this host.", url
-            )
-            return super().get_connection(url, proxies=proxies)
+        logger.debug("CustomDNSAdapter.get_connection: Default connection for URL: %s.", url)
+        return super().get_connection(url, proxies=proxies)
 
     def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs):
-        """Initialize the `urllib3.PoolManager`.
-
-        This method is overridden to inject SNI (Server Name Indication) and
-        `assert_hostname` parameters into the pool's keyword arguments if:
-        1.  A hostname was resolved to an IP by this adapter (`self._resolved_sni` is set).
-            In this case, the original hostname is used for SNI and certificate validation.
-        2.  The original request URL was an IP address and `self.default_sni_for_ip_url` was provided
-            (e.g., from a user-supplied 'Host' header). This value is then used.
-
-        Args:
-        ----
-            connections: The number of urllib3 connection pools to cache.
-            maxsize: The maximum number of connections to save in the pool.
-            block: Whether to block when no free connections are available.
-            **pool_kwargs: Additional keyword arguments to pass to the PoolManager.
-
-        """
         sni_hostname_for_pool = None
         if self._resolved_sni:
-            # Case 1: Hostname was resolved to an IP. Use original hostname for SNI/validation.
             sni_hostname_for_pool = self._resolved_sni
-            logger.info(
-                "CustomDNSAdapter.init_poolmanager: Using SNI/assert_hostname from resolved hostname: %s",
-                sni_hostname_for_pool,
-            )
+            logger.info("CustomDNSAdapter.init_poolmanager: SNI from resolved hostname: %s", sni_hostname_for_pool)
         elif self.default_sni_for_ip_url:
-            # Case 2: Original URL was an IP, and a default SNI was provided.
-            # This is used only if _resolved_sni is not set (i.e., no DNS resolution occurred for a hostname).
-            # This implies the connection is likely being made to an IP specified in the original URL.
             sni_hostname_for_pool = self.default_sni_for_ip_url
-            logger.info("CustomDNSAdapter.init_poolmanager: Using default SNI for IP URL: %s", sni_hostname_for_pool)
-
+            logger.info("CustomDNSAdapter.init_poolmanager: Default SNI for IP URL: %s", sni_hostname_for_pool)
         if sni_hostname_for_pool:
             pool_kwargs["assert_hostname"] = sni_hostname_for_pool
-            pool_kwargs["server_hostname"] = sni_hostname_for_pool  # For SNI in modern urllib3/ssl contexts
-            pool_kwargs["cert_reqs"] = ssl.CERT_REQUIRED  # Ensure certificate validation is enforced
-            logger.debug(
-                "CustomDNSAdapter.init_poolmanager: Pool configured with SNI/assert_hostname: %s", sni_hostname_for_pool
-            )
+            pool_kwargs["server_hostname"] = sni_hostname_for_pool
+            pool_kwargs["cert_reqs"] = ssl.CERT_REQUIRED
+            logger.debug("CustomDNSAdapter.init_poolmanager: Pool configured with SNI/assert_hostname: %s", sni_hostname_for_pool)
         else:
-            logger.debug(
-                "CustomDNSAdapter.init_poolmanager: No specific SNI/assert_hostname configuration for this pool."
-            )
-
+            logger.debug("CustomDNSAdapter.init_poolmanager: No specific SNI/assert_hostname.")
         super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
-
 
 logger = logging.getLogger(__name__)
 
-
 WOES_HTTP_ERROR_DOMAIN = "woes-http-error-domain"
 
-
 class HttpErrorType(int, Enum):
-    """Enumeration of HTTP error types for Gio.Task error reporting."""
-
     TIMEOUT = 0
-    HTTP_ERROR = 1  # Covers HTTP status codes >= 400
-    CONNECTION_ERROR = 2  # Covers network issues like DNS failure, connection refused
-    REQUEST_EXCEPTION = 3  # Covers other requests.exceptions like InvalidURL
-    GENERIC_UNEXPECTED = 4  # Fallback for truly unexpected Python exceptions
-    CANCELLED = 5  # If the Gio.Task was cancelled
-
+    HTTP_ERROR = 1
+    CONNECTION_ERROR = 2
+    REQUEST_EXCEPTION = 3
+    GENERIC_UNEXPECTED = 4
+    CANCELLED = 5
 
 class HeaderItem(GObject.Object):
-    """GObject representing a single header key-value pair for the Gtk.ColumnView.
-
-    Attributes
-    ----------
-        key (str): The header name or special row key.
-        value (str): The header value or special row value.
-        is_special_row (bool): True if this item represents a special informational row
-                               (e.g., URL, status) rather than a standard HTTP header.
-
-    """
-
     key: str
     value: str
     is_special_row: bool
-
     def __init__(self, key: str, value: str, is_special_row: bool = False):
-        """Initialize a HeaderItem.
-
-        Args:
-        ----
-            key: The header name or special row key.
-            value: The header value or special row value.
-            is_special_row: True if this is a special informational row.
-
-        """
         super().__init__()
         self.key = key
         self.value = value
         self.is_special_row = is_special_row
 
-
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/http_page.ui")
 class HttpPage(Adw.PreferencesPage):
-    """Activity page for fetching and inspecting HTTP headers.
-
-    Provides UI elements for URL input, Host header, User-Agent selection,
-    Akamai Pragma toggles, and displays results in a Gtk.ColumnView.
-    Handles asynchronous fetching of headers and error display.
-    Uses CustomDNSAdapter for custom DNS resolution and SNI.
-    """
-
     __gtype_name__ = "HttpPage"
     http_entry_row = Gtk.Template.Child("http_entry_row")
     http_apply_button = Gtk.Template.Child("http_apply_button")
@@ -392,142 +179,76 @@ class HttpPage(Adw.PreferencesPage):
     copy_results_button = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
-        """Initialize the HttpPage.
-
-        Sets up UI elements from the template, initializes GSettings,
-        configures the Gtk.ColumnView for displaying headers,
-        connects signal handlers, and sets initial UI state including visual cues
-        for active overrides.
-        """
         super().__init__(**kwargs)
         logger.debug("HttpPage initialized.")
         self.current_http_task = None
         self._current_header_items = []
-        self._http_task_data_for_thread: dict = {}  # Explicitly typed for clarity
-        self._ua_title_to_value_map: dict[str, Optional[str]] = {}  # Explicitly typed
-
+        self._http_task_data_for_thread: dict = {}
+        self._ua_title_to_value_map: dict[str, Optional[str]] = {}
         self.settings = Gio.Settings(schema_id=APP_ID)
         self._header_key_color = self.settings.get_string("http-output-header-key-color")
         self._header_value_color = self.settings.get_string("http-output-header-value-color")
         self._special_row_color = self.settings.get_string("http-output-special-row-color")
-
         self.settings.connect("changed::http-output-header-key-color", self._on_color_setting_changed)
         self.settings.connect("changed::http-output-header-value-color", self._on_color_setting_changed)
         self.settings.connect("changed::http-output-special-row-color", self._on_color_setting_changed)
-
         self.header_list_store = Gio.ListStore.new(HeaderItem)
         selection_model = Gtk.MultiSelection.new(self.header_list_store)
         self.http_column_view.set_model(selection_model)
-
         if not self.http_column_view.get_columns():
             header_name_factory = self._create_factory("key")
             header_value_factory = self._create_factory("value", wrap_text=True)
-
             col_name = Gtk.ColumnViewColumn.new("Header", header_name_factory)
             col_value = Gtk.ColumnViewColumn.new("Value", header_value_factory)
             col_value.set_expand(True)
-
             self.http_column_view.append_column(col_name)
             self.http_column_view.append_column(col_value)
-
         self._connect_signals()
-        self._clear_error()  # Clear any persistent error state from previous view
-        self._hide_results()  # Initially hide results section
-
-        self._update_user_agent_model()  # Populate User-Agent dropdown
+        self._clear_error()
+        self._hide_results()
+        self._update_user_agent_model()
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._update_user_agent_model())
-
-        if self.http_apply_button:
-            self.http_apply_button.set_use_underline(True)
-
-        # Call handlers to set initial visual state for overrides based on current values
-        if self.http_host_header_row:
-            self._on_host_header_changed(self.http_host_header_row)
-        if self.http_user_agent_row:
-            self._on_user_agent_changed(self.http_user_agent_row, None)
+        if self.http_apply_button: self.http_apply_button.set_use_underline(True)
+        if self.http_host_header_row: self._on_host_header_changed(self.http_host_header_row)
+        if self.http_user_agent_row: self._on_user_agent_changed(self.http_user_agent_row, None)
 
     def _connect_signals(self) -> None:
-        """Connect signals for UI elements to their respective handlers."""
         self.http_entry_row.connect("entry-activated", self._on_entry_row_activated)
         self.http_apply_button.connect("clicked", self._on_entry_row_activated)
         self.http_pragma_switch_row.connect("notify::active", self._on_pragma_toggled)
         self.clear_results_button.connect("clicked", self._on_clear_results_clicked)
-        if self.copy_results_button:
-            self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
-
-        # Signals for visual cues on active overrides
-        if self.http_host_header_row:
-            self.http_host_header_row.connect("changed", self._on_host_header_changed)
-        if self.http_user_agent_row:
-            self.http_user_agent_row.connect("notify::selected-item", self._on_user_agent_changed)
+        if self.copy_results_button: self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
+        if self.http_host_header_row: self.http_host_header_row.connect("changed", self._on_host_header_changed)
+        if self.http_user_agent_row: self.http_user_agent_row.connect("notify::selected-item", self._on_user_agent_changed)
 
     def _on_host_header_changed(self, entry_row: Adw.EntryRow) -> None:
-        """Add or remove 'active-override' CSS class based on Host header text.
-
-        Args:
-        ----
-            entry_row: The Adw.EntryRow for the Host header.
-
-        """
-        if not entry_row:
-            return
+        if not entry_row: return
         text = entry_row.get_text().strip()
-        if text:
-            entry_row.add_css_class("active-override")
-        else:
-            entry_row.remove_css_class("active-override")
+        if text: entry_row.add_css_class("active-override")
+        else: entry_row.remove_css_class("active-override")
 
     def _on_user_agent_changed(self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]) -> None:
-        """Add or remove 'active-override' CSS class based on User-Agent selection.
-
-        The class is added if the selected User-Agent is not the default "None" option.
-
-        Args:
-        ----
-            combo_row: The Adw.ComboRow for User-Agent selection.
-            _gparam: The GObject.ParamSpec associated with the signal (unused here).
-
-        """
-        if not combo_row:
-            return
+        if not combo_row: return
         selected_item_obj = combo_row.get_selected_item()
         if isinstance(selected_item_obj, Gtk.StringObject):
             selected_title = selected_item_obj.get_string()
-            # Check if the effective UA value is non-empty (i.e., not the "None" option)
             effective_ua_value = self._ua_title_to_value_map.get(selected_title)
-            if effective_ua_value:  # An actual UA string is selected (not the one mapping to None)
-                combo_row.add_css_class("active-override")
-            else:  # "None" is selected, or title not in map
-                combo_row.remove_css_class("active-override")
+            if effective_ua_value: combo_row.add_css_class("active-override")
+            else: combo_row.remove_css_class("active-override")
         elif selected_item_obj is None and not self._ua_title_to_value_map:
-            # Handles case where model might be initially empty before _update_user_agent_model.
             combo_row.remove_css_class("active-override")
 
     def _on_copy_results_clicked(self, _button: Gtk.Button) -> None:
-        """Handle click event for the 'Copy Results' button.
-
-        Collects all displayed header items (URLs, statuses, headers), formats them as text,
-        and copies them to the clipboard.
-
-        Args:
-        ----
-            _button: The Gtk.Button that was clicked (unused).
-
-        """
         logger.info("Copying all headers to clipboard.")
         lines = []
         if self.header_list_store:
             for i in range(self.header_list_store.get_n_items()):
                 item = self.header_list_store.get_item(i)
                 if isinstance(item, HeaderItem):
-                    if item.is_special_row:  # For URL/Status rows
-                        if item.value and item.value.strip():  # If there's a value part (status)
-                            lines.append(f"{item.key} {item.value}")
-                        else:  # Just the key (URL line or separator)
-                            lines.append(item.key)
-                    else:  # For actual header rows
-                        lines.append(f"{item.key}: {item.value}")
-
+                    if item.is_special_row:
+                        if item.value and item.value.strip(): lines.append(f"{item.key} {item.value}")
+                        else: lines.append(item.key)
+                    else: lines.append(f"{item.key}: {item.value}")
         if lines:
             text_to_copy = "\n".join(lines)
             try:
@@ -535,35 +256,20 @@ class HttpPage(Adw.PreferencesPage):
                 if clipboard:
                     clipboard.set(text_to_copy)
                     logger.info("Headers copied to clipboard successfully.")
-                else:
-                    logger.warning("Failed to get default clipboard for copying.")
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error("Error copying headers to clipboard: %s", e, exc_info=True)
-        else:
-            logger.info("No headers to copy from the results view.")
+                else: logger.warning("Failed to get default clipboard for copying.")
+            except Exception as e: logger.error("Error copying headers to clipboard: %s", e, exc_info=True)
+        else: logger.info("No headers to copy from the results view.")
 
     def _on_entry_row_activated(self, _widget: Gtk.Widget) -> None:
-        """Handle activation of the URL entry row or click of the 'Fetch' button.
-
-        Initiates the process of fetching HTTP headers. Validates the URL,
-        gathers configuration from UI elements (Host header, User-Agent, etc.),
-        and starts an asynchronous task (`Gio.Task`) to perform the HTTP request.
-        UI elements are made insensitive during the fetch.
-
-        Args:
-        ----
-            _widget: The widget that triggered the activation (Adw.EntryRow or Gtk.Button, unused).
-
-        """
         original_url = self.http_entry_row.get_text().strip()
-        url = self._ensure_scheme(original_url)  # Ensure URL has a scheme (https:// by default)
+        url = self._ensure_scheme(original_url)
         logger.info("Fetching headers for URL: %s (original input: %s)", url, original_url)
 
-        if not self._is_valid_url(url):
+        if not is_valid_url(url): # Use new util function
             logger.warning("Invalid URL provided: %s (processed as: %s)", original_url, url)
             toast_message = "Invalid URL format. Please enter a valid URL (e.g., https://example.com)."
             show_global_toast(self, toast_message)
-            main_window = self.get_native() # Still need to check for fallback condition
+            main_window = self.get_native()
             if not (main_window and hasattr(main_window, "show_toast")):
                 show_global_error(self, toast_message)
             self._update_column_view_model(None)
@@ -574,137 +280,53 @@ class HttpPage(Adw.PreferencesPage):
         if hasattr(self, "http_apply_button") and self.http_apply_button:
             self.http_apply_button.set_sensitive(False)
             self.http_apply_button.set_icon_name("process-working-symbolic")
-
         host_header = self.http_host_header_row.get_text().strip()
-
-        user_agent_to_send: Optional[str] = None  # Explicitly typed
+        user_agent_to_send: Optional[str] = None
         selected_title_obj = self.http_user_agent_row.get_selected_item()
         if isinstance(selected_title_obj, Gtk.StringObject):
             selected_title = selected_title_obj.get_string()
             user_agent_to_send = self._ua_title_to_value_map.get(selected_title)
-
         custom_dns_server = self.settings.get_string("custom-dns-server")
         if custom_dns_server and dns is None:
-            logger.warning(
-                "Custom DNS server ('%s') is configured, but 'dnspython' library is not available. "
-                "Custom DNS resolution will be skipped; system DNS will be used.",
-                custom_dns_server,
-            )
-            # This warning is for logging; CustomDNSAdapter handles dns=None by falling back.
-
+            logger.warning("Custom DNS server ('%s') configured, but 'dnspython' not available.", custom_dns_server)
         self._http_task_data_for_thread = {
-            "url": url,
-            "use_akamai_pragma": self.http_pragma_switch_row.get_active(),
-            "host_header": host_header if host_header else None,  # Ensure None if empty
-            "user_agent": user_agent_to_send,  # Already Optional[str]
-            "custom_dns_server": custom_dns_server if custom_dns_server else None,  # Ensure None if empty
+            "url": url, "use_akamai_pragma": self.http_pragma_switch_row.get_active(),
+            "host_header": host_header if host_header else None, "user_agent": user_agent_to_send,
+            "custom_dns_server": custom_dns_server if custom_dns_server else None,
         }
         logger.debug(f"Starting header fetch task with data: {self._http_task_data_for_thread}")
-
         task = Gio.Task.new(self, None, self._fetch_headers_task_done_cb, None)
         self.current_http_task = task
         task.run_in_thread(self._fetch_headers_task_thread_func)
 
-    def _prepare_request_headers(
-        self, use_akamai_pragma: bool, host_header_from_input: Optional[str], user_agent: Optional[str]
-    ) -> tuple[dict[str, str], dict[str, str]]:
-        """Prepare initial request-specific headers and session-wide headers.
-
-        Args:
-        ----
-            use_akamai_pragma: Whether to include Akamai Pragma headers.
-            host_header_from_input: Custom Host header value, if any.
-            user_agent: Custom User-Agent string, if any.
-
-        Returns:
-        -------
-            A tuple containing two dictionaries:
-            - `initial_request_specific_headers`: Headers for the first request only (e.g., Host).
-            - `session_headers`: Headers to be applied to the `requests.Session` object for all requests.
-
-        """
+    def _prepare_request_headers(self, use_akamai_pragma: bool, host_header_from_input: Optional[str], user_agent: Optional[str]) -> tuple[dict[str, str], dict[str, str]]:
         initial_request_specific_headers: dict[str, str] = {}
         session_headers: dict[str, str] = {}
-
         if host_header_from_input:
             initial_request_specific_headers["Host"] = host_header_from_input
-            logger.info("Using user-provided Host header for the initial request: '%s'", host_header_from_input)
-
-        if user_agent:  # If a specific User-Agent is chosen (not "None" which maps to None value)
+            logger.info("Using user-provided Host header: '%s'", host_header_from_input)
+        if user_agent:
             session_headers["User-Agent"] = user_agent
-            logger.info("Using custom User-Agent for the session: '%s'", user_agent)
-        else:  # "None" selected or no UA preference
-            logger.info("No custom User-Agent specified; `requests` default will be used.")
-
+            logger.info("Using custom User-Agent: '%s'", user_agent)
+        else: logger.info("No custom User-Agent; `requests` default will be used.")
         if use_akamai_pragma:
-            akamai_pragma_directives = [
-                "akamai-x-get-request-id",
-                "akamai-x-get-cache-key",
-                "akamai-x-cache-on",
-                "akamai-x-cache-remote-on",
-                "akamai-x-get-true-cache-key",
-                "akamai-x-check-cacheable",
-                "akamai-x-get-extracted-values",
-                "akamai-x-feo-trace",
-                "x-akamai-logging-mode: verbose",
-            ]
-            session_headers["Pragma"] = ", ".join(akamai_pragma_directives)
-            logger.info("Akamai Pragma headers will be included in session headers.")
-        else:
-            logger.info("Akamai Pragma headers will not be included.")
-
+            directives = ["akamai-x-get-request-id", "akamai-x-get-cache-key", "akamai-x-cache-on", "akamai-x-cache-remote-on", "akamai-x-get-true-cache-key", "akamai-x-check-cacheable", "akamai-x-get-extracted-values", "akamai-x-feo-trace", "x-akamai-logging-mode: verbose"]
+            session_headers["Pragma"] = ", ".join(directives)
+            logger.info("Akamai Pragma headers included.")
+        else: logger.info("Akamai Pragma headers not included.")
         return initial_request_specific_headers, session_headers
 
-    # _configure_sni_adapter method was removed as its logic is now integrated into CustomDNSAdapter.
-
-    def _fetch_headers_task_thread_func(
-        self,
-        task: Gio.Task,
-        source_object,  # pylint: disable=unused-argument
-        task_data_arg: dict,  # pylint: disable=unused-argument
-        cancellable: Optional[Gio.Cancellable],
-    ):
-        """Perform the HTTP GET request in a separate thread via `Gio.Task`.
-
-        This method orchestrates the HTTP request by:
-        1.  Preparing headers using `_prepare_request_headers`.
-        2.  Configuring a `requests.Session` with a `CustomDNSAdapter` for custom DNS
-            resolution and SNI handling.
-        3.  Executing the request using `_execute_http_request`.
-        4.  Processing the response (including redirects and HTTP errors) using `_process_http_response`.
-
-        Exceptions during the request (Timeout, ConnectionError, etc.) are caught and
-        reported to the main thread via `task.return_new_error_literal` with an appropriate
-        `HttpErrorType` and message.
-
-        Args:
-        ----
-            task: The `Gio.Task` associated with this asynchronous operation.
-            source_object: The source object that initiated the task (unused).
-            task_data_arg: Task-specific data (unused, uses `self._http_task_data_for_thread`).
-            cancellable: A `Gio.Cancellable` object to monitor for cancellation requests.
-
-        """
-        # Retrieve task data set in _on_entry_row_activated
+    def _fetch_headers_task_thread_func(self, task: Gio.Task, source_object, task_data_arg: dict, cancellable: Optional[Gio.Cancellable]):
         current_task_data = self._http_task_data_for_thread
         url_to_fetch: str = current_task_data["url"]
         use_akamai_pragma: bool = current_task_data["use_akamai_pragma"]
         host_header_from_input: Optional[str] = current_task_data.get("host_header")
         user_agent: Optional[str] = current_task_data.get("user_agent")
         custom_dns_server: Optional[str] = current_task_data.get("custom_dns_server")
-
-        # 1. Prepare headers
-        initial_request_specific_headers, session_headers = self._prepare_request_headers(
-            use_akamai_pragma, host_header_from_input, user_agent
-        )
-
-        # 2. Configure session with CustomDNSAdapter
+        initial_request_specific_headers, session_headers = self._prepare_request_headers(use_akamai_pragma, host_header_from_input, user_agent)
         session = requests.Session()
-
         parsed_url = requests.utils.urlparse(url_to_fetch)
-        url_hostname = parsed_url.hostname or ""  # Ensure str, not None
-
-        # Determine if the URL's hostname part is already an IP address
+        url_hostname = parsed_url.hostname or ""
         is_url_direct_ip = False
         if url_hostname:
             try:
@@ -714,799 +336,302 @@ class HttpPage(Adw.PreferencesPage):
                 try:
                     socket.inet_pton(socket.AF_INET6, url_hostname)
                     is_url_direct_ip = True
-                except socket.error:
-                    is_url_direct_ip = False
-
-        # SNI hint for the adapter if the URL is an IP and a Host header is provided
+                except socket.error: is_url_direct_ip = False
         adapter_sni_hint: Optional[str] = None
         if is_url_direct_ip and host_header_from_input:
             adapter_sni_hint = host_header_from_input
-            logger.info(
-                "HttpPage: URL '%s' is IP-based and Host header '%s' provided. Passing as SNI hint to CustomDNSAdapter.",
-                url_to_fetch,
-                adapter_sni_hint,
-            )
-
-        # Use custom_dns_server only if dnspython (dns module) is available
+            logger.info("HttpPage: URL '%s' is IP-based, Host header '%s' provided. SNI hint for Adapter.", url_to_fetch, adapter_sni_hint)
         effective_custom_dns_server = custom_dns_server if dns else None
-        if custom_dns_server and not dns:  # Log if configured but unavailable
-            logger.warning(
-                "HttpPage._fetch_headers_task_thread_func: Custom DNS server ('%s') configured, "
-                "but dnspython library is missing. Adapter will use system DNS.",
-                custom_dns_server,
-            )
-
-        # Instantiate and mount the CustomDNSAdapter
-        adapter = CustomDNSAdapter(
-            custom_dns_server=effective_custom_dns_server,
-            default_sni=adapter_sni_hint,  # Used by adapter if URL is IP
-        )
+        if custom_dns_server and not dns: logger.warning("HttpPage: Custom DNS ('%s') configured, but dnspython missing.", custom_dns_server)
+        adapter = CustomDNSAdapter(custom_dns_server=effective_custom_dns_server, default_sni=adapter_sni_hint)
         session.mount("http://", adapter)
         session.mount("https://", adapter)
-        logger.info(
-            "HttpPage: CustomDNSAdapter mounted (DNS server: '%s', SNI hint for IP URL: '%s').",
-            effective_custom_dns_server,
-            adapter_sni_hint,
-        )
-
-        if session_headers:  # Apply session-wide headers (User-Agent, Pragma)
-            session.headers.update(session_headers)
-
-        # 3. Execute request and process response
+        logger.info("HttpPage: CustomDNSAdapter mounted (DNS: '%s', SNI hint: '%s').", effective_custom_dns_server, adapter_sni_hint)
+        if session_headers: session.headers.update(session_headers)
         try:
             if cancellable and cancellable.is_cancelled():
-                task.return_new_error_literal(
-                    GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
-                    HttpErrorType.CANCELLED.value,
-                    "Task was cancelled before request execution.",
-                )
+                task.return_new_error_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CANCELLED.value, "Task cancelled.")
                 return
-
-            # Core request execution
             response = self._execute_http_request(session, url_to_fetch, initial_request_specific_headers, cancellable)
-
-            # Process response (handles redirects and HTTP errors)
             processed_data = self._process_http_response(response, task, url_to_fetch)
-            if processed_data:  # If no HTTPError occurred (error not set on task by _process_http_response)
-                task.return_value(processed_data)
-            # If processed_data is None, an error was already set on the task by _process_http_response
-
+            if processed_data: task.return_value(processed_data)
         except requests.exceptions.Timeout as e:
-            logger.warning("Task thread: Timeout for URL '%s': %s", url_to_fetch, e)
-            error_message = (
-                "Request timed out. This could be due to a slow network, server issues, "
-                "or a Web Application Firewall (WAF) interfering. "
-                "Please check the URL or try again later."
-            )
-            task.return_new_error_literal(
-                GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.TIMEOUT.value, error_message
-            )
+            logger.warning("Task thread: Timeout for '%s': %s", url_to_fetch, e)
+            msg = "Request timed out. Check network, server, or WAF interference."
+            task.return_new_error_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.TIMEOUT.value, msg)
         except requests.exceptions.ConnectionError as e:
-            logger.warning("Task thread: ConnectionError for URL '%s': %s", url_to_fetch, e)
+            logger.warning("Task thread: ConnectionError for '%s': %s", url_to_fetch, e)
             custom_msg = self._get_detailed_connection_error_message(e, url_to_fetch)
-            error_message = custom_msg or (  # Use detailed message if available
-                "A network connection error occurred. Please check your internet connection "
-                "and the entered URL, then try again."
-            )
-            task.return_new_error_literal(
-                GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CONNECTION_ERROR.value, error_message
-            )
-        except requests.exceptions.RequestException as e:  # Catch other requests-related errors
-            logger.warning("Task thread: RequestException for URL '%s': %s", url_to_fetch, e)
-            error_message = (
-                f"The request could not be completed due to an issue: {e}. "
-                "Please verify the URL and your network connection."
-            )
-            task.return_new_error_literal(
-                GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.REQUEST_EXCEPTION.value, error_message
-            )
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("Task thread: Truly unexpected error during HTTP fetch for URL '%s':", url_to_fetch)
-            error_message = (
-                "An unexpected internal error occurred while processing your request. "
-                "Please try again later or report this issue if it persists."
-            )
-            task.return_new_error_literal(
-                GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.GENERIC_UNEXPECTED.value, error_message
-            )
-        # No 'finally' block for unpatching socket needed anymore due to adapter pattern.
+            msg = custom_msg or "Network connection error. Check internet and URL."
+            task.return_new_error_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.CONNECTION_ERROR.value, msg)
+        except requests.exceptions.RequestException as e:
+            logger.warning("Task thread: RequestException for '%s': %s", url_to_fetch, e)
+            msg = f"Request failed: {e}. Verify URL and network."
+            task.return_new_error_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.REQUEST_EXCEPTION.value, msg)
+        except Exception:
+            logger.exception("Task thread: Unexpected error for URL '%s':", url_to_fetch)
+            msg = "Unexpected internal error during request."
+            task.return_new_error_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.GENERIC_UNEXPECTED.value, msg)
 
-    def _execute_http_request(
-        self,
-        session: requests.Session,
-        url_to_fetch: str,
-        initial_request_headers: dict[str, str],
-        cancellable: Optional[Gio.Cancellable],
-    ) -> requests.Response:
-        """Execute the HTTP GET request using the provided session and headers.
-
-        Handles pre-request cancellation check. Network-related exceptions
-        (Timeout, ConnectionError, other RequestException) are expected to be
-        caught by the caller (`_fetch_headers_task_thread_func`).
-
-        Args:
-        ----
-            session: The configured `requests.Session` to use for the request.
-            url_to_fetch: The URL to fetch.
-            initial_request_headers: Headers specific to this initial request (e.g., Host).
-                                     These are passed directly to `session.get()`.
-            cancellable: `Gio.Cancellable` object to check for cancellation.
-
-        Returns:
-        -------
-            `requests.Response` object from `session.get()`.
-
-        Raises:
-        ------
-            requests.exceptions.RequestException: If cancelled before sending, or for other
-                                                 `requests` library issues (Timeout, ConnectionError, etc.).
-                                                 HTTPError is not raised here but handled by `_process_http_response`.
-
-        """
-        logger.info("Executing HTTP GET request to %s via configured session.", url_to_fetch)
+    def _execute_http_request(self, session: requests.Session, url_to_fetch: str, initial_request_headers: dict[str, str], cancellable: Optional[Gio.Cancellable]) -> requests.Response:
+        logger.info("Executing HTTP GET to %s.", url_to_fetch)
         if cancellable and cancellable.is_cancelled():
-            # This exception will be caught by the RequestException handler in the calling function.
-            raise requests.exceptions.RequestException("Request cancelled by user before sending.")
-
-        response = session.get(
-            url_to_fetch,
-            headers=(initial_request_headers if initial_request_headers else None),
-            allow_redirects=True,  # Allow requests to handle redirects automatically
-            timeout=5,  # Standard timeout for the request in seconds
-        )
-        # HTTPError (4xx/5xx) is not raised here; _process_http_response will handle it.
+            raise requests.exceptions.RequestException("Request cancelled before sending.")
+        response = session.get(url_to_fetch, headers=(initial_request_headers if initial_request_headers else None), allow_redirects=True, timeout=5)
         return response
 
-    def _process_http_response(
-        self, response: requests.Response, task: Gio.Task, url_being_fetched: str
-    ) -> Optional[list[dict[str, object]]]:
-        """Process the HTTP response, including redirects, and checks for HTTP errors.
-
-        If an `requests.exceptions.HTTPError` (4xx or 5xx status code) occurs on the
-        final response, this method sets an error on the `Gio.Task` and returns `None`.
-        Otherwise, it compiles a list of dictionaries containing data for each response
-        in the redirect chain and the final response.
-
-        Args:
-        ----
-            response: The final `requests.Response` object from `session.get()`.
-            task: The `Gio.Task` to set errors on if an HTTPError occurs.
-            url_being_fetched: The original URL that was fetched, for logging context.
-
-        Returns:
-        -------
-            A list of response data dictionaries if successful. Each dictionary represents
-            a response (redirect or final) and includes 'type', 'url', 'status_code',
-            and 'headers'. Returns `None` if an HTTPError occurred (error is set on the task).
-
-        """
+    def _process_http_response(self, response: requests.Response, task: Gio.Task, url_being_fetched: str) -> Optional[list[dict[str, object]]]:
         all_responses_data: list[dict[str, object]] = []
-
-        # Process redirect history
-        for hist_resp in response.history:  # response.history contains prior Response objects
-            hist_data: dict[str, object] = {
-                "type": "redirect",
-                "url": str(hist_resp.url),
-                "status_code": hist_resp.status_code,
-                "headers": {str(k): str(v) for k, v in dict(hist_resp.headers).items()},
-            }
+        for hist_resp in response.history:
+            hist_data: dict[str, object] = {"type": "redirect", "url": str(hist_resp.url), "status_code": hist_resp.status_code, "headers": {str(k): str(v) for k, v in dict(hist_resp.headers).items()}}
             all_responses_data.append(hist_data)
-
-        # Process final response - check for HTTP errors first
         try:
-            response.raise_for_status()  # Raises HTTPError for 4xx/5xx status codes
+            response.raise_for_status()
             final_data_type = "final"
         except requests.exceptions.HTTPError as http_err:
-            logger.warning("HTTPError for URL '%s': %s", url_being_fetched, http_err)
+            logger.warning("HTTPError for '%s': %s", url_being_fetched, http_err)
             error_message = self._format_http_error(http_err)
-            task.return_new_error_literal(
-                GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN),
-                HttpErrorType.HTTP_ERROR.value,
-                error_message,
-            )
-            return None  # Indicate error by returning None; task error is set.
-
-        # If no HTTPError, proceed to format final response data
-        final_data: dict[str, object] = {
-            "type": final_data_type,
-            "url": str(response.url),
-            "status_code": response.status_code,
-            "headers": {str(k): str(v) for k, v in dict(response.headers).items()},
-        }
+            task.return_new_error_literal(GLib.quark_from_string(WOES_HTTP_ERROR_DOMAIN), HttpErrorType.HTTP_ERROR.value, error_message)
+            return None
+        final_data: dict[str, object] = {"type": final_data_type, "url": str(response.url), "status_code": response.status_code, "headers": {str(k): str(v) for k, v in dict(response.headers).items()}}
         all_responses_data.append(final_data)
         return all_responses_data
 
-    def _get_detailed_connection_error_message(self, exc: Exception, url: str) -> Optional[str]:  # pylint: disable=too-many-branches,too-many-statements # noqa: C901
-        """Attempt to provide a more specific error message for connection errors.
-
-        Inspects the given exception (and its causes) to identify common patterns
-        like 'Connection refused'. If found, it suggests potential causes based on the URL scheme
-        (e.g., trying HTTP for an HTTPS site or vice-versa).
-
-        Args:
-        ----
-            exc: The connection-related exception caught (e.g., `requests.exceptions.ConnectionError`).
-            url: The URL that was being accessed.
-
-        Returns:
-        -------
-            A more specific error message string if a known pattern is matched, otherwise `None`.
-
-        """
-        current_exc: Optional[BaseException] = exc  # Type hint for clarity
+    def _get_detailed_connection_error_message(self, exc: Exception, url: str) -> Optional[str]:
+        current_exc: Optional[BaseException] = exc
         found_connection_refused = False
-        max_depth = 5  # Limit how deep we traverse exception causes
-
+        max_depth = 5
         for _depth in range(max_depth):
-            if current_exc is None:
-                break
-
-            exc_str = str(current_exc).lower()  # For case-insensitive search
-
-            # Check for direct ConnectionRefusedError or specific strings/errno in common exceptions
-            if isinstance(current_exc, ConnectionRefusedError):
-                found_connection_refused = True
-                break
+            if current_exc is None: break
+            exc_str = str(current_exc).lower()
+            if isinstance(current_exc, ConnectionRefusedError): found_connection_refused = True; break
             if isinstance(current_exc, urllib3_exceptions.NewConnectionError):
-                if "connection refused" in exc_str or "errno 111" in exc_str:
-                    found_connection_refused = True
-                    break
-                # Check original_error if present (urllib3 specific)
+                if "connection refused" in exc_str or "errno 111" in exc_str: found_connection_refused = True; break
                 if hasattr(current_exc, "original_error"):
                     original_error = getattr(current_exc, "original_error")
-                    if isinstance(original_error, ConnectionRefusedError) or (
-                        hasattr(original_error, "errno") and getattr(original_error, "errno") == 111
-                    ):
-                        found_connection_refused = True
-                        break
+                    if isinstance(original_error, ConnectionRefusedError) or (hasattr(original_error, "errno") and getattr(original_error, "errno") == 111): found_connection_refused = True; break
             if isinstance(current_exc, urllib3_exceptions.MaxRetryError):
-                # MaxRetryError often wraps NewConnectionError in its 'reason' attribute
-                if hasattr(current_exc, "reason") and isinstance(
-                    current_exc.reason, urllib3_exceptions.NewConnectionError
-                ):
+                if hasattr(current_exc, "reason") and isinstance(current_exc.reason, urllib3_exceptions.NewConnectionError):
                     reason_exc_str = str(current_exc.reason).lower()
-                    if "connection refused" in reason_exc_str or "errno 111" in reason_exc_str:
-                        found_connection_refused = True
-                        break
+                    if "connection refused" in reason_exc_str or "errno 111" in reason_exc_str: found_connection_refused = True; break
                     if hasattr(current_exc.reason, "original_error"):
                         original_error = getattr(current_exc.reason, "original_error")
-                        if isinstance(original_error, ConnectionRefusedError) or (
-                            hasattr(original_error, "errno") and getattr(original_error, "errno") == 111
-                        ):
-                            found_connection_refused = True
-                            break
-
-            # Generic check in args or string representation (less reliable)
-            if (
-                any("connection refused" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str))
-                or "connection refused" in exc_str
-            ):
-                found_connection_refused = True
-            if (
-                any("errno 111" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str))
-                or "errno 111" in exc_str
-            ):  # Errno 111 is Connection Refused on Linux
-                found_connection_refused = True
-
-            if found_connection_refused:
-                break
-
-            # Traverse to the next exception in the chain (__cause__ or __context__)
+                        if isinstance(original_error, ConnectionRefusedError) or (hasattr(original_error, "errno") and getattr(original_error, "errno") == 111): found_connection_refused = True; break
+            if (any("connection refused" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str)) or "connection refused" in exc_str): found_connection_refused = True
+            if (any("errno 111" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str)) or "errno 111" in exc_str): found_connection_refused = True
+            if found_connection_refused: break
             next_exc: Optional[BaseException] = None
-            if hasattr(current_exc, "__cause__") and current_exc.__cause__ is not None:
-                next_exc = current_exc.__cause__
-            elif (
-                hasattr(current_exc, "__context__")
-                and current_exc.__context__ is not None
-                and not getattr(current_exc, "__suppress_context__", False)  # Check __suppress_context__
-            ):
-                next_exc = current_exc.__context__
-
-            if current_exc is next_exc:  # Avoid infinite loops if somehow context is self
-                break
+            if hasattr(current_exc, "__cause__") and current_exc.__cause__ is not None: next_exc = current_exc.__cause__
+            elif (hasattr(current_exc, "__context__") and current_exc.__context__ is not None and not getattr(current_exc, "__suppress_context__", False)): next_exc = current_exc.__context__
+            if current_exc is next_exc: break
             current_exc = next_exc
-
         if found_connection_refused:
-            logger.info("Connection refused condition identified for URL: %s", url)
+            logger.info("Connection refused for URL: %s", url)
             parsed_url_scheme = requests.utils.urlparse(url).scheme
-            if parsed_url_scheme == "https":
-                return (
-                    "Connection Refused: The server at the HTTPS URL actively refused the connection. "
-                    "This might be an HTTP-only service. Consider trying with 'http://'."
-                )
-            if parsed_url_scheme == "http":
-                return (
-                    "Connection Refused: The server at the HTTP URL actively refused the connection. "
-                    "The server might only support HTTPS or be down. Consider trying with 'https://'."
-                )
-            return "Connection Error: The server at the specified URL actively refused the connection."
+            if parsed_url_scheme == "https": return "Connection Refused: Server at HTTPS URL refused. Try 'http://'?"
+            if parsed_url_scheme == "http": return "Connection Refused: Server at HTTP URL refused. Try 'https://' or server down?"
+            return "Connection Error: Server actively refused connection."
+        return None
 
-        return None  # No specific detailed message generated
-
-    def _fetch_headers_task_done_cb(self, _source_object, result: Gio.AsyncResult, _user_data):  # pylint: disable=too-many-branches,too-many-statements,unused-argument # noqa: C901
-        """Handle completion of the HTTP header fetching task.
-
-        Processes the results (a list of response data dictionaries) or errors returned
-        by the background task. Updates the UI (ColumnView for headers, error banner) accordingly.
-        Re-enables UI elements that were disabled during the fetch operation.
-
-        Args:
-        ----
-            _source_object: The object that initiated the task (HttpPage instance, unused).
-            result: A `Gio.AsyncResult` containing the task's outcome (data or error).
-            _user_data: User data passed to the callback (unused).
-
-        """
-        task_being_processed = self.current_http_task  # Get the task we stored
-
-        if task_being_processed is None:  # Should ideally not happen if task management is correct
-            logger.warning("_fetch_headers_task_done_cb: current_http_task is None. UI state might be inconsistent.")
-            # Attempt to re-enable UI elements as a fallback
-            if hasattr(self, "http_entry_row") and self.http_entry_row and not self.http_entry_row.get_sensitive():
-                self.http_entry_row.set_sensitive(True)
-            if (
-                hasattr(self, "http_apply_button")
-                and self.http_apply_button
-                and not self.http_apply_button.get_sensitive()
-            ):
+    def _fetch_headers_task_done_cb(self, _source_object, result: Gio.AsyncResult, _user_data):
+        task_being_processed = self.current_http_task
+        if task_being_processed is None:
+            logger.warning("_fetch_headers_task_done_cb: current_http_task is None.")
+            if hasattr(self, "http_entry_row") and self.http_entry_row and not self.http_entry_row.get_sensitive(): self.http_entry_row.set_sensitive(True)
+            if (hasattr(self, "http_apply_button") and self.http_apply_button and not self.http_apply_button.get_sensitive()):
                 self.http_apply_button.set_sensitive(True)
-                self.http_apply_button.set_icon_name("")  # Icon cleared with empty string
+                self.http_apply_button.set_icon_name("")
             return
-
         self.current_http_task = None
         logger.info("Processing task completion in _fetch_headers_task_done_cb.")
-
         try:
-            # Propagate the result. This will raise GLib.Error if the task returned an error.
             actual_list_of_responses = task_being_processed.propagate_value()
-
-            # Ensure the result is a list, as expected.
-            # Gio.Task can sometimes wrap results in a tuple if multiple values are returned,
-            # or a GObject.Value. We expect a direct list from our thread function.
             if not isinstance(actual_list_of_responses, list) and isinstance(actual_list_of_responses, tuple):
-                if len(actual_list_of_responses) > 0 and isinstance(actual_list_of_responses[0], list):
-                    actual_list_of_responses = actual_list_of_responses[0]  # Extract if wrapped
-                elif hasattr(actual_list_of_responses, "value") and isinstance(actual_list_of_responses.value, list):
-                    actual_list_of_responses = actual_list_of_responses.value  # Extract from GObject.Value
-
+                if len(actual_list_of_responses) > 0 and isinstance(actual_list_of_responses[0], list): actual_list_of_responses = actual_list_of_responses[0]
+                elif hasattr(actual_list_of_responses, "value") and isinstance(actual_list_of_responses.value, list): actual_list_of_responses = actual_list_of_responses.value
             if isinstance(actual_list_of_responses, list):
-                logger.info("Successfully processed task result: %d response stages.", len(actual_list_of_responses))
+                logger.info("Task result: %d response stages.", len(actual_list_of_responses))
                 processed_headers_for_store: list[HeaderItem] = []
                 if not actual_list_of_responses:
-                    logger.info("Received empty list of responses (e.g. no redirects and no final data).")
+                    logger.info("Received empty list of responses.")
                     self._update_column_view_model(None)
                 else:
                     for i, response_data_dict in enumerate(actual_list_of_responses):
                         if not isinstance(response_data_dict, dict):
-                            logger.error(
-                                "Expected dict item in response list, got %s. Data: %s",
-                                type(response_data_dict),
-                                response_data_dict,
-                            )
-                            continue  # Skip malformed item
-
+                            logger.error("Expected dict in response list, got %s. Data: %s", type(response_data_dict), response_data_dict)
+                            continue
                         url_display = f"URL: {response_data_dict.get('url', 'N/A')}"
                         status_code = response_data_dict.get("status_code", "N/A")
                         response_type = response_data_dict.get("type", "unknown")
                         status_display = f"Status: {status_code} ({response_type.capitalize()})"
-
-                        processed_headers_for_store.append(
-                            HeaderItem(key=url_display, value=status_display, is_special_row=True)
-                        )
-
+                        processed_headers_for_store.append(HeaderItem(key=url_display, value=status_display, is_special_row=True))
                         headers_for_this_response = response_data_dict.get("headers", {})
                         if isinstance(headers_for_this_response, dict):
-                            for key, value in headers_for_this_response.items():
-                                processed_headers_for_store.append(
-                                    HeaderItem(key=str(key), value=str(value), is_special_row=False)
-                                )
-                        else:
-                            logger.warning(
-                                "Headers data for response stage %d is not a dict: %s", i, headers_for_this_response
-                            )
-
-                        if i < len(actual_list_of_responses) - 1:
-                            processed_headers_for_store.append(
-                                HeaderItem(key="--- Redirected To ---", value="", is_special_row=True)
-                            )
-
+                            for key, value in headers_for_this_response.items(): processed_headers_for_store.append(HeaderItem(key=str(key), value=str(value), is_special_row=False))
+                        else: logger.warning("Headers data for stage %d not dict: %s", i, headers_for_this_response)
+                        if i < len(actual_list_of_responses) - 1: processed_headers_for_store.append(HeaderItem(key="--- Redirected To ---", value="", is_special_row=True))
                     self._current_header_items = processed_headers_for_store
                     self._update_column_view_model(processed_headers_for_store)
-                if hasattr(self, "http_entry_row") and self.http_entry_row:
-                    self.http_entry_row.remove_css_class("error")  # Clear error style from entry if successful
+                if hasattr(self, "http_entry_row") and self.http_entry_row: self.http_entry_row.remove_css_class("error")
             else:
-                # This case indicates an unexpected result type from the task.
-                logger.error(
-                    "Result data from task is of unexpected type %s. Expected list. Data: %s",
-                    type(actual_list_of_responses),
-                    actual_list_of_responses,
-                )
-                show_global_error(self,
-                    f"Failed to process task result (unexpected data structure: "
-                    f"{type(actual_list_of_responses).__name__}). Please check logs."
-                )
-                if hasattr(self, "http_entry_row") and self.http_entry_row:
-                    self.http_entry_row.add_css_class("error")
+                logger.error("Result data from task is %s, expected list. Data: %s", type(actual_list_of_responses), actual_list_of_responses)
+                show_global_error(self, f"Failed to process task result (unexpected data type: {type(actual_list_of_responses).__name__}).")
+                if hasattr(self, "http_entry_row") and self.http_entry_row: self.http_entry_row.add_css_class("error")
                 self._update_column_view_model(None)
-
-        except GLib.Error as e:  # Errors set by task.return_new_error_literal land here
-            logger.warning(
-                "Task failed with GLib.Error (Domain: %s, Code: %s, Message: %s)", e.domain, e.code, e.message
-            )
-            # Sanitize error message for display (remove potential Pango markup if simple text is desired)
-            display_message = (
-                e.message.replace("<b>", "").replace("</b>", "") if e.message else "An unknown error occurred."
-            )
+        except GLib.Error as e:
+            logger.warning("Task failed with GLib.Error (Domain: %s, Code: %s, Message: %s)", e.domain, e.code, e.message)
+            display_message = e.message.replace("<b>", "").replace("</b>", "") if e.message else "An unknown error occurred."
             show_global_error(self, display_message)
-            if hasattr(self, "http_entry_row") and self.http_entry_row:
-                self.http_entry_row.add_css_class("error")  # Style entry as erroneous
+            if hasattr(self, "http_entry_row") and self.http_entry_row: self.http_entry_row.add_css_class("error")
             self._update_column_view_model(None)
-        except Exception as e:  # Catch any other Python exceptions during result processing
+        except Exception as e:
             logger.exception("Unexpected Python error in _fetch_headers_task_done_cb:")
-            error_message = "An unexpected application error occurred while displaying results."
-            # Try to get a more specific message if available
-            if hasattr(e, "message") and e.message:  # Check for a message attribute
-                error_message = str(e.message)
-            elif str(e):  # Fallback to string representation of the exception
-                error_message = str(e)
-
+            error_message = "Unexpected application error displaying results."
+            if hasattr(e, "message") and e.message: error_message = str(e.message)
+            elif str(e): error_message = str(e)
             show_global_error(self, error_message)
-            if hasattr(self, "http_entry_row") and self.http_entry_row:
-                self.http_entry_row.add_css_class("error")
+            if hasattr(self, "http_entry_row") and self.http_entry_row: self.http_entry_row.add_css_class("error")
             self._update_column_view_model(None)
         finally:
-            # Ensure UI elements are re-enabled regardless of success or failure
-            if hasattr(self, "http_entry_row") and self.http_entry_row:
-                self.http_entry_row.set_sensitive(True)
+            if hasattr(self, "http_entry_row") and self.http_entry_row: self.http_entry_row.set_sensitive(True)
             if hasattr(self, "http_apply_button") and self.http_apply_button:
                 self.http_apply_button.set_sensitive(True)
-                self.http_apply_button.set_icon_name("")  # Remove spinner icon
+                self.http_apply_button.set_icon_name("")
 
     @staticmethod
     def _ensure_scheme(url: str) -> str:
-        """Ensure the URL has a scheme (defaults to https if missing).
-
-        Args:
-        ----
-            url: The input URL string.
-
-        Returns:
-        -------
-            The URL string with "https://" prepended if no scheme was present.
-
-        """
         parsed_url = requests.utils.urlparse(url)
         if not parsed_url.scheme:
             logger.debug("URL '%s' has no scheme, prepending 'https://'.", url)
             return "https://" + url
         return url
 
-    @staticmethod
-    def _is_valid_url(url: str) -> bool:
-        """Validate if a string is a well-formed HTTP or HTTPS URL.
-
-        Checks for a scheme, a netloc (domain/IP), and uses a regex for overall structure.
-
-        Args:
-        ----
-            url: The URL string to validate.
-
-        Returns:
-        -------
-            True if the URL is considered valid, False otherwise.
-
-        """
-        # Regex for basic URL structure (scheme, authority, path/query/fragment)
-        # Allows for IP addresses (IPv4 and IPv6), hostnames, optional ports.
-        url_regex = re.compile(
-            r"^(?:http|https)://"  # Scheme: http or https
-            r"(?:\S+(?::\S*)?@)?"  # Optional user:pass@
-            r"(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,6}|"  # Hostname
-            r"localhost|"  # localhost
-            r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|"  # IPv4 address
-            r"\[?[A-Fa-f0-9:.]+\]?)"  # IPv6 address (basic check, allows surrounding brackets)
-            r"(?::\d+)?"  # Optional port
-            r"(?:/?|[/?]\S+)$",  # Optional path, query, fragment
-            re.IGNORECASE,
-        )
-        # Additionally, ensure netloc is present after parsing, as regex might be too lenient alone.
-        return bool(re.match(url_regex, url)) and bool(requests.utils.urlparse(url).netloc)
+    # _is_valid_url static method will be removed.
 
     def _format_http_error(self, e: requests.exceptions.HTTPError) -> str:
-        """Format an `requests.exceptions.HTTPError` into a user-friendly message.
-
-        Provides specific messages for common HTTP error codes (403, 404, 500)
-        and a generic message for other HTTP errors.
-
-        Args:
-        ----
-            e: The `requests.exceptions.HTTPError` instance.
-
-        Returns:
-        -------
-            A user-friendly error message string.
-
-        """
         status_code = e.response.status_code
         reason = e.response.reason if e.response.reason else "Unknown Error"
-        if status_code == 403:
-            return f"403 Forbidden: Access to the requested resource at {e.request.url} is denied."
-        if status_code == 404:
-            return f"404 Not Found: The requested resource at {e.request.url} was not found on the server."
-        if status_code == 500:
-            return f"500 Internal Server Error: The server encountered an internal error for {e.request.url}."
+        if status_code == 403: return f"403 Forbidden: Access to {e.request.url} denied."
+        if status_code == 404: return f"404 Not Found: Resource at {e.request.url} not found."
+        if status_code == 500: return f"500 Internal Server Error for {e.request.url}."
         return f"HTTP Error {status_code} ({reason}) for URL: {e.request.url}."
 
-    def _on_pragma_toggled(
-        self,
-        _widget: Gtk.Switch,  # The Gtk.Switch that was toggled (unused)
-        _gparam: GObject.ParamSpec,  # The GObject.ParamSpec of the 'active' property (unused)
-    ) -> None:
-        """Handle the toggle event for the Akamai Pragma switch.
+    def _on_pragma_toggled(self, _widget: Gtk.Switch, _gparam: GObject.ParamSpec) -> None:
+        logger.debug("Akamai Pragma toggled: %s. Re-fetching if URL present.", self.http_pragma_switch_row.get_active())
+        if self.http_entry_row.get_text().strip(): self._on_entry_row_activated(self.http_entry_row)
 
-        If the URL entry row is not empty, this method re-triggers the header fetch
-        to reflect the new Pragma header state.
-
-        Args:
-        ----
-            _widget: The Gtk.Switch that was toggled.
-            _gparam: The GObject.ParamSpec of the 'active' property.
-
-        """
-        logger.debug(
-            "Akamai Pragma toggled to: %s. Re-fetching if URL is present.", self.http_pragma_switch_row.get_active()
-        )
-        if self.http_entry_row.get_text().strip():  # Only re-fetch if there's a URL
-            self._on_entry_row_activated(self.http_entry_row)  # Pass any widget, it's unused by handler
-
-    def _update_column_view_model(
-        self, header_items: Optional[List["HeaderItem"]]
-    ) -> None:  # Forward reference for HeaderItem
-        """Update the Gtk.ColumnView's model (`Gio.ListStore`) with new header items.
-
-        Clears existing items and populates the ListStore with the provided list.
-        Shows or hides the results group (`http_results_group`) based on whether
-        `header_items` are present.
-
-        Args:
-        ----
-            header_items: A list of `HeaderItem` objects to display, or `None` to clear the view.
-
-        """
-        self.header_list_store.remove_all()  # Clear previous items
-
+    def _update_column_view_model(self, header_items: Optional[List["HeaderItem"]]) -> None:
+        self.header_list_store.remove_all()
         if header_items:
-            for item in header_items:
-                self.header_list_store.append(item)
-            self._show_results()  # Make results group visible
-        else:
-            self._hide_results()  # Hide results group if no items
+            for item in header_items: self.header_list_store.append(item)
+            self._show_results()
+        else: self._hide_results()
 
     def _show_results(self):
-        """Make the HTTP results group visible."""
-        if self.http_results_group:  # Check if it exists
-            self.http_results_group.set_visible(True)
+        if self.http_results_group: self.http_results_group.set_visible(True)
 
     def _hide_results(self):
-        """Make the HTTP results group invisible."""
-        if self.http_results_group:  # Check if it exists
-            self.http_results_group.set_visible(False)
+        if self.http_results_group: self.http_results_group.set_visible(False)
 
     def _clear_error(self) -> None:
-        """Clear any displayed error messages from the main window's banner.
-
-        Also removes the 'error' CSS class from the URL entry row.
-        """
-        main_window = self.get_native()  # Get the top-level window
-        if main_window and hasattr(main_window, "hide_error"):
-            main_window.hide_error()  # Call hide_error method on WoesWindow
-        else:
-            logger.warning("Could not find main window or its 'hide_error' method to clear error.")
-
-        if self.http_entry_row:  # Check if it exists
-            self.http_entry_row.remove_css_class("error")
+        main_window = self.get_native()
+        if main_window and hasattr(main_window, "hide_error"): main_window.hide_error()
+        else: logger.warning("Could not find main window or hide_error method to clear error.")
+        if self.http_entry_row: self.http_entry_row.remove_css_class("error")
 
     def _on_clear_results_clicked(self, _button: Gtk.Button) -> None:
-        """Handle click of the 'Clear Results' button.
-
-        Clears current header items from the internal list and the view model,
-        clears any displayed errors, and resets the URL entry row text.
-
-        Args:
-        ----
-            _button: The Gtk.Button that was clicked (unused).
-
-        """
-        logger.info("Results cleared by user action.")
-        self._current_header_items = []  # Clear internal cache of items
-        self._update_column_view_model(None)  # Clear the ListStore and hide results view
-        self._clear_error()  # Clear any error banners/styles
-        if self.http_entry_row:  # Check if it exists
-            self.http_entry_row.set_text("")  # Clear URL entry
+        logger.info("Results cleared by user.")
+        self._current_header_items = []
+        self._update_column_view_model(None)
+        self._clear_error()
+        if self.http_entry_row: self.http_entry_row.set_text("")
 
     def _on_color_setting_changed(self, settings: Gio.Settings, key: str) -> None:
-        """Handle changes to GSettings related to HTTP output colors.
-
-        Updates internal color attributes (`_header_key_color`, etc.) with the new
-        values from settings. If results are currently displayed, it re-populates
-        the `Gtk.ColumnView` to apply the new colors immediately.
-
-        Args:
-        ----
-            settings: The `Gio.Settings` object that changed.
-            key: The name of the GSetting key that changed.
-
-        """
-        logger.debug("Color setting changed for GSettings key: %s", key)
-        if key == "http-output-header-key-color":
-            self._header_key_color = settings.get_string(key)
-        elif key == "http-output-header-value-color":
-            self._header_value_color = settings.get_string(key)
-        elif key == "http-output-special-row-color":
-            self._special_row_color = settings.get_string(key)
-
-        # If results are currently displayed, re-bind them to update colors
+        logger.debug("Color setting changed: %s", key)
+        if key == "http-output-header-key-color": self._header_key_color = settings.get_string(key)
+        elif key == "http-output-header-value-color": self._header_value_color = settings.get_string(key)
+        elif key == "http-output-special-row-color": self._special_row_color = settings.get_string(key)
         if self._current_header_items:
-            logger.debug("Re-populating ColumnView to apply new color changes.")
-            self._update_column_view_model(self._current_header_items)  # This re-triggers bind
+            logger.debug("Re-populating ColumnView for new colors.")
+            self._update_column_view_model(self._current_header_items)
 
     def _update_user_agent_model(self) -> None:
-        """Update the User-Agent dropdown (Adw.ComboRow) model.
-
-        Clears and repopulates the User-Agent title-to-value map (`_ua_title_to_value_map`)
-        and the dropdown's `Gtk.StringList` model. The order is:
-        1. Custom User-Agents from GSettings.
-        2. A "None" option (representing no override / default `requests` UA).
-        3. Default User-Agents from `constants.USER_AGENTS`.
-
-        Preserves the currently selected User-Agent if possible after rebuilding the list.
-        """
-        if not self.http_user_agent_row:  # Should not happen if UI is built correctly
+        if not self.http_user_agent_row:
             logger.error("HttpPage._update_user_agent_model: http_user_agent_row is None.")
             return
-
-        self._ua_title_to_value_map.clear()  # Clear internal mapping
-
+        self._ua_title_to_value_map.clear()
         current_selection_text: Optional[str] = None
-        # Preserve current selection text if an item is selected
-        if (
-            self.http_user_agent_row.get_model()  # Check model exists
-            and self.http_user_agent_row.get_selected() != Gtk.INVALID_LIST_POSITION
-        ):
+        if (self.http_user_agent_row.get_model() and self.http_user_agent_row.get_selected() != Gtk.INVALID_LIST_POSITION):
             selected_item = self.http_user_agent_row.get_selected_item()
-            if isinstance(selected_item, Gtk.StringObject):
-                current_selection_text = selected_item.get_string()
-
+            if isinstance(selected_item, Gtk.StringObject): current_selection_text = selected_item.get_string()
         display_titles: list[str] = []
-
-        # 1. Add Custom User-Agents from GSettings
         variant = self.settings.get_value("custom-user-agents")
-        # Ensure variant is not None and is of the correct type 'a(ss)' (array of string pairs)
-        custom_ua_pairs: list[tuple[str, str]] = list(
-            variant.unpack() if variant and variant.get_type_string() == "a(ss)" else []
-        )
-
+        custom_ua_pairs: list[tuple[str, str]] = list(variant.unpack() if variant and variant.get_type_string() == "a(ss)" else [])
         for title, value in custom_ua_pairs:
-            if title not in self._ua_title_to_value_map:  # Avoid duplicate titles if somehow in GSettings
+            if title not in self._ua_title_to_value_map:
                 display_titles.append(title)
                 self._ua_title_to_value_map[title] = value
-
-        # 2. Add "None" option (to use default requests UA)
         none_title = "None"
-        if none_title not in self._ua_title_to_value_map:  # Ensure "None" title is unique
-            display_titles.append(none_title)
-        # Always map the "None" title to a None value, signifying no override.
+        if none_title not in self._ua_title_to_value_map: display_titles.append(none_title)
         self._ua_title_to_value_map[none_title] = None
-
-        # 3. Add Default User-Agents from constants.USER_AGENTS
-        for ua_dict in USER_AGENTS:  # USER_AGENTS is a list of dicts
-            title = ua_dict.get("title")
-            value = ua_dict.get("value")
-            if title and value:  # Ensure both title and value exist
-                if title not in self._ua_title_to_value_map:  # Add only if title not used by custom or "None"
-                    display_titles.append(title)
-                    self._ua_title_to_value_map[title] = value
-
-        # Set the new model for the ComboRow
+        for ua_dict in USER_AGENTS:
+            title, value = ua_dict.get("title"), ua_dict.get("value")
+            if title and value and title not in self._ua_title_to_value_map:
+                display_titles.append(title)
+                self._ua_title_to_value_map[title] = value
         self.http_user_agent_row.set_model(Gtk.StringList.new(display_titles))
-
-        # Restore selection if possible
         if current_selection_text and current_selection_text in display_titles:
             try:
                 idx = display_titles.index(current_selection_text)
                 self.http_user_agent_row.set_selected(idx)
-            except ValueError:  # Should not happen if current_selection_text is in display_titles
-                logger.warning("Error restoring User-Agent selection: '%s' not in new list.", current_selection_text)
-                if display_titles:
-                    self.http_user_agent_row.set_selected(0)  # Default to first
-        elif display_titles:  # If no prior selection or prior selection not found, select first item
-            self.http_user_agent_row.set_selected(0)
-
-        # After updating model, also update visual cue for active override
+            except ValueError:
+                logger.warning("Error restoring UA selection: '%s' not in list.", current_selection_text)
+                if display_titles: self.http_user_agent_row.set_selected(0)
+        elif display_titles: self.http_user_agent_row.set_selected(0)
         self._on_user_agent_changed(self.http_user_agent_row, None)
-
-        logging.info(
-            "User-Agent dropdown model updated with %d titles (Custom -> None -> Default order).", len(display_titles)
-        )
+        logging.info("User-Agent dropdown updated: %d titles.", len(display_titles))
 
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:
-        """Create a Gtk.SignalListItemFactory for a column in the Gtk.ColumnView.
-
-        This factory is responsible for setting up Gtk.Label widgets and binding them
-        to display `HeaderItem` data (either 'key' or 'value' attribute).
-        It applies custom colors based on GSettings and whether the row is a special
-        informational row (like URL/Status) or a standard HTTP header.
-        Text wrapping is enabled for the 'value' column.
-
-        Args:
-        ----
-            attr_name: The attribute name of `HeaderItem` to display (e.g., "key", "value").
-            wrap_text: Whether the text in the label should be wrapped (True for "value" column).
-
-        Returns:
-        -------
-            A configured `Gtk.SignalListItemFactory`.
-
-        """
         factory = Gtk.SignalListItemFactory()
-
-        # Setup function: Called once per list item when it's created.
         def setup_func(_factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem) -> None:
-            """Set up the list item factory. Create and set a Gtk.Label as child."""
-            label = Gtk.Label(xalign=0.0)  # Align text to the left
-            label.set_hexpand(True)  # Allow label to expand horizontally
-            if wrap_text:  # For "value" column
+            label = Gtk.Label(xalign=0.0)
+            label.set_hexpand(True)
+            if wrap_text:
                 label.set_wrap(True)
-                label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)  # Wrap at word or char boundaries
-                label.set_max_width_chars(80)  # Hint for max width before wrapping (approx)
+                label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
+                label.set_max_width_chars(80)
             list_item.set_child(label)
-
-        # Bind function: Called when an item needs to be displayed or re-displayed.
         def bind_func_internal(_factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem) -> None:
-            """Bind function for the list item factory. Sets label text and Pango markup."""
             label = list_item.get_child()
-            item = list_item.get_item()  # This is a HeaderItem instance
-
+            item = list_item.get_item()
             if not (isinstance(label, Gtk.Label) and isinstance(item, HeaderItem)):
-                if isinstance(label, Gtk.Label):  # If label exists but item is wrong type
-                    label.set_text("Error: Invalid item type in ColumnView.")
+                if isinstance(label, Gtk.Label): label.set_text("Error: Invalid item type.")
                 return
-
-            text_to_display = getattr(item, attr_name, "")  # Get "key" or "value" from HeaderItem
-
-            # Apply Pango markup for styling
-            if item.is_special_row:  # For URL/Status rows or separators
-                if attr_name == "key":  # Primary text for special rows is in 'key'
+            text_to_display = getattr(item, attr_name, "")
+            if item.is_special_row:
+                if attr_name == "key":
                     key_text = GLib.markup_escape_text(str(item.key))
                     value_text = GLib.markup_escape_text(str(item.value)) if item.value else ""
-                    # Combine key and value for display in the 'key' column's label for special rows
                     full_text = key_text
-                    if value_text.strip() and value_text != "N/A":  # Append value if meaningful
-                        full_text += f" {value_text}"
-
-                    # Use bold and special row color
+                    if value_text.strip() and value_text != "N/A": full_text += f" {value_text}"
                     label.set_markup(f"<b><span foreground='{self._special_row_color}'>{full_text}</span></b>")
-                else:  # 'value' column for special rows is usually empty or handled by 'key'
-                    label.set_markup("")  # Clear any previous markup
-            else:  # For standard HTTP header rows
+                else: label.set_markup("")
+            else:
                 color_to_use = self._header_key_color if attr_name == "key" else self._header_value_color
                 escaped_text = GLib.markup_escape_text(str(text_to_display))
-                # Use bold and specific color for key/value
                 label.set_markup(f"<b><span foreground='{color_to_use}'>{escaped_text}</span></b>")
-
         factory.connect("setup", setup_func)
         factory.connect("bind", bind_func_internal)
-
         return factory
 
     def trigger_fetch(self):
-        """Programmatically triggers the 'Fetch' action.
-
-        This method is typically called by a global action/shortcut.
-        It simulates a click on the fetch button.
-        """
         logging.debug("HTTP fetch triggered by shortcut.")
-        if self.http_apply_button and self.http_apply_button.get_sensitive():
-            self.http_apply_button.clicked()
-        else:
-            logging.warning("HTTP fetch button not available or not sensitive, cannot trigger fetch.")
+        if self.http_apply_button and self.http_apply_button.get_sensitive(): self.http_apply_button.clicked()
+        else: logging.warning("HTTP fetch button not available or sensitive.")
+
+# Removed _is_valid_url static method here. It will be replaced by utils.is_valid_url call.
+# The method definition itself needs to be removed from the file.
+# The imports at the top already include `from .utils import show_global_error, show_global_toast`
+# I will add `is_valid_url` to that existing import line.
+# Then, remove the static method `_is_valid_url`
+# And change `if not self._is_valid_url(url):` to `if not is_valid_url(url):`

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -12,11 +12,13 @@ import shlex
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, Union, List, Optional, Tuple # Ensured List is here, alongside Tuple
+from typing import Any, Dict, Union, List, Optional, Tuple
 
 import nmap
 from nmap import PortScannerError
 import yaml
+
+from .utils import is_valid_ip, is_valid_domain # Added new utils
 
 
 class ScanOptions(Enum):
@@ -37,7 +39,7 @@ class ScanStatus(Enum):
     IDLE = (0.0, "Idle") # Scanner is ready, no active scan
 
 
-def _is_scan_root_required(nmap_args_list: List[str]) -> bool: # Changed to typing.List
+def _is_scan_root_required(nmap_args_list: List[str]) -> bool:
     """Check if the given Nmap arguments require root privileges.
 
     Args:
@@ -57,7 +59,7 @@ def _is_scan_root_required(nmap_args_list: List[str]) -> bool: # Changed to typi
     return is_required
 
 
-def get_escalated_command(command_parts: List[str]) -> List[str]: # Changed to typing.List, removed ignore
+def get_escalated_command(command_parts: List[str]) -> List[str]:
     """Construct a command list for privilege escalation based on the OS.
 
     Supports `pkexec` on Linux and `osascript` for `do shell script with administrator privileges`
@@ -141,6 +143,7 @@ class NmapScanner:
 
         The target can be a single IP address, a hostname, a CIDR block,
         or multiple targets separated by commas or spaces.
+        Uses utility functions for IP and domain validation.
 
         Args:
         ----
@@ -151,27 +154,42 @@ class NmapScanner:
             True if the target string is valid, False otherwise.
 
         """
-        ipv4_segment = r"(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9]|0)"
-        ipv4_address = r"(?:{seg}\.{seg}\.{seg}\.{seg})".format(seg=ipv4_segment)
-        fqdn = r"(?:[A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,}"
-        cidr = rf"{ipv4_address}/[0-9]{{1,2}}"
+        if not target or not isinstance(target, str): # Handle empty or non-string input early
+            return False
 
-        addr_regex = rf"^(localhost|{ipv4_address}|{fqdn}|{cidr})$"
-
-        logger.debug(f"Validating target input: '{target}'")
         targets = re.split(r"[ ,]+", target.strip())
+        if not targets or all(not t for t in targets): # Handle case where split results in empty list or list of empty strings
+            return False
 
-        is_valid = True
+        ipv4_segment_regex = r"(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9]|0)"
+        ipv4_address_regex_str = r"{s}\.{s}\.{s}\.{s}".format(s=ipv4_segment_regex)
+        # CIDR regex for IPv4. For IPv6 CIDR, this would need expansion.
+        cidr_regex = re.compile(rf"^{ipv4_address_regex_str}/(?:[0-9]|[12][0-9]|3[0-2])$")
+
+        logger.debug(f"Validating Nmap target input: '{target}' (split into: {targets})")
+
         for t in targets:
-            if re.match(addr_regex, t):
-                logger.debug("Target segment '%s' matched the pattern.", t)
-            else:
-                logger.debug("Target segment '%s' did NOT match the pattern.", t)
-                is_valid = False
-                break # No need to check further if one segment is invalid
+            if not t: # Skip empty strings that might result from multiple separators
+                continue
+            if t.lower() == "localhost":
+                logger.debug("Target segment '%s' is 'localhost'. Valid.", t)
+                continue
+            if cidr_regex.fullmatch(t):
+                logger.debug("Target segment '%s' matched CIDR pattern. Valid.", t)
+                continue
+            if is_valid_ip(t):
+                logger.debug("Target segment '%s' is a valid IP. Valid.", t)
+                continue
+            if is_valid_domain(t):
+                logger.debug("Target segment '%s' is a valid domain. Valid.", t)
+                continue
 
-        logger.debug(f"Target validation result for '{target}': {is_valid}")
-        return is_valid
+            # If none of the above, the segment is invalid
+            logger.warning("Target segment '%s' is invalid (not localhost, CIDR, IP, or domain).", t)
+            return False
+
+        logger.debug(f"All target segments validated successfully for input '{target}'.")
+        return True
 
     def build_nmap_options(
         self, os_fingerprinting: bool, scan_all_ports: bool, selected_script: str
@@ -260,7 +278,7 @@ class NmapScanner:
 
     def _execute_nmap_command(
         self, nmap_args_list: List[str], needs_escalation: bool
-    ) -> Tuple[str, str, int]: # Changed to typing.Tuple
+    ) -> Tuple[str, str, int]:
         """Execute the Nmap command, handling privilege escalation if needed.
 
         Args:
@@ -421,7 +439,7 @@ class NmapScanner:
                 nmap_args_list, needs_escalation
             )
 
-            if returncode:  # C1805
+            if returncode:
                 logger.debug(
                     "Nmap process stdout (on error code %s): %s", returncode, nmap_xml_output
                 )
@@ -464,9 +482,9 @@ class NmapScanner:
             raise PortScannerError(
                 f"Privilege escalation not implemented for this platform: {e_ni}"
             ) from e_ni
-        except PortScannerError: # Specific re-raise, keep as is or add logger.debug if needed
+        except PortScannerError:
             raise
-        except Exception as e_unexpected: # General catch-all
+        except Exception as e_unexpected:
             logger.exception(
                 "An unexpected error occurred during the Nmap scan process:"
             )
@@ -496,7 +514,7 @@ class NmapScanner:
             logger.debug("Processing results for host: %s", host)
             host_data = nm[host]
             plain_dict = self.to_plain_dict(host_data)
-            if prescan_scripts_data: # Only add if there's actual pre-scan data
+            if prescan_scripts_data:
                 plain_dict["prescript_results"] = prescan_scripts_data
             yaml_output = yaml.safe_dump(plain_dict, default_flow_style=False)
             all_results[host] = yaml_output
@@ -522,8 +540,8 @@ class NmapScanner:
         logger.debug(f"to_plain_dict called with data of type: {type(data)}")
         if isinstance(data, nmap.PortScannerHostDict):
             return {k: self.to_plain_dict(v) for k, v in data.items()}
-        if isinstance(data, list):  # R1705 (no-else-return makes this an if)
+        if isinstance(data, list):
             return [self.to_plain_dict(item) for item in data]
-        if isinstance(data, dict):  # R1705 (no-else-return makes this an if)
+        if isinstance(data, dict):
             return {k: self.to_plain_dict(v) for k, v in data.items()}
-        return data  # R1705
+        return data

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,16 @@
 """General utility functions for the Woes application."""
 import logging
-from typing import Tuple
+import ipaddress # Added for is_valid_ip
+import re # Added for is_valid_domain
+from urllib.parse import urlparse # Added for is_valid_url
+from typing import Tuple, List # Added List for type hint
+
 import gi
 from gi.repository import Gtk, GtkSource, Adw
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("GtkSource", "5")
-gi.require_version("Adw", "1") # Added for Adw.ToastPriority
+gi.require_version("Adw", "1")
 
 logger = logging.getLogger(__name__)
 
@@ -113,3 +117,83 @@ def show_global_toast(
             "An unexpected error occurred while trying to show global toast '%s': %s",
             message, e
         )
+
+# --- New Validation Functions ---
+
+def is_valid_ip(address: str) -> bool:
+    """Check if the given string is a valid IPv4 or IPv6 address.
+
+    Args:
+    ----
+        address: The string to validate.
+
+    Returns:
+    -------
+        True if the string is a valid IP address, False otherwise.
+    """
+    if not address or not isinstance(address, str):
+        return False
+    try:
+        ipaddress.ip_address(address)
+        return True
+    except ValueError:
+        return False
+
+def is_valid_domain(domain: str) -> bool:
+    """Check if the given string is a syntactically valid domain name (ASCII).
+
+    Args:
+    ----
+        domain: The string to validate.
+
+    Returns:
+    -------
+        True if the string is a valid domain name, False otherwise.
+    """
+    if not domain or not isinstance(domain, str):
+        return False
+    # Regex for domain names:
+    # - Each label (part between dots) is 1-63 chars.
+    # - Labels consist of LDH (letters, digits, hyphen).
+    # - Labels do not start or end with a hyphen.
+    # - The TLD (last label) must be at least 2 chars and all alphabetic.
+    # - Total length up to 253 chars is often cited, but regex focuses on structure.
+    # This regex is a common one for ASCII domain names.
+    # It allows for subdomains and ensures TLD is alphabetic.
+    domain_regex = re.compile(
+        r"^(?:[a-zA-Z0-9]"  # First character of a label
+        r"(?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)"  # Subsequent characters of a label, then a dot
+        r"+[a-zA-Z]{2,63}$"  # TLD (all letters, 2-63 chars)
+    )
+    # Using fullmatch to ensure the entire string conforms.
+    return bool(domain_regex.fullmatch(domain))
+
+
+def is_valid_url(url: str, schemes: List[str] = None) -> bool:
+    """Check if the given string is a syntactically valid URL with specific schemes.
+
+    Args:
+    ----
+        url: The string to validate.
+        schemes: A list of allowed schemes (e.g., ['http', 'https']).
+                 If None or empty, any scheme is effectively allowed as long as one is present.
+                 Defaults to ['http', 'https'].
+
+    Returns:
+    -------
+        True if the string is a valid URL with an allowed scheme, False otherwise.
+    """
+    if schemes is None: # Default to http and https if not provided
+        schemes = ['http', 'https']
+
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        parsed_url = urlparse(url)
+        if not (parsed_url.scheme and parsed_url.netloc):
+            return False
+        if schemes and parsed_url.scheme not in schemes:
+            return False
+        return True
+    except ValueError: # urlparse can raise ValueError for some malformed URLs, though it's rare
+        return False

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -4,20 +4,20 @@ This page provides a simple interface to run Nikto scans against a target URL
 and display the results.
 """
 import subprocess
-import re
+import re # Keep re for now, other parts of the file might use it, or remove if truly unused later.
 import logging
 logger = logging.getLogger(__name__)
 from typing import Optional
 
 import gi
-from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, GtkSource # Added Gdk and GtkSource
+from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, GtkSource
 
 from .constants import RESOURCE_PREFIX
-from .utils import show_global_error, show_global_toast
+from .utils import show_global_error, show_global_toast, is_valid_url # Added is_valid_url
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-gi.require_version("GtkSource", "5") # Match version from UI file
+gi.require_version("GtkSource", "5")
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/webscan_page.ui")
@@ -39,10 +39,7 @@ class WebScanPage(Adw.PreferencesPage):
     copy_results_button = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
-        """Initialize the WebScanPage.
-
-        Sets up signal handlers for UI elements.
-        """
+        """Initialize the WebScanPage."""
         super().__init__(**kwargs)
         self.current_web_scan_task = None
         logger.debug("WebScanPage initialized")
@@ -68,34 +65,14 @@ class WebScanPage(Adw.PreferencesPage):
             self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
 
     def _on_clear_results_clicked(self, _button: Gtk.Button):
-        """Handle click of the 'Clear Results' button.
-
-        Clears the content of the results TextView.
-
-        Args:
-        ----
-            _button: The Gtk.Button that was clicked (unused).
-
-        """
+        """Handle click of the 'Clear Results' button."""
         logger.info("Webscan results cleared by user action.")
         if self.results_textview:
             buffer = self.results_textview.get_buffer()
             buffer.set_text("")
-        # Optionally, clear any related error banners if desired
-        # main_window = self.get_native()
-        # if main_window and hasattr(main_window, 'hide_error'):
-        # main_window.hide_error()
 
     def _on_copy_results_clicked(self, _button: Gtk.Button):
-        """Handle click of the 'Copy Results' button.
-
-        Copies the entire content of the results TextView to the clipboard.
-
-        Args:
-        ----
-            _button: The Gtk.Button that was clicked (unused).
-
-        """
+        """Handle click of the 'Copy Results' button."""
         logger.info("Copying webscan results to clipboard.")
         if self.results_textview:
             buffer = self.results_textview.get_buffer()
@@ -117,47 +94,24 @@ class WebScanPage(Adw.PreferencesPage):
                 logger.info("No webscan results to copy.")
 
     def on_scan_button_clicked(self, _widget: Gtk.Button):
-        """Handle the 'Scan' button click event.
-
-        Validates the URL entered by the user, then initiates an asynchronous
-        Nikto scan task if the URL is valid. Disables the scan button during
-        the scan.
-
-        Args:
-        ----
-            _widget: The Gtk.Button that was clicked.
-
-        """
+        """Handle the 'Scan' button click event."""
         logger.debug(f"WebScanPage scan button clicked. URL: '{self.url_entry.get_text()}'")
-        target_url = self.url_entry.get_text()
+        target_url = self.url_entry.get_text().strip() # Added strip() here for consistency
 
-        url_pattern = re.compile(
-            r"^(?:(?:https?|ftp)://)?(?:\S+(?::\S*)?@)?"  # Scheme and optional user:pass
-            r"(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])"  # IPv4 part 1
-            r"(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}"  # IPv4 part 2 & 3
-            r"(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|"  # IPv4 part 4
-            r"(?:(?:[a-z¡-￿0-9]-*)*[a-z¡-￿0-9]+)"  # Domain name
-            r"(?:\.(?:[a-z¡-￿0-9]-*)*[a-z¡-￿0-9]+)*"  # Optional subdomains
-            r"(?:\.(?:[a-z¡-￿]{2,}))\.?)"  # Top Level Domain
-            r"(?::\d{2,5})?"  # Optional port
-            r"(?:[/?#]\S*)?$",  # Optional path, query, or fragment
-            re.IGNORECASE,
-        )
+        # Removed local url_pattern regex definition
+
         if not target_url:
-            # Attempt to show a toast.
             show_global_toast(self, "Target URL cannot be empty.")
-            # If the toast mechanism itself isn't available (e.g., no main_window or show_toast method),
-            # the original code would fall back to _show_main_banner_error.
-            # We replicate this by calling show_global_error under the same conditions.
             main_window = self.get_native()
             if not (main_window and hasattr(main_window, 'show_toast')):
                 show_global_error(self, "Target URL cannot be empty.")
             return
 
-        if not url_pattern.match(target_url):
-            # Attempt to show a toast.
+        # Use the new is_valid_url utility function
+        # The original regex allowed http, https, ftp.
+        # is_valid_url defaults to ['http', 'https'], so we provide the schemes.
+        if not is_valid_url(target_url, schemes=['http', 'https', 'ftp']):
             show_global_toast(self, "Invalid URL format. Please enter a valid URL.")
-            # Fallback to error banner if the toast mechanism isn't available.
             main_window = self.get_native()
             if not (main_window and hasattr(main_window, 'show_toast')):
                 show_global_error(self, "Invalid URL format. Please enter a valid URL.")
@@ -176,7 +130,7 @@ class WebScanPage(Adw.PreferencesPage):
                 logger.warning(f"Error trying to cancel previous web scan task: {e_cancel}")
 
         cancellable = Gio.Cancellable()
-        task = Gio.Task.new(self, cancellable, self._on_scan_task_done, None) # task_data is None
+        task = Gio.Task.new(self, cancellable, self._on_scan_task_done, None)
         self.current_web_scan_task = task
 
         self._temp_scan_data = {
@@ -192,24 +146,12 @@ class WebScanPage(Adw.PreferencesPage):
 
     def _run_scan_task_thread_func(self,
                                    task: Gio.Task,
-                                   source_object: GObject.Object, # This is 'self' (WebScanPage instance)
-                                   task_data: object, # This will be None as no task_data is passed to Gio.Task.new
+                                   source_object: GObject.Object,
+                                   task_data: object,
                                    cancellable: Gio.Cancellable):
-        """Execute the Nikto scan in a separate thread.
-
-        This method is run by `Gio.Task.run_in_thread`. It retrieves scan parameters
-        from the `source_object` (WebScanPage instance), constructs, and runs the Nikto command.
-
-        Args:
-        ----
-            task: The `Gio.Task` associated with this asynchronous operation.
-            source_object: The source GObject that initiated the task (the WebScanPage instance).
-            task_data: Task-specific data (None in this implementation, parameters are on source_object).
-            cancellable: A `Gio.Cancellable` to monitor for cancellation requests.
-
-        """
+        """Execute the Nikto scan in a separate thread."""
         logger.debug("WebScanPage._run_scan_task_thread_func started")
-        page_instance = source_object # page_instance is 'self' (WebScanPage)
+        page_instance = source_object
         scan_data = page_instance._temp_scan_data
 
         target_url = scan_data["target_url"]
@@ -220,8 +162,22 @@ class WebScanPage(Adw.PreferencesPage):
         mutate_active = scan_data.get("mutate", False)
         maxtime_str = scan_data.get("maxtime", "")
 
-        if not target_url.startswith(("http://", "https://")):
+        # Note: is_valid_url used in on_scan_button_clicked ensures scheme presence.
+        # However, Nikto itself might prepend http:// if no scheme is given.
+        # To be safe and explicit for Nikto's -h argument:
+        if not target_url.startswith(("http://", "https://", "ftp://")): # Check against allowed schemes
+            # Defaulting to http for nikto if scheme is missing after validation
+            # This case should ideally not be hit if is_valid_url (with schemes) works as expected
+            # and target_url is passed directly from input.
+            # However, if is_valid_url allows URLs without explicit schemes (e.g. example.com)
+            # then this logic is needed. The current is_valid_url requires a scheme.
+            # Let's assume target_url from input might be schemeless and is_valid_url allows it.
+            # The current is_valid_url in utils.py DOES require a scheme.
+            # So this block might be less critical if target_url is always pre-schemed by user or validation.
+            # For robustness with Nikto:
+            logger.info("Prepending http:// to target URL for Nikto as scheme was missing or not http/https/ftp.")
             target_url = "http://" + target_url
+
 
         nikto_command = ['nikto', '-h', target_url]
 
@@ -235,25 +191,17 @@ class WebScanPage(Adw.PreferencesPage):
             try:
                 maxtime_val = int(maxtime_str)
                 if maxtime_val > 0:
-                    nikto_command.extend(['-maxtime', str(maxtime_val) + 's']) # Nikto expects time with 's' suffix
+                    nikto_command.extend(['-maxtime', str(maxtime_val) + 's'])
                 else:
                     logger.warning(f"Invalid maxtime value '{maxtime_str}', must be positive. Ignoring.")
             except ValueError:
                 logger.warning(f"Invalid maxtime value '{maxtime_str}', not an integer. Ignoring.")
 
         tuning_options = []
-        if cgi_vulns:
-            tuning_options.append('2') # Corresponds to Nikto's "Misconfiguration / Default File"
-        if interesting_content:
-            tuning_options.append('1') # Corresponds to Nikto's "Interesting File / Seen in logs"
+        if cgi_vulns: tuning_options.append('2')
+        if interesting_content: tuning_options.append('1')
 
-        # Nikto's -Tuning option takes a string of numbers (e.g., "12") to specify checks.
-        # If no tuning switches are active, the -Tuning option is omitted,
-        # allowing Nikto to use its default set of checks.
         if tuning_options:
-            # Using set avoids duplicates (e.g. if '1' was added twice)
-            # and sorted() ensures a consistent order (e.g., "12" not "21"),
-            # though order usually doesn't matter for Nikto's -Tuning inclusion.
             tuning_string = "".join(sorted(list(set(tuning_options))))
             if tuning_string:
                 nikto_command.extend(['-Tuning', tuning_string])
@@ -269,46 +217,27 @@ class WebScanPage(Adw.PreferencesPage):
             ) as process:
                 stdout, stderr = process.communicate(timeout=300)
             task.return_value((stdout, stderr, None))
-
         except FileNotFoundError:
             task.return_value((None, None, "FileNotFoundError"))
         except subprocess.TimeoutExpired:
             task.return_value((None, None, "TimeoutExpired"))
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             task.return_value((None, str(e), "Exception"))
 
     def _on_scan_task_done(self, source_object: GObject.Object, async_result_obj: Gio.AsyncResult, _user_data: object):
-        """Handle completion of the Nikto scan task.
-
-        This callback is executed in the main thread. It retrieves the results
-        (or error information) from the completed `Gio.Task` and updates the UI
-        (TextView for results, error banner for errors). Re-enables the scan button.
-
-        Args:
-        ----
-            task: The `Gio.Task` that has completed.
-            result: The `Gio.AsyncResult` associated with the task's completion.
-            _user_data: User data passed to the callback (unused).
-
-        """
+        """Handle completion of the Nikto scan task."""
         target_url = "Unknown URL"
-        if hasattr(self, '_temp_scan_data') and self._temp_scan_data: # Check if scan data exists
+        if hasattr(self, '_temp_scan_data') and self._temp_scan_data:
             target_url = self._temp_scan_data.get("target_url", target_url)
 
         active_task = self.current_web_scan_task
         if not active_task:
             logger.warning("_on_scan_task_done called but no active_task found.")
-            if not self.scan_button.get_sensitive(): # Re-enable button if it got stuck
+            if not self.scan_button.get_sensitive():
                 self.scan_button.set_sensitive(True)
             return
 
         try:
-            # Gio.Task.propagate_value() can raise a GLib.Error if the task itself
-            # encountered an unhandled exception.
-            # On success, it returns a 2-tuple. The first element's role is secondary
-            # here as critical errors are caught by GLib.Error.
-            # The second element is the actual payload (our 3-element tuple)
-            # passed to task.return_value() in the thread.
             _intermediate_tuple_from_propagate = active_task.propagate_value()
             _status_or_bool, actual_payload_tuple = _intermediate_tuple_from_propagate
             stdout, stderr_or_error_msg, error_type = actual_payload_tuple
@@ -343,17 +272,7 @@ class WebScanPage(Adw.PreferencesPage):
             self.current_web_scan_task = None
 
     def _update_textview(self, stdout: Optional[str], stderr: Optional[str]):
-        """Update the results TextView with Nikto's stdout and stderr.
-
-        Appends stdout first, then stderr if present. Scrolls the TextView
-        to the end to show the latest results.
-
-        Args:
-        ----
-            stdout: The standard output from the Nikto command, or None.
-            stderr: The standard error from the Nikto command, or None.
-
-        """
+        """Update the results TextView with Nikto's stdout and stderr."""
         buffer = self.results_textview.get_buffer()
         if stdout:
             buffer.insert(buffer.get_end_iter(), stdout)
@@ -365,11 +284,7 @@ class WebScanPage(Adw.PreferencesPage):
             scroll_adj.set_value(scroll_adj.get_upper() - scroll_adj.get_page_size())
 
     def trigger_scan(self):
-        """Programmatically triggers the WebScan 'Scan' action.
-
-        This method is typically called by a global action/shortcut.
-        It simulates a click on the scan button.
-        """
+        """Programmatically triggers the WebScan 'Scan' action."""
         logger.debug("Webscan scan triggered by shortcut.")
         if self.scan_button and self.scan_button.get_sensitive():
             self.scan_button.clicked()


### PR DESCRIPTION
This commit introduces common input validation functions in `src/utils.py` for IP addresses (`is_valid_ip`), domain names (`is_valid_domain`), and URLs (`is_valid_url`).

The following modules were refactored to use these centralized utilities:
- `dns_page.py`: Replaced local IP and domain validation.
- `http_page.py`: Replaced local URL validation.
- `webscan_page.py`: Replaced inline URL regex validation.
- `nmap_scanner.py`: Enhanced its `validate_target_input` method to use the new IP and domain validators for component parts of Nmap targets, while retaining Nmap-specific logic for CIDR, "localhost", and target lists.

This refactoring:
- Reduces code duplication.
- Improves the robustness of input validation by using standard libraries (e.g., `ipaddress`) and well-defined regexes/parsing.
- Enhances consistency in how inputs are validated across the application.
- Improves maintainability by centralizing core validation logic.