### PR TITLE
Fix: Resolve NameError and ensure correct typing imports

### DIFF
--- a/src/custom_dns_adapter.py
+++ b/src/custom_dns_adapter.py
@@ -3,7 +3,7 @@
 import logging
 import socket
 import ssl
-from typing import Optional
+from typing import Optional, Tuple, List, Dict, Any # Added Tuple, List, Dict, Any
 
 import requests
 import requests.utils # For urlparse, urlunparse
@@ -53,7 +53,7 @@ class CustomDNSAdapter(HTTPAdapter):
         self.custom_dns_server = custom_dns_server
         self.default_sni_for_ip_url = default_sni
         self._resolved_sni: Optional[str] = None  # SNI derived from hostname resolution by this adapter.
-        self.resolved_ip_cache = {} # Cache for resolved IPs: hostname -> IP
+        self.resolved_ip_cache: Dict[str, str] = {} # Cache for resolved IPs: hostname -> IP
         super().__init__(*args, **kwargs)
 
     def _resolve_hostname_to_ip(self, hostname: str) -> Optional[str]:
@@ -82,7 +82,7 @@ class CustomDNSAdapter(HTTPAdapter):
         resolver.timeout = 2.0  # Short timeout for each DNS query attempt
         resolver.lifetime = 2.0  # Total time for the entire resolution attempt including retries
 
-        ips: list[str] = []
+        ips: List[str] = []
         try:
             for rdtype in ("AAAA", "A"):  # Prefer AAAA (IPv6) if available
                 try:
@@ -106,7 +106,7 @@ class CustomDNSAdapter(HTTPAdapter):
             logger.error("CustomDNSAdapter: Unexpected error during custom DNS resolution for %s: %s", hostname, e, exc_info=True)
         return None
 
-    def send(self, request: requests.models.PreparedRequest, stream: bool = False, timeout: Optional[float] = None, verify: bool = True, cert: Optional[tuple[str, str] | str] = None, proxies=None):
+    def send(self, request: requests.models.PreparedRequest, stream: bool = False, timeout: Optional[float] = None, verify: bool = True, cert: Optional[Tuple[str, str] | str] = None, proxies=None):
         """Override HTTPAdapter.send method."""
         parsed_url = requests.utils.urlparse(request.url)
         original_hostname = parsed_url.hostname

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 # DNS library imports (dns.resolver, etc.) are now primarily in dns_client.py
 import gi
 from gi.repository import Adw, Gio, Gtk, Pango, GObject # Added GObject
-from typing import Tuple, Sequence, Any, List, Dict # Kept for type hints if _display_result uses them
+from typing import Optional, Tuple, Sequence, Any, List, Dict # Kept for type hints, added Optional
 
 from .constants import APP_ID, RESOURCE_PREFIX
 from .utils import show_global_error, show_global_toast, is_valid_ip, is_valid_domain

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -10,7 +10,7 @@ via a :class:`.custom_dns_adapter.CustomDNSAdapter`.
 # ruff: noqa: E501
 import logging
 from enum import Enum
-from typing import Optional, List, Any # Added Any
+from typing import Optional, List, Any, Dict # Added Dict
 
 # Removed requests, requests.utils, dns.resolver, urllib3.exceptions as they moved to http_client
 # CustomDNSAdapter is now used by HttpFetcher, not directly here.
@@ -109,8 +109,8 @@ class HttpPage(Adw.PreferencesPage):
         logger.debug("HttpPage initialized.")
         self.current_http_task: Optional[Gio.Task] = None
         self._current_header_items: List[HeaderItem] = []
-        self._http_task_data_for_thread: dict = {}
-        self._ua_title_to_value_map: dict[str, Optional[str]] = {}
+        self._http_task_data_for_thread: Dict[str, Any] = {} # Changed dict to Dict
+        self._ua_title_to_value_map: Dict[str, Optional[str]] = {} # Changed dict to Dict
         self.settings = Gio.Settings(schema_id=APP_ID)
         self._header_key_color = self.settings.get_string("http-output-header-key-color")
         self._header_value_color = self.settings.get_string("http-output-header-value-color")
