### PR TITLE
Fix: Resolve NmapPage UI errors and cleanup comments

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -164,6 +164,13 @@
                                 <property name="visible">False</property>
                               </object>
                             </child>
+                            <child type="suffix">
+                              <object class="GtkButton" id="nmap_cancel_scan_button">
+                                <property name="label" translatable="yes">Cancel</property>
+                                <property name="icon-name">process-stop-symbolic</property>
+                                <property name="visible">False</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
I addressed Gtk-CRITICAL and AttributeError on NmapPage:
- Gtk-CRITICAL: 'Unable to retrieve child object 'nmap_cancel_scan_button'' was resolved by adding the 'nmap_cancel_scan_button' GtkButton to the src/gtk/nmap_page.ui file within the 'status_row' AdwActionRow.
- AttributeError: ''NoneType' object has no attribute 'set_spinning'' for 'scan_spinner' is believed to be resolved as a cascading effect of the template now loading correctly.

The nmap_cancel_scan_button is now correctly defined in the UI template, matching its Gtk.Template.Child declaration in nmap_page.py.

A review of comments in nmap_page.py was conducted, and existing comments were found to be relevant and explanatory, so no comments were removed during the cleanup phase.