### PR TITLE
Fix: Add custom_dns_adapter.py to meson.build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -73,6 +73,7 @@ gnome.compile_resources(
 woes_sources = files(
   '__init__.py',
   'constants.py',
+  'custom_dns_adapter.py',
   'dns_page.py',
   'helper.py',
   'http_page.py',


### PR DESCRIPTION
The file `custom_dns_adapter.py` was created to modularize the CustomDNSAdapter class, but it was not added to the `woes_sources` list in `src/meson.build`. This resulted in the file not being included in the build and installation, leading to a `ModuleNotFoundError: No module named 'woes.custom_dns_adapter'` when `http_page.py` tried to import it.

This commit adds `custom_dns_adapter.py` to the `woes_sources` list in `src/meson.build`, ensuring it is correctly packaged and installed.