### PR TITLE
Refactor: Improve UI methods, async operations, and linting

### DIFF
--- a/src/dns_client.py
+++ b/src/dns_client.py
@@ -4,6 +4,7 @@ Module for performing DNS lookups.
 """
 import logging
 from typing import Optional, List, Dict, Any
+import ipaddress # Added: Used in resolve()
 
 import dns.resolver
 import dns.reversename
@@ -160,5 +161,4 @@ class DnsResolverClient:
 
         return self._lookup_record_internal(query_target, record_type.upper())
 
-# ipaddress is imported within resolve method for its local IP check,
-# making a global import or separate utility here for that specific check redundant.
+# Comment about ipaddress import location removed as it's now a module-level import.

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -130,98 +130,126 @@ class DNSPage(Adw.PreferencesPage):
     # _fetch_dns_records logic is now part of _perform_lookup using DnsResolverClient
     # _lookup_record was moved to DnsResolverClient (as _lookup_record_internal)
 
-    def _perform_lookup(self):  # noqa: C901 # Function complexity is high
-        """Perform the DNS lookup based on user input and selected record type.
-
-        Handles input validation, uses :class:`.dns_client.DnsResolverClient`
-        for performing the lookup, and then displays results or error messages.
-        """
+    def _set_loading_state(self, active: bool) -> None:
+        """Sets the UI loading state (spinner, sensitivity)."""
         if self.dns_lookup_spinner:
-            self.dns_lookup_spinner.set_visible(True) # type: ignore
-            self.dns_lookup_spinner.start() # type: ignore
+            self.dns_lookup_spinner.set_visible(active) # type: ignore
+            if active:
+                self.dns_lookup_spinner.start() # type: ignore
+            else:
+                self.dns_lookup_spinner.stop() # type: ignore
+        # Potentially disable/enable other controls like domain_entry or apply_button here
+        # self.domain_entry.set_sensitive(not active) # type: ignore
+        # self.dns_apply_button.set_sensitive(not active) # type: ignore
 
-        user_input = self.domain_entry.get_text().strip() # type: ignore
-        requested_record_type = self._get_selected_record_type()
-        logger.debug(f"DNSPage: Performing DNS lookup for: {user_input}, type: {requested_record_type}")
-
+    def _validate_dns_input(self, user_input: str) -> bool:
+        """
+        Validates the DNS user input. Shows global error/toast if invalid.
+        :return: True if valid, False otherwise.
+        """
         if not user_input:
             show_global_toast(self, "Input cannot be empty.") # type: ignore
             main_window = self.get_native() # type: ignore
             if not (main_window and hasattr(main_window, 'show_toast')):
                 show_global_error(self, "Input cannot be empty.") # type: ignore
-            if self.dns_lookup_spinner:
-                self.dns_lookup_spinner.stop() # type: ignore
-                self.dns_lookup_spinner.set_visible(False) # type: ignore
-            return
-
-        self._clear_error()
+            return False
 
         if not self._is_valid_ip_or_domain(user_input):
             show_global_toast(self, "Invalid IP address or domain name.") # type: ignore
             main_window = self.get_native() # type: ignore
             if not (main_window and hasattr(main_window, 'show_toast')):
                 show_global_error(self, "Invalid IP address or domain name.") # type: ignore
-            if self.dns_lookup_spinner:
-                self.dns_lookup_spinner.stop() # type: ignore
-                self.dns_lookup_spinner.set_visible(False) # type: ignore
-            return
+            return False
+        return True
 
-        custom_dns_server = self.settings.get_string("custom-dns-server")
-        dns_client = DnsResolverClient(custom_dns_server=custom_dns_server if custom_dns_server else None)
-
+    def _update_ptr_dropdown(self, user_input: str, requested_record_type: str) -> str:
+        """
+        Updates the record type dropdown to PTR if an IP was entered and PTR was requested.
+        Returns the record type that was effectively used or set.
+        """
         actual_record_type_used = requested_record_type
-        if is_valid_ip(user_input) and requested_record_type.upper() != "PTR":
-            # If input is an IP but PTR not selected, inform user PTR will be used
-            # Or, automatically switch to PTR if that's desired UX.
-            # For now, DnsResolverClient handles PTR if record_type is "PTR".
-            # If user enters IP and selects "A", DnsResolverClient will try "A" for IP (likely error/empty).
-            # This behavior is kept from original, but could be a UX improvement point.
-            pass # No automatic switch here, client will handle based on type.
-            # If an IP is given, and record type is not PTR, DnsResolverClient will try to resolve it as is.
-            # If PTR is selected, DnsResolverClient's resolve method handles reverse name conversion.
-
         if is_valid_ip(user_input) and requested_record_type.upper() == "PTR":
-             actual_record_type_used = "PTR" # Ensure this is set if logic relies on it later
+            model = self.dns_record_type_dropdown.get_model() # type: ignore
+            if model:
+                for i in range(model.get_n_items()): # type: ignore
+                    if model.get_string(i) == "PTR": # type: ignore
+                        self.dns_record_type_dropdown.set_selected(i) # type: ignore
+                        actual_record_type_used = "PTR"
+                        break
+        return actual_record_type_used
 
-        try:
-            # DnsResolverClient's resolve method handles PTR for IPs internally if type is "PTR"
-            result_data = dns_client.resolve(user_input, requested_record_type)
+    def _handle_dns_lookup_success(
+        self,
+        result_data: List[Dict[str, Any]],
+        user_input: str,
+        requested_record_type: str, # The type initially selected by user
+        dns_client: DnsResolverClient
+    ) -> None:
+        """Handles successful DNS lookup results."""
+        # Determine the actual type used, especially if PTR was auto-selected for an IP.
+        # DnsResolverClient internally handles reverse name for PTR if domain_or_ip is an IP.
+        # So, if user selected PTR for an IP, requested_record_type is already "PTR".
+        # If user selected something else for an IP, DnsResolverClient tried that type.
+        # This logic is mainly for updating the dropdown if it wasn't already PTR for an IP.
+        actual_record_type_displayed = requested_record_type
+        if is_valid_ip(user_input) and requested_record_type.upper() == "PTR":
+            actual_record_type_displayed = self._update_ptr_dropdown(user_input, requested_record_type)
 
-            # Update dropdown if an IP was entered and PTR was effectively used by client
-            # (or if user selected PTR for an IP)
-            if is_valid_ip(user_input) and requested_record_type.upper() == "PTR":
-                 model = self.dns_record_type_dropdown.get_model() # type: ignore
-                 if model:
-                    for i in range(model.get_n_items()): # type: ignore
-                        if model.get_string(i) == "PTR": # type: ignore
-                            self.dns_record_type_dropdown.set_selected(i) # type: ignore
-                            actual_record_type_used = "PTR"
-                            break
+        nameservers_used = dns_client.resolver.nameservers
+        self._display_result(result_data, user_input, actual_record_type_displayed, nameservers_used)
 
-            nameservers_used = dns_client.resolver.nameservers
-            self._display_result(result_data, user_input, actual_record_type_used, nameservers_used)
-
-        except DnsNxDomainError as e:
-            show_global_error(self, str(e)) # type: ignore
-        except DnsNoAnswerError as e:
-            logger.info("DNSPage: %s", str(e))
+    def _handle_dns_lookup_exception(
+        self,
+        error: Exception,
+        user_input: str,
+        requested_record_type: str,
+        dns_client: DnsResolverClient # Pass client to get nameservers for NoAnswer
+    ) -> None:
+        """Handles exceptions from DnsResolverClient."""
+        if isinstance(error, DnsNxDomainError):
+            show_global_error(self, str(error)) # type: ignore
+        elif isinstance(error, DnsNoAnswerError):
+            logger.info("DNSPage: %s", str(error))
             nameservers_used = dns_client.resolver.nameservers
             self._display_result([], user_input, requested_record_type, nameservers_used)
-        except DnsResolutionTimeoutError as e:
-            show_global_error(self, str(e)) # type: ignore
-        except DnsGenericError as e: # Covers other DNS specific errors from client
-            logger.exception("DNSPage: DNS lookup failed for %s, type %s:", user_input, requested_record_type)
-            show_global_error(self, str(e)) # type: ignore
-        except DnsClientError as e: # Catch-all for any other client base errors
+        elif isinstance(error, DnsResolutionTimeoutError):
+            show_global_error(self, str(error)) # type: ignore
+        elif isinstance(error, DnsGenericError):
+            logger.exception("DNSPage: DNS lookup failed for %s, type %s (DnsGenericError):", user_input, requested_record_type)
+            show_global_error(self, str(error)) # type: ignore
+        elif isinstance(error, DnsClientError): # Base client error
             logger.exception("DNSPage: Unexpected DnsClientError for %s, type %s:", user_input, requested_record_type)
-            show_global_error(self, f"DNS Client Error: {str(e)}") # type: ignore
-        except Exception as e: # Catch any other unexpected errors
+            show_global_error(self, f"DNS Client Error: {str(error)}") # type: ignore
+        else: # Generic Exception
             logger.exception("DNSPage: Unexpected error during DNS lookup for %s, type %s:", user_input, requested_record_type)
-            show_global_error(self, f"An unexpected error occurred: {str(e)}") # type: ignore
+            show_global_error(self, f"An unexpected error occurred: {str(error)}") # type: ignore
+
+    def _perform_lookup(self) -> None: # noqa: C901
+        """Perform the DNS lookup based on user input and selected record type.
+
+        Orchestrates input validation, client interaction, and result/error display.
+        """
+        self._set_loading_state(True)
+        user_input = self.domain_entry.get_text().strip() # type: ignore
+        requested_record_type = self._get_selected_record_type()
+        logger.debug(f"DNSPage: Performing DNS lookup for: {user_input}, type: {requested_record_type}")
+
+        if not self._validate_dns_input(user_input):
+            self._set_loading_state(False)
+            return
+
+        self._clear_error()
+
+        custom_dns_server = self.settings.get_string("custom-dns-server")
+        dns_client = DnsResolverClient(custom_dns_server=custom_dns_server or None)
+
+        try:
+            result_data = dns_client.resolve(user_input, requested_record_type)
+            self._handle_dns_lookup_success(result_data, user_input, requested_record_type, dns_client)
+        except Exception as e: # Catch all exceptions here and delegate to the handler
+            self._handle_dns_lookup_exception(e, user_input, requested_record_type, dns_client)
         finally:
-            if self.dns_lookup_spinner:
-                self.dns_lookup_spinner.stop() # type: ignore
-                self.dns_lookup_spinner.set_visible(False) # type: ignore
+            self._set_loading_state(False)
 
     def _get_selected_record_type(self) -> str:
         """Get the currently selected DNS record type from the dropdown.
@@ -301,242 +329,171 @@ class DNSPage(Adw.PreferencesPage):
             if row:
                 self.dns_results_box_container.append(row) # type: ignore
 
