### PR TITLE
Fix: Handle _ResultTuple in NmapPage and cleanup comments

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -11,10 +11,7 @@ via a :class:`.custom_dns_adapter.CustomDNSAdapter`.
 import logging
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
-
-# Removed requests, requests.utils, dns.resolver, urllib3.exceptions as they moved to http_client
-# CustomDNSAdapter is now used by HttpFetcher, not directly here.
-# dns variable for checking dnspython availability is also implicitly handled by HttpFetcher
+# Note: Most HTTP client logic, including requests and dnspython, is now in http_client.py
 import gi
 from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk, Pango
 
@@ -109,8 +106,8 @@ class HttpPage(Adw.PreferencesPage):
         logger.debug("HttpPage initialized.")
         self.current_http_task: Optional[Gio.Task] = None
         self._current_header_items: List[HeaderItem] = []
-        self._http_task_data_for_thread: Dict[str, Any] = {} # Changed dict to Dict
-        self._ua_title_to_value_map: Dict[str, Optional[str]] = {} # Changed dict to Dict
+        self._http_task_data_for_thread: Dict[str, Any] = {}
+        self._ua_title_to_value_map: Dict[str, Optional[str]] = {}
         self.settings = Gio.Settings(schema_id=APP_ID)
         self._header_key_color = self.settings.get_string("http-output-header-key-color")
         self._header_value_color = self.settings.get_string("http-output-header-value-color")
@@ -264,15 +261,13 @@ class HttpPage(Adw.PreferencesPage):
             selected_title = selected_title_obj.get_string() # type: ignore
             user_agent_to_send = self._ua_title_to_value_map.get(selected_title)
         custom_dns_server = self.settings.get_string("custom-dns-server")
-        # HttpPage no longer needs to check for `dns` module availability directly for HttpFetcher,
-        # but it was checked above for the logger warning. This is fine.
         # Store parameters for the thread to access
         self._http_task_data_for_thread = {
             "url": url,
             "use_akamai_pragma": self.http_pragma_switch_row.get_active(), # type: ignore
             "host_header": host_header if host_header else None,
             "user_agent": user_agent_to_send,
-            "custom_dns_server": custom_dns_server if custom_dns_server else None, # Retain for HttpFetcher
+            "custom_dns_server": custom_dns_server if custom_dns_server else None,
         }
         logger.debug(f"HttpPage: Starting header fetch task with data: {self._http_task_data_for_thread}")
 
@@ -280,18 +275,12 @@ class HttpPage(Adw.PreferencesPage):
         self.current_http_task = task
         task.run_in_thread(self._fetch_headers_task_thread_func) # type: ignore
 
-    # _prepare_request_headers moved to HttpFetcher
-    # _execute_http_request moved to HttpFetcher
-    # _process_http_response moved to HttpFetcher
-    # _get_detailed_connection_error_message moved to HttpFetcher
-    # _format_http_error moved to HttpFetcher
-
     def _fetch_headers_task_thread_func(
         self,
-        task: Gio.Task, # The task itself, passed by run_in_thread
+        task: Gio.Task,
         _source_object: GObject.Object, # type: ignore
-        _task_data_arg: Dict[str, Any], # type: ignore # Not used, self._http_task_data_for_thread is used
-        cancellable: Optional[Gio.Cancellable], # Provided by Gio.Task
+        _task_data_arg: Dict[str, Any], # type: ignore # Unused (params retrieved from self._http_task_data_for_thread)
+        cancellable: Optional[Gio.Cancellable],
     ) -> None:
         """Background thread function for fetching HTTP headers.
 
@@ -518,7 +507,7 @@ class HttpPage(Adw.PreferencesPage):
                 self.http_entry_row.set_sensitive(True) # type: ignore
             if hasattr(self, "http_apply_button") and self.http_apply_button:
                 self.http_apply_button.set_sensitive(True)
-                # self.http_apply_button.set_icon_name(None) # Removed
+                # Spinner icon logic for http_apply_button was removed
 
     @staticmethod
     def _ensure_scheme(url: str) -> str:
@@ -532,12 +521,10 @@ class HttpPage(Adw.PreferencesPage):
         :return: The URL string, with 'https://' prepended if no scheme was present.
         :rtype: str
         """
-        if "://" not in url: # Basic check
+        if "://" not in url:
             logger.debug("HttpPage: URL '%s' has no scheme, prepending 'https://'.", url)
             return "https://" + url
         return url
