### PR TITLE
Fix: Resolve Nmap callback TypeError and AdwViewStack warnings

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -71,7 +71,7 @@
                   </object>
                 </property>
                 <property name="icon-name">network-transmit-receive-symbolic</property>
-                <property name="name">http_page</property>
+                <property name="name">http</property>
                 <property name="title">HTTP Headers</property>
                 <property name="use-underline">true</property>
               </object>
@@ -105,7 +105,7 @@
                   </object>
                 </property>
                 <property name="icon-name">face-devilish</property>
-                <property name="name">nmap_page</property>
+                <property name="name">nmap</property>
                 <property name="title">Port Scan</property>
                 <property name="use-underline">true</property>
               </object>
@@ -138,6 +138,7 @@
                   </object>
                 </property>
                 <property name="icon-name">org.gnome.Epiphany-symbolic</property>
+                <property name="name">dns</property>
                 <property name="title">DNS</property>
                 <property name="use-underline">true</property>
               </object>
@@ -164,7 +165,7 @@
                   </object>
                 </property>
                 <property name="icon-name">face-cool</property>
-                <property name="name">webscan_page</property>
+                <property name="name">webscan</property>
                 <property name="title">Web Scan</property>
                 <property name="use-underline">true</property>
               </object>

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -220,7 +220,7 @@ class NmapPage(Gtk.Box):
         logger.info(f"NmapPage: Starting Nmap scan task with params: {scan_params}")
 
         self.current_nmap_task = Gio.Task.new(
-            self, self.current_nmap_cancellable, self._nmap_scan_task_done_cb # type: ignore
+            self, self.current_nmap_cancellable, self._nmap_scan_task_done_cb, None # type: ignore
         )
         self._current_nmap_scan_params = scan_params # Store params in instance variable
         self.current_nmap_task.run_in_thread(self._run_nmap_scan_thread_func) # type: ignore
@@ -273,10 +273,10 @@ class NmapPage(Gtk.Box):
             logger.info("Nmap scan thread finished for %s.", target)
             # UI sensitivity updates are handled in _nmap_scan_task_done_cb
 
-    def _nmap_scan_task_done_cb(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: object): # type: ignore # pylint: disable=unused-argument
+    def _nmap_scan_task_done_cb(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Optional[Any]): # type: ignore # pylint: disable=unused-argument
         """Callback for when the Nmap scan Gio.Task completes."""
         # _source_object is self (NmapPage instance)
-        # _user_data is None (as passed in Gio.Task.new)
+        # _user_data is None (as passed to Gio.Task.new)
         # The 'result' parameter is the Gio.Task object for this callback.
 
         # Retrieve original target from instance variable if task data was not used,
@@ -295,7 +295,7 @@ class NmapPage(Gtk.Box):
         nm_results: Optional[nmap.PortScanner] = None
         try:
             # Use 'result' (the Gio.AsyncResult/Gio.Task object) to propagate value
-            nm_results = result.propagate_value().value if hasattr(result.propagate_value(), 'value') else result.propagate_value() # type: ignore
+            nm_results = result.propagate_value() # type: ignore
             if isinstance(nm_results, nmap.PortScanner):
                  self._process_scan_results(nm_results, original_target)
             # Ensure nm_results is not None and is of the expected type before processing further.


### PR DESCRIPTION
- NmapPage (`src/nmap_page.py`):
  - Corrected the signature of the `_nmap_scan_task_done_cb` method to properly align with `GAsyncReadyCallback` expectations, including accepting a `user_data` argument.
  - Explicitly passed `user_data=None` when creating the `Gio.Task` for Nmap scans in `_on_target_activate`.
  - Simplified result retrieval in `_nmap_scan_task_done_cb` to use `result.propagate_value()` directly on the `Gio.AsyncResult` object.
  - These changes resolve the `TypeError` related to a missing `_user_data` argument and ensure correct task result propagation.

- Main Window UI (`src/gtk/window.ui`):
  - Corrected the `name` properties for all `AdwViewStackPage` children (HTTP, Nmap, DNS, WebScan pages) within the main `AdwViewStack` (id="stack").
  - The names now use short identifiers (e.g., "http", "nmap") to match the strings used in `set_visible_child_name()` calls in `src/main.py`.
  - This fixes the `Adwaita-WARNING: Child name '...' not found` errors and ensures page navigation works as intended.