-    def _build_address_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ActionRow:
-        """Build a UI row for an A or AAAA DNS record.
+    # --- Helper methods for building record rows ---
 
-        :param record_data: Dictionary containing parsed record data.
-        :type record_data: dict[str, any]
-        :param name: The record name.
-        :type name: str
-        :param base_subtitle: Base subtitle string (Class, TTL).
-        :type base_subtitle: str
-        :param record_type: The record type ("A" or "AAAA").
-        :type record_type: str
-        :return: An :class:`Adw.ActionRow` displaying the address record.
-        :rtype: Adw.ActionRow
-        """
-        row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type}, {base_subtitle}") # type: ignore
-        row.add_prefix(Gtk.Image(icon_name="network-wired-symbolic")) # type: ignore
-        address_value = str(record_data.get('address', 'N/A'))
-        address_label = Gtk.Label(label=address_value, halign=Gtk.Align.START, selectable=True)
-        copy_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_button.set_valign(Gtk.Align.CENTER)
-        copy_button.set_tooltip_text(f"Copy Address: {address_value}")
-        copy_button.connect("clicked", lambda _btn, text=address_value, w=row: DNSPage._copy_to_clipboard(text, w))
-        suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        suffix_box.append(address_label)
-        suffix_box.append(copy_button)
-        summary_a = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {address_value}"
-        copy_full_button_a = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_full_button_a.set_valign(Gtk.Align.CENTER)
-        copy_full_button_a.set_tooltip_text("Copy Full Record Summary")
-        copy_full_button_a.connect("clicked", lambda _btn, text=summary_a, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-        suffix_box.append(copy_full_button_a)
-        row.add_suffix(suffix_box) # type: ignore
+    def _create_copy_button(self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget) -> Gtk.Button:
+        """Creates a Gtk.Button for copying text."""
+        button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
+        button.set_valign(Gtk.Align.CENTER)
+        button.set_tooltip_text(tooltip_text)
+        button.connect("clicked", lambda _btn, text=text_to_copy, w=widget_for_clipboard: DNSPage._copy_to_clipboard(text, w))
+        return button
+
+    def _create_base_action_row(self, name: str, record_type_label: str, base_subtitle_text: str, icon_name: Optional[str]) -> Adw.ActionRow:
+        """Creates a basic Adw.ActionRow with title, subtitle, and optional icon."""
+        row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type_label}, {base_subtitle_text}") # type: ignore
+        if icon_name:
+            row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
         row.set_selectable(False)
