### PR TITLE
Fix: Remove spinner icons from HTTP and DNS action buttons

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -215,8 +215,10 @@ class DNSPage(Adw.PreferencesPage):
             else:
                 self.dns_lookup_spinner.stop() # type: ignore
         # Potentially disable/enable other controls like domain_entry or apply_button here
-        # self.domain_entry.set_sensitive(not active)
-        # self.dns_apply_button.set_sensitive(not active)
+        if self.domain_entry: # Check if bound
+            self.domain_entry.set_sensitive(not active) # type: ignore
+        if self.dns_apply_button: # Check if bound
+            self.dns_apply_button.set_sensitive(not active) # type: ignore
 
     def _validate_dns_input(self, user_input: str) -> bool:
         """

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -256,7 +256,7 @@ class HttpPage(Adw.PreferencesPage):
         self.http_entry_row.set_sensitive(False) # type: ignore
         if hasattr(self, "http_apply_button") and self.http_apply_button:
             self.http_apply_button.set_sensitive(False)
-            self.http_apply_button.set_icon_name("process-working-symbolic")
+            # self.http_apply_button.set_icon_name("process-working-symbolic") # Removed
         host_header = self.http_host_header_row.get_text().strip() # type: ignore
         user_agent_to_send: Optional[str] = None
         selected_title_obj = self.http_user_agent_row.get_selected_item() # type: ignore
@@ -518,7 +518,7 @@ class HttpPage(Adw.PreferencesPage):
                 self.http_entry_row.set_sensitive(True) # type: ignore
             if hasattr(self, "http_apply_button") and self.http_apply_button:
                 self.http_apply_button.set_sensitive(True)
-                self.http_apply_button.set_icon_name(None)  # Correct way to remove spinner icon
+                # self.http_apply_button.set_icon_name(None) # Removed
 
     @staticmethod
     def _ensure_scheme(url: str) -> str:


### PR DESCRIPTION
Based on your feedback, I made the following changes:

- HTTP Page (`src/http_page.py`):
  - I removed logic that set a spinner icon (`process-working-symbolic`) on the 'Fetch' button (`http_apply_button`) during requests.
  - The button now only toggles its sensitivity state. This resolves a UI glitch where the button's appearance changed incorrectly after use.

- DNS Page (`src/dns_page.py`):
  - I confirmed that the 'Lookup' button (`dns_apply_button`) was not using its icon as a spinner.
  - I enabled logic in `_set_loading_state` to set the sensitivity of `dns_apply_button` and `domain_entry` during DNS lookups, improving UI feedback. The page uses a separate spinner widget for activity indication.

These changes ensure that the action buttons on the HTTP and DNS pages do not use icons for loading indication, relying only on sensitivity changes and dedicated spinner widgets where appropriate.