### PR TITLE
Fix: Resolve AttributeError for nmap_cancel_scan_button

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -71,6 +71,7 @@ class NmapPage(Gtk.Box):
     nmap_timing_template_comborow = Gtk.Template.Child("nmap_timing_template_comborow")
     status_row = Gtk.Template.Child("status_row")
     scan_spinner = Gtk.Template.Child("scan_spinner")
+    nmap_cancel_scan_button = Gtk.Template.Child() # Added binding
 
     left_vbox_content = Gtk.Template.Child("left_vbox_content")
     nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")


### PR DESCRIPTION
Addresses an `AttributeError: 'NmapPage' object has no attribute 'nmap_cancel_scan_button'` in `src/nmap_page.py`.

The 'nmap_cancel_scan_button' widget is defined in the `src/gtk/nmap_page.ui` file, but the corresponding Python class `NmapPage` was missing the `Gtk.Template.Child()` binding for it.

This commit adds `nmap_cancel_scan_button = Gtk.Template.Child()` to the `NmapPage` class definition, ensuring the button is correctly bound from the UI template during initialization.