### PR TITLE
Fix: Correct HTTP Fetch button UI after scan completion

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -518,7 +518,7 @@ class HttpPage(Adw.PreferencesPage):
                 self.http_entry_row.set_sensitive(True) # type: ignore
             if hasattr(self, "http_apply_button") and self.http_apply_button:
                 self.http_apply_button.set_sensitive(True)
-                self.http_apply_button.set_icon_name("")  # Remove spinner
+                self.http_apply_button.set_icon_name(None)  # Correct way to remove spinner icon
 
     @staticmethod
     def _ensure_scheme(url: str) -> str:


### PR DESCRIPTION
The 'Fetch' button on the HTTP Headers page would lose its text or change appearance after a fetch operation. This was due to its icon being set to an empty string ("") upon task completion.

Changed `_fetch_headers_task_done_cb` in `src/http_page.py` to call `http_apply_button.set_icon_name(None)`. This correctly removes any icon previously set (like the spinner) and allows the button to revert to its default state, displaying its label as intended.