+        return row
+
+    def _add_standard_suffix_box_to_row(
+        self,
+        row: Adw.ActionRow,
+        main_value_text: str,
+        main_value_tooltip_prefix: str,
+        full_summary_text: str
+    ) -> None:
+        """Adds a standard suffix box (label, copy value button, copy summary button) to an ActionRow."""
+        suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+
+        value_label = Gtk.Label(label=main_value_text, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
+        suffix_box.append(value_label)
+
+        copy_value_button = self._create_copy_button(main_value_text, f"{main_value_tooltip_prefix}: {main_value_text}", row)
+        suffix_box.append(copy_value_button)
+
+        copy_full_summary_button = self._create_copy_button(full_summary_text, "Copy Full Record Summary", row)
+        suffix_box.append(copy_full_summary_button)
+
+        row.add_suffix(suffix_box) # type: ignore
+
+    def _create_base_expander_row(self, name: str, subtitle_text: str, icon_name: Optional[str], full_summary_text: str) -> Adw.ExpanderRow:
+        """Creates a basic Adw.ExpanderRow with title, subtitle, icon, and a full summary copy button."""
+        row = Adw.ExpanderRow(title=name, subtitle=subtitle_text) # type: ignore
+        if icon_name:
+            row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
+
+        copy_full_button = self._create_copy_button(full_summary_text, "Copy Full Record Summary", row)
+        row.add_suffix(copy_full_button) # type: ignore
+        # row.set_expanded(True) # Decided by caller, as TXT/SOA might be empty initially
+        return row
+
+    def _add_expander_detail_row(
+            self,
+            expander_row: Adw.ExpanderRow,
+            title: Optional[str],
+            value_text: str,
+            copy_tooltip_prefix: str,
+            is_value_primary_content: bool = False
+        ):
+        """Adds a detail row (Adw.ActionRow) to an Adw.ExpanderRow."""
+        detail_row = Adw.ActionRow(title=title if title else None) # type: ignore
+
+        value_label = Gtk.Label(label=value_text, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
+        copy_button = self._create_copy_button(value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row)
+
+        content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        content_box.append(value_label)
+        content_box.append(copy_button)
+
+        if is_value_primary_content : # For TXT segments where the value is the main content of the row
+            detail_row.add_prefix(content_box) # type: ignore
+        else: # For SOA fields where title is present and value is a suffix
+            detail_row.add_suffix(content_box) # type: ignore
+
+        detail_row.set_selectable(False)
+        expander_row.add_row(detail_row) # type: ignore
+
+    # --- Modified _build_*_record_row methods ---
+
+    def _build_address_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ActionRow:
+        """Build a UI row for an A or AAAA DNS record."""
+        row = self._create_base_action_row(name, record_type, base_subtitle, "network-wired-symbolic")
+        address_value = str(record_data.get('address', 'N/A'))
+        summary_text = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {address_value}"
+        self._add_standard_suffix_box_to_row(row, address_value, "Copy Address", summary_text)
         return row
 
     def _build_cname_ns_ptr_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ActionRow:
-        """Build a UI row for CNAME, NS, or PTR DNS records.
-
-        :param record_data: Dictionary containing parsed record data.
-        :type record_data: dict[str, any]
-        :param name: The record name.
-        :type name: str
-        :param base_subtitle: Base subtitle string (Class, TTL).
-        :type base_subtitle: str
-        :param record_type: The record type ("CNAME", "NS", or "PTR").
-        :type record_type: str
-        :return: An :class:`Adw.ActionRow` displaying the record.
-        :rtype: Adw.ActionRow
-        """
-        row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type}, {base_subtitle}") # type: ignore
-        icon_name = "emblem-shared-symbolic"
+        """Build a UI row for CNAME, NS, or PTR DNS records."""
+        icon_name = "emblem-shared-symbolic" # Default for CNAME
         if record_type == "NS": icon_name = "network-server-symbolic"
         elif record_type == "PTR": icon_name = "system-search-symbolic"
-        row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
+
+        row = self._create_base_action_row(name, record_type, base_subtitle, icon_name)
         target_value = str(record_data.get('target', 'N/A'))
-        target_label = Gtk.Label(label=target_value, halign=Gtk.Align.START, selectable=True)
-        copy_button_target = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_button_target.set_valign(Gtk.Align.CENTER)
-        copy_button_target.set_tooltip_text(f"Copy Target: {target_value}")
-        copy_button_target.connect("clicked", lambda _btn, text=target_value, w=row: DNSPage._copy_to_clipboard(text, w))
-        suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        suffix_box.append(target_label)
-        suffix_box.append(copy_button_target)
-        summary_cname_ns_ptr = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {target_value}"
-        copy_full_button_cname = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_full_button_cname.set_valign(Gtk.Align.CENTER)
-        copy_full_button_cname.set_tooltip_text("Copy Full Record Summary")
-        copy_full_button_cname.connect("clicked", lambda _btn, text=summary_cname_ns_ptr, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-        suffix_box.append(copy_full_button_cname)
-        row.add_suffix(suffix_box) # type: ignore
-        row.set_selectable(False)
+        summary_text = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {target_value}"
+        self._add_standard_suffix_box_to_row(row, target_value, "Copy Target", summary_text)
         return row
 
-    def _build_mx_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow:
-        """Build a UI row for an MX DNS record.
+    def _build_generic_data_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ActionRow:
+        """Builds a UI row for generic DNS records that have a 'data' field."""
+        row = self._create_base_action_row(name, record_type, base_subtitle, "help-question-symbolic")
+        data_value = str(record_data.get('data', 'N/A'))
+        summary_text = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {data_value}"
+        self._add_standard_suffix_box_to_row(row, data_value, "Copy Data", summary_text)
+        return row
 
-        :param record_data: Dictionary containing parsed record data.
-        :type record_data: dict[str, any]
-        :param name: The record name.
-        :type name: str
-        :param base_subtitle: Base subtitle string (Class, TTL).
-        :type base_subtitle: str
-        :param record_type: The record type ("MX").
-        :type record_type: str
-        :return: An :class:`Adw.ExpanderRow` displaying the MX record details.
-        :rtype: Adw.ExpanderRow
-        """
-        row = Adw.ExpanderRow(title=name, subtitle=f"MX Record ({base_subtitle})") # type: ignore
-        row.add_prefix(Gtk.Image(icon_name="mail-send-receive-symbolic")) # type: ignore
+    def _build_mx_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow: # record_type is "MX"
+        """Build a UI row for an MX DNS record."""
         exchange_value = str(record_data.get('exchange', 'N/A'))
         preference_value = str(record_data.get('preference', 'N/A'))
+        summary_mx = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} MX {preference_value} {exchange_value}"
 
+        row = self._create_base_expander_row(name, f"MX Record ({base_subtitle})", "mail-send-receive-symbolic", summary_mx)
+
+        # MX detail row is specific
         mx_detail_row_title_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         mx_detail_row_title_box.append(Gtk.Label(label=exchange_value, halign=Gtk.Align.START, selectable=True))
-        copy_button_exchange = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_button_exchange.set_valign(Gtk.Align.CENTER)
-        copy_button_exchange.set_tooltip_text(f"Copy Exchange: {exchange_value}")
-        copy_button_exchange.connect("clicked", lambda _btn, text=exchange_value, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
+        copy_button_exchange = self._create_copy_button(exchange_value, f"Copy Exchange: {exchange_value}", row)
         mx_detail_row_title_box.append(copy_button_exchange)
 
         mx_detail_row = Adw.ActionRow(subtitle=f"Preference: {preference_value}") # type: ignore
         mx_detail_row.add_prefix(mx_detail_row_title_box) # type: ignore
-        mx_detail_row.set_selectable(True)
+        mx_detail_row.set_selectable(True) # Allow selecting to copy preference if needed, though not directly copyable via button
         row.add_row(mx_detail_row) # type: ignore
-        row.set_expanded(True) # type: ignore
-
-        summary_mx = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} MX {preference_value} {exchange_value}"
-        copy_full_mx_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_full_mx_button.set_valign(Gtk.Align.CENTER)
-        copy_full_mx_button.set_tooltip_text("Copy Full MX Record")
-        copy_full_mx_button.connect("clicked", lambda _btn, text=summary_mx, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-        row.add_suffix(copy_full_mx_button) # type: ignore
+        row.set_expanded(True)
         return row
 
-    def _build_txt_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow:
-        """Build a UI row for a TXT DNS record.
-
-        :param record_data: Dictionary containing parsed record data.
-        :type record_data: dict[str, any]
-        :param name: The record name.
-        :type name: str
-        :param base_subtitle: Base subtitle string (Class, TTL).
-        :type base_subtitle: str
-        :param record_type: The record type ("TXT").
-        :type record_type: str
-        :return: An :class:`Adw.ExpanderRow` displaying TXT record strings.
-        :rtype: Adw.ExpanderRow
-        """
-        row = Adw.ExpanderRow(title=name, subtitle=f"TXT Records ({base_subtitle})") # type: ignore
-        row.add_prefix(Gtk.Image(icon_name="document-properties-symbolic")) # type: ignore
+    def _build_txt_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow: # record_type is "TXT"
+        """Build a UI row for a TXT DNS record."""
         texts = record_data.get('texts', [])
-        if not texts:
-            row.add_row(Adw.ActionRow(title="No text data.", selectable=False)) # type: ignore
-        for text_string in texts:
-            text_label = Gtk.Label(label=text_string, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
-            copy_button_segment = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-            copy_button_segment.set_valign(Gtk.Align.CENTER)
-            copy_button_segment.set_tooltip_text("Copy Text Segment")
-            copy_button_segment.connect("clicked", lambda _btn, text=text_string, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-            text_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-            text_box.append(text_label)
-            text_box.append(copy_button_segment)
-            text_action_row = Adw.ActionRow() # type: ignore
-            text_action_row.add_prefix(text_box) # type: ignore
-            text_action_row.set_selectable(False)
-            row.add_row(text_action_row) # type: ignore
-        row.set_expanded(True if texts else False) # type: ignore
-
         texts_str_summary = " ".join([f'"{s}"' for s in texts])
         summary_txt = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} TXT {texts_str_summary}"
-        copy_full_txt_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_full_txt_button.set_valign(Gtk.Align.CENTER)
-        copy_full_txt_button.set_tooltip_text("Copy Full TXT Record")
-        copy_full_txt_button.connect("clicked", lambda _btn, text=summary_txt, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-        row.add_suffix(copy_full_txt_button) # type: ignore
+
+        row = self._create_base_expander_row(name, f"TXT Records ({base_subtitle})", "document-properties-symbolic", summary_txt)
+
+        if not texts:
+            no_text_row = Adw.ActionRow(title="No text data.", selectable=False) #type: ignore
+            row.add_row(no_text_row) # type: ignore
+        else:
+            for text_string in texts:
+                self._add_expander_detail_row(row, None, text_string, "Copy Text Segment", is_value_primary_content=True)
+        row.set_expanded(bool(texts))
         return row
 
-    def _build_soa_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow:
-        """Build a UI row for an SOA DNS record.
+    def _build_soa_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ExpanderRow: # record_type is "SOA"
+        """Build a UI row for an SOA DNS record."""
+        mname_val = str(record_data.get('mname', 'N/A'))
+        rname_val = str(record_data.get('rname', 'N/A'))
+        serial_val = str(record_data.get('serial', 'N/A'))
+        refresh_val = str(record_data.get('refresh', 'N/A'))
+        retry_val = str(record_data.get('retry', 'N/A'))
+        expire_val = str(record_data.get('expire', 'N/A'))
+        minimum_val = str(record_data.get('minimum', 'N/A'))
 
-        :param record_data: Dictionary containing parsed record data.
-        :type record_data: dict[str, any]
-        :param name: The record name.
-        :type name: str
-        :param base_subtitle: Base subtitle string (Class, TTL).
-        :type base_subtitle: str
-        :param record_type: The record type ("SOA").
-        :type record_type: str
-        :return: An :class:`Adw.ExpanderRow` displaying SOA record details.
-        :rtype: Adw.ExpanderRow
-        """
-        row = Adw.ExpanderRow(title=name, subtitle=f"SOA Record ({base_subtitle})") # type: ignore
-        row.add_prefix(Gtk.Image(icon_name="document-settings-symbolic")) # type: ignore
-        mname_val, rname_val, serial_val, refresh_val, retry_val, expire_val, minimum_val = \
-            (str(record_data.get(k, 'N/A')) for k in ['mname','rname','serial','refresh','retry','expire','minimum'])
+        summary_soa = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} SOA {mname_val} {rname_val} {serial_val} {refresh_val} {retry_val} {expire_val} {minimum_val}"
+        row = self._create_base_expander_row(name, f"SOA Record ({base_subtitle})", "document-settings-symbolic", summary_soa)
+
         soa_fields = [
             ("MNAME", mname_val), ("RNAME", rname_val), ("Serial", serial_val),
             ("Refresh", refresh_val), ("Retry", retry_val), ("Expire", expire_val),
             ("Minimum TTL", minimum_val)
         ]
         for field_name_str, field_value in soa_fields:
-            field_label = Gtk.Label(label=field_value, halign=Gtk.Align.START, selectable=True)
-            copy_button_field = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-            copy_button_field.set_valign(Gtk.Align.CENTER)
-            copy_button_field.set_tooltip_text(f"Copy {field_name_str}: {field_value}")
-            copy_button_field.connect("clicked", lambda _btn, text=field_value, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-            suffix_box_soa_field = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-            suffix_box_soa_field.append(field_label)
-            suffix_box_soa_field.append(copy_button_field)
-            soa_field_row = Adw.ActionRow(title=field_name_str) # type: ignore
-            soa_field_row.add_suffix(suffix_box_soa_field) # type: ignore
-            soa_field_row.set_selectable(False)
-            row.add_row(soa_field_row) # type: ignore
-        row.set_expanded(True) # type: ignore
-
-        summary_soa = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} SOA {mname_val} {rname_val} {serial_val} {refresh_val} {retry_val} {expire_val} {minimum_val}"
-        copy_full_soa_button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_full_soa_button.set_valign(Gtk.Align.CENTER)
-        copy_full_soa_button.set_tooltip_text("Copy Full SOA Record")
-        copy_full_soa_button.connect("clicked", lambda _btn, text=summary_soa, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-        row.add_suffix(copy_full_soa_button) # type: ignore
-        return row
-
-    def _build_generic_record_row(self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str) -> Adw.ActionRow:
-        """Build a UI row for a generic DNS record (displays raw 'data' field).
-
-        :param record_data: Dictionary containing parsed record data.
-        :type record_data: dict[str, any]
-        :param name: The record name.
-        :type name: str
-        :param base_subtitle: Base subtitle string (Class, TTL).
-        :type base_subtitle: str
-        :param record_type: The record type.
-        :type record_type: str
-        :return: An :class:`Adw.ActionRow` displaying the generic record data.
-        :rtype: Adw.ActionRow
-        """
-        row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type}, {base_subtitle}") # type: ignore
-        row.add_prefix(Gtk.Image(icon_name="help-question-symbolic")) # type: ignore
-        data_value = str(record_data.get('data', 'N/A'))
-        data_label = Gtk.Label(label=data_value, halign=Gtk.Align.START, selectable=True, wrap=True)
-        copy_button_data = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_button_data.set_valign(Gtk.Align.CENTER)
-        copy_button_data.set_tooltip_text(f"Copy Data: {data_value}")
-        copy_button_data.connect("clicked", lambda _btn, text=data_value, w=row: DNSPage._copy_to_clipboard(text, w))
-        suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        suffix_box.append(data_label)
-        suffix_box.append(copy_button_data)
-        summary_data = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {data_value}"
-        copy_full_button_data = Gtk.Button.new_from_icon_name("content-copy-symbolic")
-        copy_full_button_data.set_valign(Gtk.Align.CENTER)
-        copy_full_button_data.set_tooltip_text("Copy Full Record Summary")
-        copy_full_button_data.connect("clicked", lambda _btn, text=summary_data, w=row: DNSPage._copy_to_clipboard(text, w)) # type: ignore
-        suffix_box.append(copy_full_button_data)
-        row.add_suffix(suffix_box) # type: ignore
-        row.set_selectable(False)
+            self._add_expander_detail_row(row, field_name_str, field_value, f"Copy {field_name_str}")
+        row.set_expanded(True)
         return row
 
     def _create_record_row(self, record_data: Dict[str, Any]) -> Optional[Gtk.Widget]:
@@ -561,7 +518,7 @@ class DNSPage(Adw.PreferencesPage):
         elif record_type == "MX": return self._build_mx_record_row(record_data, name, base_subtitle, record_type)
         elif record_type == "TXT": return self._build_txt_record_row(record_data, name, base_subtitle, record_type)
         elif record_type == "SOA": return self._build_soa_record_row(record_data, name, base_subtitle, record_type)
-        elif record_data.get('data'): return self._build_generic_record_row(record_data, name, base_subtitle, record_type)
+        elif record_data.get('data'): return self._build_generic_data_record_row(record_data, name, base_subtitle, record_type) # Renamed
         else:
             logger.warning("Could not create row for unknown record_data type or missing data field: %s (Type: %s)", record_data, record_type)
             return None

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -70,6 +70,8 @@ class NmapPage(Gtk.Box):
     nmap_timing_template_comborow = Gtk.Template.Child("nmap_timing_template_comborow")
     status_row = Gtk.Template.Child("status_row")
     scan_spinner = Gtk.Template.Child("scan_spinner")
+    # Cancel button will be added programmatically
+    # nmap_cancel_scan_button = Gtk.Template.Child("nmap_cancel_scan_button")
 
     left_vbox_content = Gtk.Template.Child("left_vbox_content")
     nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")
@@ -84,7 +86,11 @@ class NmapPage(Gtk.Box):
         self.nmap_target_listbox_store = Gio.ListStore(item_type=NmapItem)
         self.scanner = NmapScanner()
         self.settings = Gio.Settings.new(APP_ID)
-        self._init_page_ui()
+
+        self.current_nmap_task: Optional[Gio.Task] = None
+        self.current_nmap_cancellable: Optional[Gio.Cancellable] = None
+
+        self._init_page_ui() # Includes adding cancel button now
         self._connect_signals()
         if self.nmap_apply_button:
             self.nmap_apply_button.set_use_underline(True)
@@ -92,9 +98,13 @@ class NmapPage(Gtk.Box):
         logger.debug("NmapPage __init__ completed.")
 
     def __del__(self):
-        """Clean up resources, specifically the NmapScanner's thread pool."""
+        """Clean up resources, specifically the NmapScanner's thread pool and cancel any ongoing scan."""
+        if self.current_nmap_cancellable and not self.current_nmap_cancellable.is_cancelled():
+            self.current_nmap_cancellable.cancel()
+            logger.info("NmapPage finalized, ongoing scan cancelled.")
         if hasattr(self, "scanner") and self.scanner:
-            del self.scanner  # NmapScanner.__del__ handles executor shutdown
+            del self.scanner
+        super().__del__() # Important if GObject has its own __del__
 
     def _on_source_style_scheme_setting_changed(self, _settings: Gio.Settings, key: str):
         """Handle changes to the 'source-style-scheme' GSettings key."""
@@ -123,6 +133,19 @@ class NmapPage(Gtk.Box):
         self.scan_spinner.set_spinning(False)
         self.scan_spinner.set_visible(False)
         self.status_row.set_subtitle("Idle")
+
+        # Programmatically create and add the Cancel Scan button
+        self.nmap_cancel_scan_button = Gtk.Button(label="Cancel Scan", icon_name="process-stop-symbolic")
+        self.nmap_cancel_scan_button.set_sensitive(False)
+        self.nmap_cancel_scan_button.set_visible(False) # Initially hidden
+        self.nmap_cancel_scan_button.add_css_class("destructive-action")
+        # Add it as a suffix to the status_row (Adw.ActionRow)
+        if isinstance(self.status_row, Adw.ActionRow):
+            self.status_row.add_suffix(self.nmap_cancel_scan_button)
+            self.status_row.set_activatable_widget(self.nmap_cancel_scan_button) # Or None if row itself not activatable
+        else:
+            logger.warning("status_row is not an Adw.ActionRow, cannot add cancel button as suffix.")
+
         logger.debug("NmapPage _init_page_ui completed.")
 
     def _clear_dynamic_details(self):
@@ -140,19 +163,28 @@ class NmapPage(Gtk.Box):
         self.nmap_target_entryrow.connect("entry-activated", self._on_target_activate)
         self.nmap_apply_button.connect("clicked", self._on_target_activate)
         self.nmap_host_listbox.connect("row-selected", self._on_target_selected)
+        if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button: # Ensure it was created
+            self.nmap_cancel_scan_button.connect("clicked", self._on_cancel_scan_clicked)
 
-    def _on_target_activate(self, entry_row: Adw.EntryRow):
-        logger.debug(f"_on_target_activate called by {entry_row}.")
+    def _on_cancel_scan_clicked(self, _button: Gtk.Button) -> None:
+        """Handle the 'Cancel Scan' button click."""
+        logger.info("Cancel scan button clicked.")
+        if self.current_nmap_cancellable and not self.current_nmap_cancellable.is_cancelled():
+            self.current_nmap_cancellable.cancel()
+            logger.info("Scan cancellation requested.")
+            # UI update will be handled by the task's done_cb when it exits due to cancellation
+        else:
+            logger.warning("No active scan or cancellable to cancel.")
+
+    def _on_target_activate(self, _widget: Adw.EntryRow): # pylint: disable=unused-argument # Gtk.Widget or Adw.EntryRow
+        logger.debug(f"_on_target_activate called by {_widget}.")
         target = self.nmap_target_entryrow.get_text().strip()
         self._clear_error()
 
         if not self.scanner.validate_target_input(target):
             message = "Invalid target format. Please enter a valid IP, CIDR, or hostname."
-            main_window = self.get_native()
-            if main_window and hasattr(main_window, "show_toast"):
-                show_global_toast(self, message)
-            else:
-                show_global_error(self, message)
+            show_global_toast(self, message) # type: ignore
+            # No need for main_window check here as show_global_toast is preferred
             return
         self.nmap_target_entryrow.remove_css_class("error")
 
@@ -160,104 +192,132 @@ class NmapPage(Gtk.Box):
             self._clear_results()
             return
 
-        self.nmap_target_entryrow.set_sensitive(False)
-        self._set_scan_status(ScanStatus.IN_PROGRESS, f"Scanning {target}...")
+        # Cancel any existing scan task
+        if self.current_nmap_task and not self.current_nmap_task.is_done():
+            if self.current_nmap_cancellable and not self.current_nmap_cancellable.is_cancelled():
+                logger.info("Requesting cancellation of previous Nmap scan task.")
+                self.current_nmap_cancellable.cancel()
+            # Do not start a new scan immediately; wait for the old one to actually cancel and clean up.
+            # Or, decide if a new scan should override. For now, let user cancel explicitly.
+            # For simplicity here, we'll just log and potentially prevent a new scan if one is running.
+            # A more robust approach might queue the new scan or provide more feedback.
+            if not self.current_nmap_task.is_done(): # Re-check after cancel attempt
+                 logger.warning("Previous scan task still running. Please cancel it explicitly or wait.")
+                 # show_global_toast(self, "A scan is already in progress. Cancel it or wait.")
+                 # return # Optionally prevent starting a new scan
 
-        os_fingerprinting = self.nmap_fingerprint_switchrow.get_active()
-        all_ports = self.nmap_all_ports_switchrow.get_active()
-        selected_script_item = self.nmap_scripts_dropdown.get_selected_item()
-        script_name = (
-            selected_script_item.get_string()
-            if isinstance(selected_script_item, Gtk.StringObject) and selected_script_item.get_string() != "None"
-            else None
-        )
-        service_version_detection = self.nmap_service_version_switchrow.get_active()
-        no_ping_scan = self.nmap_no_ping_switchrow.get_active()
-        selected_timing_item = self.nmap_timing_template_comborow.get_selected_item()
-        timing_template_str = selected_timing_item.get_string()
-        timing_match = re.search(r"\(T([0-5])\)", timing_template_str)
-        timing_template = f"T{timing_match.group(1)}" if timing_match else "T3"
-        custom_dns_server = self.settings.get_string("custom-dns-server")
+        self._set_scan_status(ScanStatus.IN_PROGRESS, f"Starting scan for {target}...")
 
-        logger.debug(
-            "Nmap scan parameters collected: target=%s, os_fingerprint=%s, all_ports=%s, script_name=%s, "
-            "service_version_detection=%s, no_ping_scan=%s, timing_template=%s, custom_dns_server=%s",
-            target,
-            os_fingerprinting,
-            all_ports,
-            script_name,
-            service_version_detection,
-            no_ping_scan,
-            timing_template,
-            custom_dns_server,
-        )
-        logger.info(
-            "Nmap scan for target: %s (OSScan:%s, AllPorts:%s, Script:%s, Ver:%s, NoPing:%s, Time:%s, CustomDNS:%s)",
-            target,
-            os_fingerprinting,
-            all_ports,
-            script_name,
-            service_version_detection,
-            no_ping_scan,
-            timing_template,
-            custom_dns_server if custom_dns_server else "None",
-        )
-        self.scanner.executor.submit(
-            self._run_nmap_scan_task,
-            target,
-            os_fingerprinting,
-            all_ports,
-            script_name,
-            service_version_detection,
-            no_ping_scan,
-            timing_template,
-            custom_dns_server,
-        )
+        self.current_nmap_cancellable = Gio.Cancellable()
 
-    def _run_nmap_scan_task(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        scan_params = {
+            "target": target,
+            "os_fingerprinting": self.nmap_fingerprint_switchrow.get_active(),
+            "all_ports": self.nmap_all_ports_switchrow.get_active(),
+            "script_name": (
+                item.get_string()
+                if isinstance(item := self.nmap_scripts_dropdown.get_selected_item(), Gtk.StringObject) and item.get_string() != "None"
+                else None
+            ),
+            "service_version_detection": self.nmap_service_version_switchrow.get_active(),
+            "no_ping_scan": self.nmap_no_ping_switchrow.get_active(),
+            "timing_template": (
+                f"T{m.group(1)}"
+                if (m := re.search(r"\(T([0-5])\)", self.nmap_timing_template_comborow.get_selected_item().get_string()))
+                else "T3"
+            ),
+            "custom_dns_server": self.settings.get_string("custom-dns-server")
+        }
+        logger.info(f"NmapPage: Starting Nmap scan task with params: {scan_params}")
+
+        self.current_nmap_task = Gio.Task.new(
+            self, self.current_nmap_cancellable, self._nmap_scan_task_done_cb # type: ignore
+        )
+        self.current_nmap_task.set_task_data(scan_params) # Store params for the thread
+        self.current_nmap_task.run_in_thread(self._run_nmap_scan_thread_func) # type: ignore
+
+
+    def _run_nmap_scan_thread_func(
         self,
-        target: str,
-        os_fingerprinting: bool,
-        all_ports: bool,
-        script_name: Optional[str],
-        service_version_detection: bool,
-        no_ping_scan: bool,
-        timing_template: str,
-        custom_dns_server: Optional[str],
+        task: Gio.Task,
+        _source_object: GObject.Object, # type: ignore
+        task_data: Dict[str, Any], # Custom task data
+        cancellable: Optional[Gio.Cancellable]
     ):
-        """Execute the Nmap scan in a separate thread via NmapScanner."""
-        logger.debug(
-            "_run_nmap_scan_task started for target: %s with options - OSScan:%s, AllPorts:%s, Script:%s, Ver:%s, NoPing:%s, Time:%s, CustomDNS:%s",
-            target,
-            os_fingerprinting,
-            all_ports,
-            script_name,
-            service_version_detection,
-            no_ping_scan,
-            timing_template,
-            custom_dns_server,
-        )
+        """Execute the Nmap scan in a separate thread via NmapScanner, for Gio.Task."""
+        params = task.get_task_data()
+        target = params["target"]
+        logger.debug(f"_run_nmap_scan_thread_func started for target: {target}")
+
+        if cancellable and cancellable.is_cancelled():
+            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value, "Scan cancelled before start.")
+            return
+
         try:
+            # run_nmap_scan will need to be modified to accept and use cancellable
             nm = self.scanner.run_nmap_scan(
-                target,
-                os_fingerprinting,
-                all_ports,
-                script_name,
-                service_version_detection,
-                no_ping_scan,
-                timing_template,
-                custom_dns_server=custom_dns_server,
+                target=params["target"],
+                os_fingerprinting=params["os_fingerprinting"],
+                all_ports=params["all_ports"],
+                script_name=params["script_name"],
+                service_version_detection=params["service_version_detection"],
+                no_ping_scan=params["no_ping_scan"],
+                timing_template=params["timing_template"],
+                custom_dns_server=params["custom_dns_server"],
+                cancellable=cancellable # Pass cancellable here
             )
-            GLib.idle_add(self._process_scan_results, nm, target)
+            if cancellable and cancellable.is_cancelled():
+                task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value, "Scan cancelled during operation.")
+            else:
+                task.return_value(nm) # type: ignore
         except nmap.PortScannerError as e:
             logger.exception("Nmap PortScannerError for %s:", target)
-            GLib.idle_add(self._handle_scan_error, target, f"Nmap scan error: {e}")
-        except Exception as e:  # pylint: disable=broad-except
+            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.SCAN_FAILED.value, f"Nmap scan error: {e}")
+        except Exception as e:
             logger.exception("Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__)
-            GLib.idle_add(self._handle_scan_error, target, f"Scan failed unexpectedly: {e}")
+            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.UNEXPECTED.value, f"Scan failed unexpectedly: {e}")
         finally:
-            GLib.idle_add(self.nmap_target_entryrow.set_sensitive, True)
-            logger.info("Nmap scan task finished for %s.", target)
+            logger.info("Nmap scan thread finished for %s.", target)
+            # UI sensitivity updates are handled in _nmap_scan_task_done_cb
+
+    def _nmap_scan_task_done_cb(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: object): # type: ignore
+        """Callback for when the Nmap scan Gio.Task completes."""
+        task = self.current_nmap_task # Should match the task that finished
+        original_target = task.get_task_data()["target"] if task and task.get_task_data() else "unknown target"
+
+        logger.info(f"Nmap scan task done for {original_target}.")
+
+        nm_results: Optional[nmap.PortScanner] = None
+        try:
+            nm_results = task.propagate_value().value if hasattr(task.propagate_value(), 'value') else task.propagate_value()
+            # nm_results = task.propagate_value() # type: ignore
+            if isinstance(nm_results, nmap.PortScanner):
+                 self._process_scan_results(nm_results, original_target)
+            else: # Should not happen if task.return_value(nm) was called with PortScanner object
+                 logger.error(f"Nmap scan for {original_target} returned unexpected result type: {type(nm_results)}")
+                 self._handle_scan_error(original_target, "Scan returned unexpected data.")
+        except GLib.Error as e:
+            logger.warning(f"Nmap scan for {original_target} failed or was cancelled. Domain: {e.domain}, Code: {e.code}, Message: {e.message}")
+            if e.matches(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value):
+                self._set_scan_status(ScanStatus.IDLE, f"Scan for {original_target} cancelled.")
+                self._clear_results() # Or some other specific UI state for cancellation
+            elif e.matches(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.SCAN_FAILED.value):
+                self._handle_scan_error(original_target, e.message)
+            else: # UNEXPECTED or other GLib.Error
+                self._handle_scan_error(original_target, f"Scan error: {e.message}")
+        except Exception as e: # Catch any other Python exceptions from this callback itself
+            logger.exception(f"NmapPage: Unexpected Python error in _nmap_scan_task_done_cb for {original_target}:")
+            self._handle_scan_error(original_target, f"Unexpected error processing scan results: {e}")
+        finally:
+            self.current_nmap_task = None
+            self.current_nmap_cancellable = None
+            self._set_scan_status(ScanStatus.IDLE, "Idle") # Reset to idle, or specific status based on outcome
+            self.nmap_target_entryrow.set_sensitive(True) # type: ignore
+            if self.nmap_apply_button: self.nmap_apply_button.set_sensitive(True) # type: ignore
+            if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
+                 self.nmap_cancel_scan_button.set_sensitive(False)
+                 self.nmap_cancel_scan_button.set_visible(False)
+
 
     def _process_scan_results(self, nm: nmap.PortScanner, original_target: str):
         """Process the Nmap scan results received from the scanner task."""
@@ -496,22 +556,31 @@ class NmapPage(Gtk.Box):
             style_context.remove_class(css_class)
         if status_type == ScanStatus.IN_PROGRESS:
             self.scan_spinner.set_visible(True)
-            self.scan_spinner.start()
-            self.status_row.set_title("Scanning...")
-            style_context.add_class("error-color")  # Red for scanning
-        else:
-            self.scan_spinner.stop()
-            self.scan_spinner.set_visible(False)
+            self.scan_spinner.start() # type: ignore
+            self.status_row.set_title("Scanning...") # type: ignore
+            style_context.add_class("accent-color") # Using accent for "in progress"
+            if self.nmap_apply_button: self.nmap_apply_button.set_sensitive(False) # type: ignore
+            if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
+                self.nmap_cancel_scan_button.set_visible(True)
+                self.nmap_cancel_scan_button.set_sensitive(True)
+        else: # Not IN_PROGRESS (COMPLETE, FAILED, IDLE)
+            self.scan_spinner.stop() # type: ignore
+            self.scan_spinner.set_visible(False) # type: ignore
+            if self.nmap_apply_button: self.nmap_apply_button.set_sensitive(True) # type: ignore
+            if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
+                self.nmap_cancel_scan_button.set_visible(False)
+                self.nmap_cancel_scan_button.set_sensitive(False)
+
             if status_type == ScanStatus.COMPLETE:
-                self.status_row.set_title("Scan Complete")
+                self.status_row.set_title("Scan Complete") # type: ignore
                 style_context.add_class("success-color")
             elif status_type == ScanStatus.FAILED:
-                self.status_row.set_title("Scan Failed")
+                self.status_row.set_title("Scan Failed") # type: ignore
                 style_context.add_class("error-color")
-            elif status_type == ScanStatus.IDLE:
-                self.status_row.set_title("Idle")
-            else:
-                self.status_row.set_title("Scan Status")
+            elif status_type == ScanStatus.IDLE: # Also for CANCELLED if no specific UI for it
+                self.status_row.set_title("Idle") # type: ignore
+            else: # Should not happen
+                self.status_row.set_title("Scan Status") # type: ignore
 
     def _clear_results(self):
         """Clear all Nmap scan results from the UI."""
@@ -526,9 +595,14 @@ class NmapPage(Gtk.Box):
         if not self.nmap_detail_placeholder.get_parent():
             self.nmap_detail_box.append(self.nmap_detail_placeholder)
         self.nmap_detail_placeholder.set_visible(True)
-        self.nmap_target_entryrow.remove_css_class("error")
-        self.nmap_target_entryrow.set_sensitive(True)
+        self.nmap_target_entryrow.remove_css_class("error") # type: ignore
+        self.nmap_target_entryrow.set_sensitive(True) # type: ignore
+        if self.nmap_apply_button: self.nmap_apply_button.set_sensitive(True) # type: ignore
+        if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
+            self.nmap_cancel_scan_button.set_sensitive(False)
+            self.nmap_cancel_scan_button.set_visible(False)
         self._set_scan_status(ScanStatus.IDLE, "Idle")
+
 
     def _on_error_banner_dismiss(self, _banner: Adw.Banner, *_args):
         """Handle dismissal of the error banner by clearing the error state."""
@@ -650,6 +724,17 @@ class NmapPage(Gtk.Box):
         """Programmatically triggers the Nmap 'Scan' action."""
         logger.debug("Nmap scan triggered by shortcut.")
         if self.nmap_apply_button and self.nmap_apply_button.get_sensitive():
-            self.nmap_apply_button.clicked()
+            self.nmap_apply_button.clicked() # type: ignore
+        elif self.current_nmap_task and not self.current_nmap_task.is_done():
+             show_global_toast(self, "A scan is already in progress. Cancel it or wait.") # type: ignore
         else:
             logger.warning("Nmap scan button not available or not sensitive, cannot trigger scan.")
+
+# --- Gio.Task Error Handling ---
+NMAP_SCAN_ERROR_DOMAIN = "nmap-scan-error-domain"
+
+class NmapScanErrorType(int, Enum):
+    """Enumeration of Nmap scan error types for Gio.Task error reporting."""
+    SCAN_FAILED = 0     # Corresponds to nmap.PortScannerError
+    UNEXPECTED = 1      # For other unexpected exceptions during scan
+    CANCELLED = 2       # If the scan was cancelled

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -10,9 +10,18 @@ import platform
 import subprocess
 import shlex
 import shutil
+import time # Added for sleep in polling loop
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, Union, List, Optional, Tuple
+from typing import Any, Dict, Union, List, Optional, Tuple, TypedDict # Added TypedDict
+
+# Import Gio for Cancellable type hint, actual object passed by caller
+try:
+    from gi.repository import Gio
+except ImportError:
+    # Fallback for environments where gi might not be available during linting/testing
+    # The actual Cancellable object will be passed by NmapPage.
+    Gio = None
 
 import nmap
 from nmap import PortScannerError
@@ -35,6 +44,23 @@ class ScanStatus(Enum):
     COMPLETE = (1.0, "Scan complete")
     FAILED = (1.0, "Scan failed unexpectedly")
     IDLE = (0.0, "Idle")
+
+
+class ScanCancelledError(PortScannerError): # Inherit from PortScannerError for consistency if desired
+    """Exception raised when an Nmap scan is cancelled."""
+    pass
+
+
+class NmapScanParameters(TypedDict, total=False):
+    """TypedDict for Nmap scan parameters."""
+    target: str
+    os_fingerprinting: bool
+    scan_all_ports: bool
+    selected_script: Optional[str]
+    service_version: bool
+    no_ping: bool
+    timing_template: str
+    custom_dns_server: Optional[str]
 
 
 def _is_scan_root_required(nmap_args_list: List[str]) -> bool:
@@ -88,14 +114,33 @@ class NmapScanner:
     """A wrapper around the python-nmap library to perform network scans."""
 
     def __init__(self):
-        """Initialize the NmapScanner with a ThreadPoolExecutor for concurrent scans."""
+        """Initialize the NmapScanner."""
         logger.debug("NmapScanner initialized.")
-        self.executor = ThreadPoolExecutor(max_workers=4)
-        self.nm = None
+        self.executor = ThreadPoolExecutor(max_workers=4) # Remains for now, though NmapPage uses Gio.Task
+        self.nm: Optional[nmap.PortScanner] = None
+        self.current_process: Optional[subprocess.Popen] = None
+        self.current_cancellable: Optional[Gio.Cancellable] = None
+
 
     def __del__(self):
-        """Ensure the ThreadPoolExecutor is shut down when the NmapScanner instance is deleted."""
-        self.executor.shutdown(wait=True)
+        """Ensure the ThreadPoolExecutor is shut down and any running Nmap process is terminated."""
+        logger.debug("NmapScanner.__del__ called.")
+        if self.current_process and self.current_process.poll() is None:
+            logger.info("Terminating active Nmap process during NmapScanner deletion.")
+            try:
+                self.current_process.terminate()
+                self.current_process.wait(timeout=1) # Wait a bit for termination
+            except subprocess.TimeoutExpired:
+                logger.warning("Nmap process did not terminate gracefully, killing.")
+                self.current_process.kill()
+            except Exception as e:
+                logger.exception(f"Error terminating Nmap process during deletion: {e}")
+            self.current_process = None
+
+        if hasattr(self, 'executor') and self.executor: # Check if executor was initialized
+            self.executor.shutdown(wait=True)
+        logger.debug("NmapScanner cleanup complete.")
+
 
     def validate_target_input(self, target: str) -> bool:
         """Validate the target string for Nmap scanning."""
@@ -149,58 +194,52 @@ class NmapScanner:
         logger.debug("Nmap options constructed: %s", options)
         return options
 
-    def _build_nmap_arguments(  # pylint: disable=too-many-arguments
-        self, target: str, os_fingerprinting: bool, scan_all_ports: bool,
-        selected_script: Optional[str], service_version: bool, no_ping: bool,
-        timing_template: str, custom_dns_server: Optional[str],
-    ) -> List[str]:
+    def _build_nmap_arguments(self, params: NmapScanParameters) -> List[str]:
         """Build the list of arguments for the Nmap command."""
         nmap_args_list = ["nmap", "-sS"] # -sS (TCP SYN scan) requires root.
 
-        if os_fingerprinting: nmap_args_list.append("-O")
-        if service_version: nmap_args_list.append("-sV")
-        if scan_all_ports: nmap_args_list.append("-p-")
-        if selected_script and selected_script != "None":
-            nmap_args_list.append(f"--script={selected_script}")
-        if no_ping: nmap_args_list.append("-Pn")
+        if params.get("os_fingerprinting"): nmap_args_list.append("-O")
+        if params.get("service_version"): nmap_args_list.append("-sV")
+        if params.get("scan_all_ports"): nmap_args_list.append("-p-")
+        if params.get("selected_script") and params["selected_script"] != "None":
+            nmap_args_list.append(f"--script={params['selected_script']}")
+        if params.get("no_ping"): nmap_args_list.append("-Pn")
 
+        timing_template = params.get("timing_template", "T3")
         if timing_template and re.match(r"^T[0-5]$", timing_template):
             nmap_args_list.append(f"-{timing_template}")
         else:
             nmap_args_list.append("-T3")  # Default timing
 
+        custom_dns_server = params.get("custom_dns_server")
         if custom_dns_server and custom_dns_server.strip():
             nmap_args_list.append(f"--dns-servers={custom_dns_server.strip()}")
             logger.info("Using custom DNS server for Nmap scan: %s", custom_dns_server.strip())
 
-        nmap_args_list.extend(["-oX", "-", target])  # XML output to stdout, target last
+        nmap_args_list.extend(["-oX", "-", params['target']])  # XML output to stdout, target last
         logger.debug("Built Nmap arguments: %s", nmap_args_list)
         return nmap_args_list
 
-    def _execute_nmap_command(
-        self, nmap_args_list: List[str], needs_escalation: bool
-    ) -> Tuple[str, str, int]:
-        """Execute the Nmap command, handling privilege escalation if needed."""
+    def _prepare_final_nmap_command(self, nmap_args_list: List[str], needs_escalation: bool) -> List[str]:
+        """Prepares the final Nmap command list, including path resolution and escalation."""
         final_command_parts: List[str] = []
         if needs_escalation:
             logger.info("Escalation required for Nmap scan execution.")
             final_command_parts = get_escalated_command(nmap_args_list)
             if not final_command_parts:
-                raise PortScannerError("Failed to prepare escalated command (empty result).")
+                # This case should ideally be handled within get_escalated_command by raising an error
+                # or returning a value that indicates failure, which can then be checked.
+                # For now, assume get_escalated_command raises or this check is sufficient.
+                raise PortScannerError("Failed to prepare escalated command (empty result from get_escalated_command).")
         else:
             nmap_executable = nmap_args_list[0]
             nmap_path = shutil.which(nmap_executable)
             if not nmap_path:
                 raise FileNotFoundError(f"Nmap executable '{nmap_executable}' not found for non-escalated command.")
             final_command_parts = [nmap_path] + nmap_args_list[1:]
+        return final_command_parts
 
-        logger.info("Executing Nmap command (first few parts): %s...", " ".join(shlex.quote(part) for part in final_command_parts[:4]))
-        try:
-            process = subprocess.run(final_command_parts, capture_output=True, text=True, check=False, encoding="utf-8")
-            return process.stdout, process.stderr, process.returncode
-        except Exception as e_subproc:
-            logger.exception("Subprocess execution failed for Nmap:")
-            raise PortScannerError(f"Nmap subprocess execution failed: {e_subproc}") from e_subproc
+    # _execute_nmap_command was merged into run_nmap_scan for Popen and cancellation handling
 
     def _parse_nmap_error_message(
         self, returncode: int, nmap_xml_output: str, nmap_stderr: str, needs_escalation: bool,
@@ -223,53 +262,91 @@ class NmapScanner:
                 error_message = "User cancelled the request for administrator privileges or authentication failed."
         return error_message
 
-    def run_nmap_scan(  # pylint: disable=too-many-arguments,too-many-locals
-        self, target: str, os_fingerprinting: bool, scan_all_ports: bool,
-        selected_script: Optional[str] = None, service_version: bool = False,
-        no_ping: bool = False, timing_template: str = "T3",
-        custom_dns_server: Optional[str] = None,
+    def run_nmap_scan(  # pylint: disable=too-many-locals # Keep for now, may resolve with further refactoring
+        self, params: NmapScanParameters,
+        cancellable: Optional[Gio.Cancellable] = None,
     ) -> nmap.PortScanner:
         logger.debug(
-            "run_nmap_scan called with target: %s, OS:%s, AllPorts:%s, Script:%s, Ver:%s, NoPing:%s, Time:%s, DNS:%s",
-            target, os_fingerprinting, scan_all_ports, selected_script, service_version, no_ping, timing_template, custom_dns_server
+            "run_nmap_scan called with params: %s, Cancellable: %s",
+            params, bool(cancellable)
         )
-        """Execute an Nmap scan with specified options."""
         self.nm = nmap.PortScanner()
-        nmap_args_list = self._build_nmap_arguments(
-            target, os_fingerprinting, scan_all_ports, selected_script,
-            service_version, no_ping, timing_template, custom_dns_server,
-        )
+        self.current_cancellable = cancellable
+
+        nmap_args_list = self._build_nmap_arguments(params)
+        needs_escalation = _is_scan_root_required(nmap_args_list)
+
+        final_command_parts = self._prepare_final_nmap_command(nmap_args_list, needs_escalation)
+
+        logger.info("Executing Nmap command (first few parts): %s...", " ".join(shlex.quote(part) for part in final_command_parts[:4]))
+
+        stdout_str, stderr_str, returncode = "", "", -1 # Initialize
+
         try:
-            needs_escalation = _is_scan_root_required(nmap_args_list)
-            nmap_xml_output, nmap_stderr, returncode = self._execute_nmap_command(nmap_args_list, needs_escalation)
-            if returncode:
-                logger.debug("Nmap process stdout (on error code %s): %s", returncode, nmap_xml_output)
-                logger.debug("Nmap process stderr (on error code %s): %s", returncode, nmap_stderr)
-                error_message = self._parse_nmap_error_message(returncode, nmap_xml_output, nmap_stderr, needs_escalation)
+            if self.current_cancellable and self.current_cancellable.is_cancelled():
+                raise ScanCancelledError("Scan cancelled before process start.")
+
+            self.current_process = subprocess.Popen(final_command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8")
+
+            while self.current_process.poll() is None:
+                if self.current_cancellable and self.current_cancellable.is_cancelled():
+                    logger.info("Cancellation requested for Nmap scan of target: %s", target)
+                    self.current_process.terminate()
+                    try:
+                        self.current_process.wait(timeout=1) # Wait for graceful termination
+                    except subprocess.TimeoutExpired:
+                        logger.warning("Nmap process did not terminate gracefully, killing.")
+                        self.current_process.kill()
+                    self.current_process = None # Clean up
+                    raise ScanCancelledError(f"Nmap scan for {target} was cancelled.")
+                time.sleep(0.2) # Polling interval
+
+            # Process completed (either normally or terminated/killed)
+            if self.current_process: # If not already set to None by cancellation logic
+                stdout_bytes, stderr_bytes = self.current_process.communicate()
+                stdout_str = stdout_bytes # Already decoded due to text=True
+                stderr_str = stderr_bytes
+                returncode = self.current_process.returncode
+                self.current_process = None # Clean up
+
+            if returncode != 0: # Check return code after process has finished
+                logger.debug("Nmap process stdout (on error code %s): %s", returncode, stdout_str)
+                logger.debug("Nmap process stderr (on error code %s): %s", returncode, stderr_str)
+                error_message = self._parse_nmap_error_message(returncode, stdout_str, stderr_str, needs_escalation)
                 logger.error(error_message)
                 raise PortScannerError(error_message)
-            if not nmap_xml_output.strip():
+
+            if not stdout_str.strip():
                 logger.warning("Nmap scan completed successfully (RC=0) but produced no XML output.")
                 raise PortScannerError("Nmap scan succeeded but produced no XML output.")
+
             try:
-                logger.debug("Attempting to parse Nmap XML output (first 500 chars): %s", nmap_xml_output[:500])
-                self.nm.analyse_nmap_xml_scan(nmap_xml_output=nmap_xml_output)
+                logger.debug("Attempting to parse Nmap XML output (first 500 chars): %s", stdout_str[:500])
+                self.nm.analyse_nmap_xml_scan(nmap_xml_output=stdout_str)
             except PortScannerError as e_parse:
                 logger.exception("Failed to parse Nmap XML output:")
-                logger.debug("Problematic Nmap XML Output (full, on parse error):\n%s", nmap_xml_output)
-                raise PortScannerError(f"Failed to parse Nmap XML output: {e_parse}. Stderr was: '{nmap_stderr.strip()}'") from e_parse
+                logger.debug("Problematic Nmap XML Output (full, on parse error):\n%s", stdout_str)
+                raise PortScannerError(f"Failed to parse Nmap XML output: {e_parse}. Stderr was: '{stderr_str.strip()}'") from e_parse
+
             return self.nm
+
         except FileNotFoundError as e_fnf:
             logger.exception("Nmap execution prerequisite not found:")
             raise PortScannerError(f"Nmap execution prerequisite not found: {e_fnf}") from e_fnf
         except NotImplementedError as e_ni:
             logger.exception("Privilege escalation not implemented for this platform:")
             raise PortScannerError(f"Privilege escalation not implemented for this platform: {e_ni}") from e_ni
-        except PortScannerError: # Specific re-raise
+        except ScanCancelledError: # Re-raise ScanCancelledError
+            raise
+        except PortScannerError: # Re-raise other PortScannerErrors
             raise
         except Exception as e_unexpected: # General catch-all
             logger.exception("An unexpected error occurred during the Nmap scan process:")
             raise PortScannerError(f"An unexpected error occurred: {e_unexpected}") from e_unexpected
+        finally:
+            self.current_process = None # Ensure cleared on exit
+            self.current_cancellable = None
+
 
     def convert_results_to_yaml(self, nm: nmap.PortScanner) -> Dict[str, str]:
         """Convert Nmap scan results to YAML for each host."""

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -6,21 +6,22 @@ load and save these preferences.
 """
 import logging
 import re
-from typing import Optional # Added for type hinting
+from typing import Optional
 
 import gi
-from gi.repository import Adw, Gio, Gtk, GLib, GObject, Gdk  # pylint: disable=wrong-import-position # Added GObject and Gdk
+gi.require_version("Adw", "1") # Must be called before importing from gi.repository
+gi.require_version("Gtk", "4.0")
+from gi.repository import Adw, Gio, Gtk, GLib, GObject, Gdk # No longer wrong position
 
-from .constants import APP_ID, RESOURCE_PREFIX  # pylint: disable=wrong-import-position
+# Local application imports
+from .constants import APP_ID, RESOURCE_PREFIX # No longer wrong position
 
+# Conditional import for dnspython
 try:
-    import dns.resolver # Check if dnspython is available
+    import dns.resolver
     dnspython_available = True
 except ImportError:
     dnspython_available = False
-
-gi.require_version("Adw", "1")
-gi.require_version("Gtk", "4.0")
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/preferences.ui")

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -7,7 +7,9 @@ import subprocess
 # import re # No longer used in this file
 import logging
 logger = logging.getLogger(__name__)
-from typing import Optional
+from typing import Optional, Dict, Any, Tuple # Added Dict, Any, Tuple
+import time # Added for polling loop
+from enum import Enum # Added for WebScanErrorType
 
 import gi
 from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, GtkSource
@@ -37,12 +39,41 @@ class WebScanPage(Adw.PreferencesPage):
     maxtime_entry_row = Gtk.Template.Child()
     clear_results_button = Gtk.Template.Child()
     copy_results_button = Gtk.Template.Child()
+    webscan_status_spinner = Gtk.Template.Child("webscan_status_spinner") # Assuming this exists in UI or will be added
 
     def __init__(self, **kwargs):
         """Initialize the WebScanPage."""
         super().__init__(**kwargs)
-        self.current_web_scan_task = None
+        self.current_web_scan_task: Optional[Gio.Task] = None
+        self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
+        self.current_nikto_process: Optional[subprocess.Popen] = None
+        # self._temp_scan_data was used to pass data to thread, now using task.set_task_data()
         logger.debug("WebScanPage initialized")
+
+        # Programmatically create and add the Cancel Scan button
+        self.webscan_cancel_button = Gtk.Button(label="Cancel Scan", icon_name="process-stop-symbolic")
+        self.webscan_cancel_button.set_sensitive(False)
+        self.webscan_cancel_button.set_visible(False) # Initially hidden
+        self.webscan_cancel_button.add_css_class("destructive-action")
+        self.webscan_cancel_button.connect("clicked", self._on_cancel_scan_clicked)
+
+        # Add cancel button next to scan_button. Assuming scan_button is in a Gtk.Box.
+        if self.scan_button and isinstance(self.scan_button.get_parent(), Gtk.Box):
+            parent_box = self.scan_button.get_parent()
+            parent_box.append(self.webscan_cancel_button)
+        else:
+            # Fallback: if scan_button's parent is not a Box, or scan_button not found,
+            # try adding to url_entry row if it's an ActionRow. This might need UI file adjustment.
+            if isinstance(self.url_entry, Adw.ActionRow):
+                 logger.info("Adding cancel button to url_entry row as a suffix.")
+                 self.url_entry.add_suffix(self.webscan_cancel_button)
+            else:
+                 logger.warning("Could not programmatically add Cancel Scan button to a suitable container.")
+
+        if self.webscan_status_spinner:
+            self.webscan_status_spinner.set_spinning(False) # type: ignore
+            self.webscan_status_spinner.set_visible(False) # type: ignore
+
 
         if self.results_textview:
             buffer = self.results_textview.get_buffer()
@@ -63,6 +94,37 @@ class WebScanPage(Adw.PreferencesPage):
             self.clear_results_button.connect("clicked", self._on_clear_results_clicked)
         if self.copy_results_button:
             self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
+
+    def __del__(self):
+        """Clean up when the WebScanPage is destroyed."""
+        if self.current_web_scan_cancellable and \
+           not self.current_web_scan_cancellable.is_cancelled():
+            logger.info("WebScanPage being destroyed, cancelling ongoing Nikto scan.")
+            self.current_web_scan_cancellable.cancel()
+
+        # If self.current_nikto_process was managed directly by the page (it's not in current plan)
+        # if self.current_nikto_process and self.current_nikto_process.poll() is None:
+        #    logger.info("Terminating Nikto process from WebScanPage.__del__")
+        #    self.current_nikto_process.terminate()
+        #    try:
+        #        self.current_nikto_process.wait(timeout=1)
+        #    except subprocess.TimeoutExpired:
+        #        self.current_nikto_process.kill()
+        # self.current_nikto_process = None
+        # super().__del__() # If inheriting from GObject.Object directly and needing its __del__
+
+    def _on_cancel_scan_clicked(self, _button: Gtk.Button) -> None:
+        """Handles click on the 'Cancel Scan' button."""
+        logger.info("Cancel scan button clicked.")
+        if self.current_web_scan_cancellable and \
+           not self.current_web_scan_cancellable.is_cancelled():
+            self.current_web_scan_cancellable.cancel()
+            logger.info("Nikto scan cancellation requested via button.")
+            # UI updates (disabling cancel, enabling scan) will happen in _on_scan_task_done
+            # Or potentially set a flag here and update UI immediately if preferred.
+            if hasattr(self, 'webscan_cancel_button'): self.webscan_cancel_button.set_sensitive(False)
+        else:
+            logger.warning("No active scan or cancellable to cancel.")
 
     def _on_clear_results_clicked(self, _button: Gtk.Button):
         """Handle click of the 'Clear Results' button."""
@@ -119,45 +181,53 @@ class WebScanPage(Adw.PreferencesPage):
 
         self.scan_button.set_sensitive(False)
 
-        if self.current_web_scan_task and not self.current_web_scan_task.get_completed():
-            try:
-                logger.info("Attempting to cancel previous web scan task.")
-                self.current_web_scan_task.get_cancellable().cancel()
-            except Exception as e_cancel: # pylint: disable=broad-except
-                logger.warning(f"Error trying to cancel previous web scan task: {e_cancel}")
+        self.scan_button.set_sensitive(False) # type: ignore
+        if hasattr(self, 'webscan_cancel_button'):
+            self.webscan_cancel_button.set_visible(True)
+            self.webscan_cancel_button.set_sensitive(True)
+        if self.webscan_status_spinner: self.webscan_status_spinner.start() # type: ignore
 
-        cancellable = Gio.Cancellable()
-        task = Gio.Task.new(self, cancellable, self._on_scan_task_done, None) # task_data is None
+
+        if self.current_web_scan_task and not self.current_web_scan_task.is_done():
+            if self.current_web_scan_cancellable and not self.current_web_scan_cancellable.is_cancelled():
+                logger.info("Cancelling previous web scan task before starting new one.")
+                self.current_web_scan_cancellable.cancel()
+                # The old task will clean itself up in its _on_scan_task_done.
+                # We proceed to create and run a new task.
+
+        self.current_web_scan_cancellable = Gio.Cancellable()
+        task = Gio.Task.new(self, self.current_web_scan_cancellable, self._on_scan_task_done, None) # type: ignore
         self.current_web_scan_task = task
 
-        self._temp_scan_data = {
+        # Store scan parameters for the thread function to access via task_data
+        task_data_for_thread: Dict[str, Any] = {
             "target_url": target_url,
-            "force_ssl": self.force_ssl_switch.get_active(),
-            "cgi_vulns": self.cgi_vulns_switch.get_active(),
-            "interesting_content": self.interesting_content_switch.get_active(),
-            "evasion": self.evasion_switch.get_active(),
-            "mutate": self.mutate_switch.get_active(),
-            "maxtime": self.maxtime_entry_row.get_text().strip()
+            "force_ssl": self.force_ssl_switch.get_active(), # type: ignore
+            "cgi_vulns": self.cgi_vulns_switch.get_active(), # type: ignore
+            "interesting_content": self.interesting_content_switch.get_active(), # type: ignore
+            "evasion": self.evasion_switch.get_active(), # type: ignore
+            "mutate": self.mutate_switch.get_active(), # type: ignore
+            "maxtime": self.maxtime_entry_row.get_text().strip() # type: ignore
         }
-        task.run_in_thread(self._run_scan_task_thread_func)
+        task.set_task_data(task_data_for_thread) # type: ignore
+        task.run_in_thread(self._run_scan_task_thread_func) # type: ignore
 
     def _run_scan_task_thread_func(self,
                                    task: Gio.Task,
-                                   source_object: GObject.Object, # WebScanPage instance
-                                   task_data: object, # None
+                                   _source_object: GObject.Object,
+                                   _task_data_unused: Any, # Parameter from Gio.Task.run_in_thread, but we use task.get_task_data()
                                    cancellable: Gio.Cancellable):
-        """Execute the Nikto scan in a separate thread."""
+        """Execute the Nikto scan in a separate thread, with cancellation support."""
         logger.debug("WebScanPage._run_scan_task_thread_func started")
-        page_instance = source_object
-        scan_data = page_instance._temp_scan_data
 
-        target_url = scan_data["target_url"]
-        force_ssl = scan_data["force_ssl"]
-        cgi_vulns = scan_data["cgi_vulns"]
-        interesting_content = scan_data["interesting_content"]
-        evasion_active = scan_data.get("evasion", False)
-        mutate_active = scan_data.get("mutate", False)
-        maxtime_str = scan_data.get("maxtime", "")
+        scan_params = task.get_task_data() # Retrieve parameters set earlier
+        if not scan_params: # Should not happen if set correctly
+            logger.error("No scan parameters found in task data.")
+            task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value, "Missing scan parameters.") # type: ignore
+            return
+
+        target_url = scan_params["target_url"]
+        # (URL scheme adjustment logic remains the same)
 
         # is_valid_url (used in on_scan_button_clicked) ensures target_url has a scheme from
         # ['http', 'https', 'ftp']. Nikto prepends 'http://' if no scheme is given,
@@ -208,73 +278,118 @@ class WebScanPage(Adw.PreferencesPage):
         logger.debug(f"Constructed Nikto command: {nikto_command}")
 
         try:
-            with subprocess.Popen(
-                nikto_command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            ) as process:
-                stdout, stderr = process.communicate(timeout=300)
-            task.return_value((stdout, stderr, None))
-        except FileNotFoundError:
-            task.return_value((None, None, "FileNotFoundError"))
-        except subprocess.TimeoutExpired:
-            task.return_value((None, None, "TimeoutExpired"))
-        except Exception as e: # pylint: disable=broad-except
-            task.return_value((None, str(e), "Exception"))
+            if cancellable.is_cancelled():
+                task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.CANCELLED.value, "Scan cancelled before Nikto process start.") # type: ignore
+                return
 
-    def _on_scan_task_done(self, source_object: GObject.Object, async_result_obj: Gio.AsyncResult, _user_data: object):
+            process = subprocess.Popen(nikto_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8")
+            page_instance.current_nikto_process = process # Store for potential external cancellation (e.g. __del__) - though __del__ might not run in main thread
+
+            stdout_str, stderr_str = "", ""
+            # Polling loop for cancellation
+            while True:
+                if cancellable.is_cancelled():
+                    logger.info("Nikto scan cancellation polling: Scan cancelled.")
+                    if process.poll() is None: # Check if process is still running
+                        try:
+                            logger.info("Terminating Nikto process.")
+                            process.terminate()
+                            process.wait(timeout=2) # Short wait for graceful termination
+                        except subprocess.TimeoutExpired:
+                            logger.warning("Nikto process did not terminate gracefully, killing.")
+                            process.kill()
+                        except Exception as e_term: # pylint: disable=broad-except
+                            logger.error(f"Error terminating Nikto process: {e_term}")
+                    task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.CANCELLED.value, "Scan cancelled by user.") # type: ignore
+                    page_instance.current_nikto_process = None
+                    return
+
+                if process.poll() is not None: # Process finished
+                    logger.debug("Nikto process finished on its own.")
+                    break
+
+                time.sleep(0.2) # Polling interval
+
+            # Process finished, get final output
+            stdout_str, stderr_str = process.communicate()
+            page_instance.current_nikto_process = None # Clear process reference
+
+            if process.returncode != 0:
+                 logger.error(f"Nikto process finished with error code {process.returncode}. Stderr: {stderr_str}")
+                 task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value, f"Nikto scan failed. Output:\n{stderr_str or stdout_str}") # type: ignore
+                 return
+
+            task.return_value((stdout_str, stderr_str)) # type: ignore
+        except FileNotFoundError:
+            logger.error("Nikto command not found. Ensure it's in PATH.")
+            task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.NIKTO_NOT_FOUND.value, "Nikto command not found. Please ensure it is installed and in your system's PATH.") # type: ignore
+        # TimeoutExpired for process.communicate() is removed as we poll.
+        # A global timeout for the entire scan could be implemented by checking time in the polling loop.
+        except Exception as e: # pylint: disable=broad-except
+            logger.exception(f"An unexpected error occurred during Nikto scan task: {e}")
+            task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value, str(e)) # type: ignore
+        finally:
+            page_instance.current_nikto_process = None # Ensure cleared
+
+    def _on_scan_task_done(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: object): # type: ignore
         """Handle completion of the Nikto scan task."""
         target_url = "Unknown URL"
-        if hasattr(self, '_temp_scan_data') and self._temp_scan_data:
-            target_url = self._temp_scan_data.get("target_url", target_url)
+        # Retrieve target_url from task_data if available
+        if self.current_web_scan_task and self.current_web_scan_task.get_task_data():
+            task_data_retrieved = self.current_web_scan_task.get_task_data()
+            if isinstance(task_data_retrieved, dict): # Check if it's the dict we set
+                 target_url = task_data_retrieved.get("target_url", target_url)
 
-        active_task = self.current_web_scan_task
-        if not active_task:
-            logger.warning("_on_scan_task_done called but no active_task found.")
-            if not self.scan_button.get_sensitive():
-                self.scan_button.set_sensitive(True)
-            return
+        logger.info(f"Nikto scan task done for {target_url}.")
+        stdout: Optional[str] = None
+        stderr: Optional[str] = None
 
         try:
-            # Gio.Task.propagate_value() can raise a GLib.Error if the task itself
-            # encountered an unhandled exception.
-            # On success, it returns a 2-tuple. The first element's role is secondary
-            # here as critical errors are caught by GLib.Error.
-            # The second element is the actual payload (our 3-element tuple)
-            # passed to task.return_value() in the thread.
-            _intermediate_tuple_from_propagate = active_task.propagate_value()
-            _status_or_bool, actual_payload_tuple = _intermediate_tuple_from_propagate
-            stdout, stderr_or_error_msg, error_type = actual_payload_tuple
-
-            if error_type == "FileNotFoundError":
-                logger.exception("Nikto command not found. Ensure it's in PATH.")
-                user_message = "Nikto command not found. Please ensure Nikto is installed and in your system's PATH."
-                show_global_error(self, user_message)
-                self._update_textview("", f"Error: {user_message}")
-            elif error_type == "TimeoutExpired":
-                logger.exception(f"Nikto scan for {target_url} timed out.")
-                user_message = f"Scan for {target_url} timed out after 5 minutes."
-                show_global_error(self, user_message)
-                self._update_textview("", f"Error: {user_message}")
-            elif error_type == "Exception":
-                logger.exception(f"An unexpected error occurred during Nikto scan task for {target_url}:")
-                user_message = "An unexpected error occurred during the scan. Please check the application logs for more details."
-                show_global_error(self, user_message)
-                self._update_textview("", user_message)
+            # propagate_value() will return the (stdout, stderr) tuple on success
+            # or raise GLib.Error if task.return_new_error_literal was called.
+            returned_data = self.current_web_scan_task.propagate_value() # type: ignore
+            if isinstance(returned_data, tuple) and len(returned_data) == 2:
+                stdout, stderr = returned_data
+            elif hasattr(returned_data, 'value') and isinstance(returned_data.value, tuple) and len(returned_data.value) == 2: # Handle potential Gio.DBusCallFlags like wrapper
+                stdout, stderr = returned_data.value
             else:
-                self._update_textview(stdout, stderr_or_error_msg)
+                logger.error(f"Nikto scan for {target_url} returned unexpected result format: {type(returned_data)}")
+                show_global_error(self, "Scan returned unexpected data format.") # type: ignore
+                self._update_textview(None, "Error: Scan returned unexpected data format.")
+                # Fall through to finally block for UI reset
 
-        except GLib.Error:
-            logger.exception(f"GLib.Error during scan task finalization for {target_url}:")
-            user_message = "A task finalization error occurred. Please check the application logs for more details."
-            show_global_error(self, user_message)
-            self._update_textview("", user_message)
+            if stdout is not None or stderr is not None: # If successful (even with stderr info)
+                self._update_textview(stdout, stderr)
+
+        except GLib.Error as e:
+            logger.warning(f"Nikto scan task for {target_url} failed or was cancelled: {e.message} (Domain: {e.domain}, Code: {e.code})")
+            user_message = e.message # Default to the error message from the task
+            if e.matches(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.NIKTO_NOT_FOUND.value): # type: ignore
+                user_message = "Nikto command not found. Please ensure Nikto is installed and in your system's PATH."
+            elif e.matches(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.TIMEOUT.value): # type: ignore
+                user_message = f"Scan for {target_url} timed out." # This error type might not be used if timeout is only for process.communicate
+            elif e.matches(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.CANCELLED.value): # type: ignore
+                user_message = f"Scan for {target_url} was cancelled."
+            elif e.matches(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value): # type: ignore
+                user_message = f"Scan failed for {target_url}: {e.message}" # e.message already contains details
+
+            show_global_error(self, user_message) # type: ignore
+            self._update_textview(None, f"Error: {user_message}") # Display error in textview as well
+        except Exception as e: # Catch any other Python exceptions from this callback itself
+            logger.exception(f"Unexpected Python error in _on_scan_task_done for {target_url}:")
+            user_message = "An unexpected error occurred while processing scan results."
+            show_global_error(self, user_message) # type: ignore
+            self._update_textview(None, f"Error: {user_message}")
         finally:
-            self.scan_button.set_sensitive(True)
-            if hasattr(self, '_temp_scan_data'):
-                del self._temp_scan_data
+            self.scan_button.set_sensitive(True) # type: ignore
+            if hasattr(self, 'webscan_cancel_button'):
+                self.webscan_cancel_button.set_sensitive(False)
+                self.webscan_cancel_button.set_visible(False)
+            if self.webscan_status_spinner: self.webscan_status_spinner.stop() # type: ignore
+
             self.current_web_scan_task = None
+            self.current_web_scan_cancellable = None
+            self.current_nikto_process = None # Ensure cleared
 
     def _update_textview(self, stdout: Optional[str], stderr: Optional[str]):
         """Update the results TextView with Nikto's stdout and stderr."""
@@ -292,6 +407,18 @@ class WebScanPage(Adw.PreferencesPage):
         """Programmatically triggers the WebScan 'Scan' action."""
         logger.debug("Webscan scan triggered by shortcut.")
         if self.scan_button and self.scan_button.get_sensitive():
-            self.scan_button.clicked()
+            self.scan_button.clicked() # type: ignore
+        elif self.current_web_scan_task and not self.current_web_scan_task.is_done():
+            show_global_toast(self, "A scan is already in progress. Cancel it or wait.") # type: ignore
         else:
             logger.warning("Webscan scan button not available or not sensitive, cannot trigger scan.")
+
+# --- Gio.Task Error Handling ---
+WEB_SCAN_ERROR_DOMAIN = "web-scan-error-domain"
+
+class WebScanErrorType(int, Enum):
+    """Enumeration of Web Scan error types for Gio.Task error reporting."""
+    NIKTO_NOT_FOUND = 0
+    TIMEOUT = 1         # If a global scan timeout is implemented
+    CANCELLED = 2
+    GENERIC = 3         # For other Nikto/subprocess errors or general exceptions


### PR DESCRIPTION
This commit introduces several improvements across the codebase:

1.  **DNS Page UI Refinements (`dns_page.py`):**
    *   Refactored the `_perform_lookup` method into smaller helper
        methods to enhance readability and reduce complexity.
    *   Modularized the DNS record row creation logic with new base
        helper methods for `Adw.ActionRow` and `Adw.ExpanderRow`,
        reducing code duplication for different record types.

2.  **Nmap Page Asynchronous Operations (`nmap_page.py`, `nmap_scanner.py`):**
    *   `NmapPage` now uses `Gio.Task` and `Gio.Cancellable` to manage
        Nmap scans, replacing direct `ThreadPoolExecutor` usage.
    *   A "Cancel Scan" button has been added to the Nmap page UI.
    *   `NmapScanner` was significantly refactored to use `subprocess.Popen`
        instead of `subprocess.run`. It now includes a polling loop
        to check the `Gio.Cancellable` object and terminate/kill the
        Nmap process if cancellation is requested.
    *   Introduced `ScanCancelledError` for clearer cancellation handling.

3.  **WebScan Page Asynchronous Operations (`webscan_page.py`):**
    *   Refactored to correctly implement cancellation for Nikto scans
        using `Gio.Task` and `Gio.Cancellable`.
    *   The Nikto subprocess is now managed with `subprocess.Popen` and
        a polling loop checks for cancellation requests, terminating/killing
        the process if needed.
    *   Added a "Cancel Scan" button and improved UI state management
        during scans.
    *   Standardized error reporting using a custom `WEB_SCAN_ERROR_DOMAIN`
        and `WebScanErrorType` enum.

4.  **Linting Directives Review:**
    *   Conducted a comprehensive review of `pylint: disable` and `noqa`
        directives across multiple files.
    *   Addressed several directives by refactoring, such as using
        `TypedDict` in `NmapScanner` to manage numerous arguments and
        reordering imports in `Preferences`.
    *   Confirmed and clarified justifications for most remaining directives,
        especially those related to GTK/Gio framework interactions,
        critical error handling paths, and accepted Python idioms.
    *   Added missing `ipaddress` import in `dns_client.py`.