-
-    # _format_http_error was moved to HttpFetcher and its functionality is now part of HttpFetcher's exceptions.
 
     def _on_pragma_toggled(self, _widget: Gtk.Switch, _gparam: GObject.ParamSpec) -> None:
         """Handle toggling of the Akamai Pragma switch.
@@ -663,11 +650,11 @@ class HttpPage(Adw.PreferencesPage):
                 display_titles.append(title)
                 self._ua_title_to_value_map[title] = value
 
-        # "None" option
-        none_title = "None" # This is the display title for "no override"
+        # "None" option (represents no override)
+        none_title = "None"
         if none_title not in self._ua_title_to_value_map:
             display_titles.append(none_title)
-        self._ua_title_to_value_map[none_title] = None  # Actual value is None
+        self._ua_title_to_value_map[none_title] = None # Actual value for "None" selection
 
         # Default UAs from constants
         for ua_dict in USER_AGENTS:

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -71,7 +71,7 @@ class NmapPage(Gtk.Box):
     nmap_timing_template_comborow = Gtk.Template.Child("nmap_timing_template_comborow")
     status_row = Gtk.Template.Child("status_row")
     scan_spinner = Gtk.Template.Child("scan_spinner")
-    nmap_cancel_scan_button = Gtk.Template.Child() # Added binding
+    nmap_cancel_scan_button = Gtk.Template.Child()
 
     left_vbox_content = Gtk.Template.Child("left_vbox_content")
     nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")
@@ -232,7 +232,7 @@ class NmapPage(Gtk.Box):
         _source_object: GObject.Object,
         _task_data: Optional[Dict[str, Any]], # pylint: disable=unused-argument # This arg from run_in_thread is not used
         cancellable: Optional[Gio.Cancellable]
-    ): # _source_object is self (NmapPage instance)
+    ):
         """Execute the Nmap scan in a separate thread via NmapScanner, for Gio.Task."""
         page_instance: NmapPage = _source_object # type: ignore
         params = page_instance._current_nmap_scan_params
@@ -240,7 +240,6 @@ class NmapPage(Gtk.Box):
 
         if not params:
             logger.error("NmapPage: _run_nmap_scan_thread_func: _current_nmap_scan_params is None. This indicates a programming error.")
-            # The task object is available for error reporting.
             task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.UNEXPECTED.value, "Internal error: Scan parameters not found.") # type: ignore
             return
 
@@ -252,7 +251,6 @@ class NmapPage(Gtk.Box):
             return
 
         try:
-            # Call run_nmap_scan with the params dictionary and cancellable
             nm = self.scanner.run_nmap_scan(params, cancellable=cancellable)
 
             if cancellable and cancellable.is_cancelled():
@@ -292,20 +290,28 @@ class NmapPage(Gtk.Box):
 
         logger.info(f"Nmap scan task done for {original_target}.")
 
-        nm_results: Optional[nmap.PortScanner] = None
+        nm_results_final: Optional[nmap.PortScanner] = None
         try:
-            # Use 'result' (the Gio.AsyncResult/Gio.Task object) to propagate value
-            nm_results = result.propagate_value() # type: ignore
-            if isinstance(nm_results, nmap.PortScanner):
-                 self._process_scan_results(nm_results, original_target)
-            # Ensure nm_results is not None and is of the expected type before processing further.
-            # This condition might be redundant if task.propagate_value() already guarantees a PortScanner object or raises.
-            # However, if task.return_value(None) was possible, this check would be useful.
-            # Given the current logic of _run_nmap_scan_thread_func, it should always return PortScanner or raise.
-            elif nm_results is not None: # Should not happen if task.return_value(nm) was called with PortScanner object
-                 logger.error(f"Nmap scan for {original_target} returned unexpected result type: {type(nm_results)}")
-                 self._handle_scan_error(original_target, "Scan returned unexpected data.")
-            # If nm_results is None, it means an error was already raised and handled by GLib.Error block.
+            propagated_value = result.propagate_value() # type: ignore
+
+            if isinstance(propagated_value, nmap.PortScanner):
+                nm_results_final = propagated_value
+            elif hasattr(propagated_value, 'value') and isinstance(getattr(propagated_value, 'value'), nmap.PortScanner):
+                logger.warning(f"NmapPage: Received wrapped object {type(propagated_value)} with .value attribute containing nmap.PortScanner. Unwrapping.")
+                nm_results_final = getattr(propagated_value, 'value')
+            elif hasattr(propagated_value, 'value'):
+                logger.error(f"NmapPage: Received wrapped object {type(propagated_value)} with .value of type {type(getattr(propagated_value, 'value'))}. Expected nmap.PortScanner.")
+                self._handle_scan_error(original_target, "Scan returned unexpectedly wrapped data of the wrong type.")
+            else:
+                logger.error(f"Nmap scan for {original_target} returned unexpected result type: {type(propagated_value)}")
+                self._handle_scan_error(original_target, "Scan returned an unexpected data type.")
+
+            if nm_results_final: # Only proceed if we successfully got a PortScanner object
+                self._process_scan_results(nm_results_final, original_target)
+            # If nm_results_final is None here and no GLib.Error was raised,
+            # it means an unexpected type was received and handled by one of the error logs above.
+            # The _handle_scan_error calls would have updated the status.
+
         except GLib.Error as e:
             logger.warning(f"Nmap scan for {original_target} failed or was cancelled. Domain: {e.domain}, Code: {e.code}, Message: {e.message}")
             if e.matches(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value): # type: ignore


### PR DESCRIPTION
- NmapPage (`src/nmap_page.py`):
  - I modified `_nmap_scan_task_done_cb` to defensively handle and unwrap potential `_ResultTuple`-like wrapper objects (similar to `HttpPage`) that might be returned by `Gio.Task.propagate_value()`. This ensures an `nmap.PortScanner` object is correctly processed, resolving an "unexpected result type" error.

- Comment and Dead Code Cleanup:
  - I performed an aggressive review and cleanup of comments and dead code in `src/nmap_page.py`, `src/http_page.py`, and `src/nmap_scanner.py`.
  - I removed low-effort, redundant, meta, and obsolete comments.
  - I ensured remaining comments provide high value for complex logic or unavoidable workarounds.
  - I verified and improved justifications for linting directives.
  - I removed obsolete programmatic Nmap cancel button creation code from `nmap_page.py` (already defined in UI).