@@ -290,7 +290,7 @@ class HttpPage(Adw.PreferencesPage):
         self,
         task: Gio.Task, # The task itself, passed by run_in_thread
         _source_object: GObject.Object, # type: ignore
-        _task_data_arg: dict, # type: ignore # Not used, self._http_task_data_for_thread is used
+        _task_data_arg: Dict[str, Any], # type: ignore # Not used, self._http_task_data_for_thread is used
         cancellable: Optional[Gio.Cancellable], # Provided by Gio.Task
     ) -> None:
         """Background thread function for fetching HTTP headers.

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ parsing, and launching the main application window and services.
 import sys
 import os
 import logging
-from typing import Optional, List
+from typing import Optional, List, Callable # Added Callable
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -435,7 +435,7 @@ class WoesApplication(Adw.Application):
         preferences_dialog = Preferences(main_window=self.win)
         preferences_dialog.present()
 
-    def create_action(self, name: str, callback, shortcuts: Optional[List[str]] = None):
+    def create_action(self, name: str, callback: Callable, shortcuts: Optional[List[str]] = None):
         """Create and add a Gio.SimpleAction to the application.
 
         :param name: The name of the action (e.g., "quit", "about").

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,7 +3,7 @@ import logging
 import ipaddress
 import re
 from urllib.parse import urlparse
-from typing import Tuple, List
+from typing import Tuple, List, Optional # Added Optional
 
 import gi
 from gi.repository import Gtk, GtkSource, Adw
@@ -169,7 +169,7 @@ def is_valid_domain(domain: str) -> bool:
     return bool(domain_regex.fullmatch(domain))
 
 
-def is_valid_url(url: str, schemes: List[str] = None) -> bool:
+def is_valid_url(url: str, schemes: Optional[List[str]] = None) -> bool:
     """Check if the given string is a syntactically valid URL with specific schemes.
 
     :param url: The string to validate.
@@ -178,7 +178,7 @@ def is_valid_url(url: str, schemes: List[str] = None) -> bool:
                     If ``None``, defaults to ``['http', 'https']``.
                     If an empty list is provided, any scheme is effectively allowed
                     as long as one is present in the URL.
-    :type schemes: list[str], optional
+    :type schemes: Optional[List[str]]
     :return: ``True`` if the string is a valid URL with an allowed scheme
              (or any scheme if ``schemes`` is empty), ``False`` otherwise.
     :rtype: bool

--- a/src/window.py
+++ b/src/window.py
@@ -6,6 +6,7 @@ window state and theme preferences, and integrates system font settings.
 """
 import logging
 import platform
+from typing import Optional, Any # Added Optional, Any
 import gi
 from gi.repository import Adw, Gdk, Gio, Gtk, GLib, GObject
 
@@ -100,7 +101,7 @@ class WoesWindow(Adw.ApplicationWindow):
             self.main_error_banner.connect("button-clicked", self._on_main_error_banner_dismissed)
             self.hide_error()
 
-    def _on_main_error_banner_dismissed(self, _banner: Adw.Banner = None, _data=None):
+    def _on_main_error_banner_dismissed(self, _banner: Optional[Adw.Banner] = None, _data: Optional[Any] = None):
         """Handle dismissal of the main error banner.
 
         This callback is connected to the 'button-clicked' signal of the


### PR DESCRIPTION
This commit addresses a NameError caused by missing typing imports and ensures that type hints are correctly imported across several files.

- Added `from typing import Optional, ...` and consolidated other typing imports in `src/dns_page.py` to resolve a `NameError`.
- Reviewed and added/corrected necessary imports from the `typing` module in the following files:
    - `src/http_page.py` (added Dict)
    - `src/custom_dns_adapter.py` (added Tuple, List, Dict, Any)
    - `src/main.py` (added Callable)
    - `src/window.py` (added Optional, Any)
    - `src/utils.py` (added Optional)
- Verified typing imports in `src/http_client.py` and `src/dns_client.py`.
- Updated some internal type hints to use imported types (e.g., `dict` to `Dict`).