### PR TITLE
Fix: Resolve Enum NameError and ensure comprehensive typing/enum imports

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,6 @@
 """Global constants for the Woes application."""
 import os
+from typing import Dict, List
 
 from gi.repository import Gtk
 

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -10,7 +10,7 @@ via a :class:`.custom_dns_adapter.CustomDNSAdapter`.
 # ruff: noqa: E501
 import logging
 from enum import Enum
-from typing import Optional, List, Any, Dict # Added Dict
+from typing import Any, Dict, List, Optional, Tuple
 
 # Removed requests, requests.utils, dns.resolver, urllib3.exceptions as they moved to http_client
 # CustomDNSAdapter is now used by HttpFetcher, not directly here.

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ parsing, and launching the main application window and services.
 import sys
 import os
 import logging
-from typing import Optional, List, Callable # Added Callable
+from typing import Any, Callable, List, Optional
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -9,7 +9,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 import re
-from typing import Optional, List, Dict, Any # Added List, Dict, Any
+from enum import Enum
+from typing import Optional, List, Dict, Any
 import yaml
 
 import gi

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -13,7 +13,7 @@ import shutil
 import time # Added for sleep in polling loop
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, Union, List, Optional, Tuple, TypedDict # Added TypedDict
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 # Import Gio for Cancellable type hint, actual object passed by caller
 try:


### PR DESCRIPTION
- I added `from enum import Enum` to `src/nmap_page.py` to fix `NameError: name 'Enum' is not defined`.
- I conducted a comprehensive review of all Python files in `src/` to ensure all necessary types from the `typing` and `enum` modules are imported where used.
- I added missing `typing` imports to `src/constants.py`.
- I updated and alphabetized `typing` imports in `src/http_page.py`, `src/main.py`, and `src/nmap_scanner.py` for completeness and consistency.
- I verified and confirmed correct `typing` and `enum` imports in other project files.