### PR TITLE
Fix WebScanPage errors and improve UI consistency.

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -40,10 +40,14 @@ class DNSPage(Adw.PreferencesPage):
     __gtype_name__ = "DNSPage"
 
     domain_entry = Gtk.Template.Child()
-    dns_lookup_spinner = Gtk.Template.Child()
+    # dns_lookup_spinner was removed from UI, replaced by dns_status_spinner
     dns_apply_button = Gtk.Template.Child()
     dns_record_type_dropdown = Gtk.Template.Child()
     dns_results_box_container = Gtk.Template.Child()
+    dns_clear_results_button = Gtk.Template.Child()
+    dns_copy_all_results_button = Gtk.Template.Child()
+    dns_status_row = Gtk.Template.Child()
+    dns_status_spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: GObject.GObject):
         """Initialize the DNSPage.
@@ -61,15 +65,89 @@ class DNSPage(Adw.PreferencesPage):
         if self.dns_apply_button:
             self.dns_apply_button.set_use_underline(True)
 
-        if self.dns_lookup_spinner:
-            self.dns_lookup_spinner.set_spinning(False)
-            self.dns_lookup_spinner.set_visible(False)
+        # Removed old dns_lookup_spinner initialization
+
+        # Initialize new status row and spinner
+        if self.dns_status_row:
+            self.dns_status_row.set_subtitle("Idle") # type: ignore
+        if self.dns_status_spinner:
+            self.dns_status_spinner.set_spinning(False) # type: ignore
+            self.dns_status_spinner.set_visible(False) # type: ignore
+
+        # Initially disable clear/copy buttons as there are no results
+        if self.dns_clear_results_button:
+            self.dns_clear_results_button.set_sensitive(False)
+        if self.dns_copy_all_results_button:
+            self.dns_copy_all_results_button.set_sensitive(False)
 
     def _connect_signals(self) -> None:
         """Connect signals for UI elements to their respective handlers."""
         self.domain_entry.connect("activate", self._on_entry_activated) # type: ignore
         self.dns_apply_button.connect("clicked", self._on_entry_activated) # type: ignore
         self.dns_record_type_dropdown.connect("notify::selected", self._on_record_type_changed) # type: ignore
+        if self.dns_clear_results_button:
+            self.dns_clear_results_button.connect("clicked", self._on_clear_results_clicked)
+        if self.dns_copy_all_results_button:
+            self.dns_copy_all_results_button.connect("clicked", self._on_copy_all_results_clicked)
+
+    def _on_clear_results_clicked(self, _button: Gtk.Button) -> None:
+        """Clear all DNS lookup results from the UI."""
+        logger.info("Clearing DNS results.")
+        while (child := self.dns_results_box_container.get_first_child()): # type: ignore
+            self.dns_results_box_container.remove(child) # type: ignore
+
+        # Optionally, add a placeholder back if desired, or leave it empty.
+        # For now, just clear.
+
+        if self.dns_clear_results_button:
+            self.dns_clear_results_button.set_sensitive(False)
+        if self.dns_copy_all_results_button:
+            self.dns_copy_all_results_button.set_sensitive(False)
+
+    def _on_copy_all_results_clicked(self, _button: Gtk.Button) -> None:
+        """Copy all displayed DNS results to the clipboard."""
+        logger.info("Copying all DNS results to clipboard.")
+        all_results_text = []
+
+        # Iterate through children of dns_results_box_container
+        child = self.dns_results_box_container.get_first_child() # type: ignore
+        while child:
+            text_parts_for_child = []
+            if isinstance(child, Adw.ActionRow):
+                title = child.get_title()
+                subtitle = child.get_subtitle()
+                if title: text_parts_for_child.append(title)
+                if subtitle: text_parts_for_child.append(subtitle)
+
+                # Attempt to get text from suffixes if they are labels
+                # This is a simplified approach; real implementation might need to traverse deeper
+                # or access data from the model that generated the rows.
+                # For this example, we'll focus on title/subtitle of ActionRows.
+                # If the row has a Gtk.Label in a suffix, try to get its text.
+                # This part is heuristic as direct access to full record data isn't stored on rows.
+
+            elif isinstance(child, Adw.ExpanderRow):
+                title = child.get_title()
+                subtitle = child.get_subtitle()
+                if title: text_parts_for_child.append(title)
+                if subtitle: text_parts_for_child.append(subtitle)
+                # Could iterate expander's rows too, but keeping it simple for now.
+                # A more robust way would be to have the data that generated these rows
+                # stored in an instance variable and iterate that.
+
+            if text_parts_for_child:
+                all_results_text.append(" - ".join(text_parts_for_child))
+
+            child = child.get_next_sibling()
+
+        if not all_results_text:
+            show_global_toast(self, "No results to copy.") # type: ignore
+            return
+
+        final_text_to_copy = "\n".join(all_results_text)
+        DNSPage._copy_to_clipboard(final_text_to_copy, self)
+        show_global_toast(self, "All results copied to clipboard.") # type: ignore
+
 
     @staticmethod
     def _copy_to_clipboard(text: str, widget: Gtk.Widget) -> None:
@@ -206,19 +284,31 @@ class DNSPage(Adw.PreferencesPage):
         detail_row.set_selectable(False)
         expander_row.add_row(detail_row) # type: ignore
 
-    def _set_loading_state(self, active: bool) -> None:
-        """Sets the UI loading state (spinner, sensitivity)."""
-        if self.dns_lookup_spinner:
-            self.dns_lookup_spinner.set_visible(active) # type: ignore
+    def _set_loading_state(self, active: bool, message: Optional[str] = None) -> None:
+        """Sets the UI loading state (spinner, status message, sensitivity)."""
+        if self.dns_status_spinner:
+            self.dns_status_spinner.set_visible(active) # type: ignore
             if active:
-                self.dns_lookup_spinner.start() # type: ignore
+                self.dns_status_spinner.start() # type: ignore
             else:
-                self.dns_lookup_spinner.stop() # type: ignore
-        # Potentially disable/enable other controls like domain_entry or apply_button here
-        if self.domain_entry: # Check if bound
+                self.dns_status_spinner.stop() # type: ignore
+
+        if self.dns_status_row:
+            current_subtitle = self.dns_status_row.get_subtitle() # type: ignore
+            if message:
+                self.dns_status_row.set_subtitle(message) # type: ignore
+            elif active and current_subtitle != "Looking up...": # Default message when starting an operation
+                self.dns_status_row.set_subtitle("Looking up...") # type: ignore
+            elif not active and not message : # Default message when stopping (idle) and no specific message given
+                self.dns_status_row.set_subtitle("Idle") # type: ignore
+            # If not active and a message is present (e.g. error or success), it will be set by the caller.
+
+        if self.domain_entry:
             self.domain_entry.set_sensitive(not active) # type: ignore
-        if self.dns_apply_button: # Check if bound
+        if self.dns_apply_button:
             self.dns_apply_button.set_sensitive(not active) # type: ignore
+        if self.dns_record_type_dropdown:
+            self.dns_record_type_dropdown.set_sensitive(not active) # type: ignore
 
     def _validate_dns_input(self, user_input: str) -> bool:
         """Validates the DNS user input. Shows global error/toast if invalid.
@@ -274,6 +364,13 @@ class DNSPage(Adw.PreferencesPage):
         nameservers_used = dns_client.resolver.nameservers
         self._display_result(result_data, user_input, actual_record_type_displayed, nameservers_used)
 
+        status_message = f"{len(result_data)} {actual_record_type_displayed} record(s) found." if result_data else f"No {actual_record_type_displayed} records found for {user_input}."
+        if self.dns_status_row:
+            self.dns_status_row.set_subtitle(status_message) # type: ignore
+        # show_global_toast is good for transient notifications, status row is persistent.
+        # Consider if toast is still needed or if status row is sufficient. Keeping for now.
+        show_global_toast(self, status_message) # type: ignore
+
     def _handle_dns_lookup_exception(
         self,
         error: Exception,
@@ -282,36 +379,51 @@ class DNSPage(Adw.PreferencesPage):
         dns_client: DnsResolverClient # Pass client to get nameservers for NoAnswer
     ) -> None:
         """Handles exceptions from DnsResolverClient."""
+        error_message = str(error) # Original full error message
+        status_subtitle = f"Error: {error_message.splitlines()[0]}" # Default status: first line of error
+
         if isinstance(error, DnsNxDomainError):
-            show_global_error(self, str(error)) # type: ignore
+            show_global_error(self, error_message) # type: ignore
+            status_subtitle = f"NXDOMAIN: Domain '{user_input}' not found."
         elif isinstance(error, DnsNoAnswerError):
-            logger.info("DNSPage: %s", str(error))
+            logger.info("DNSPage: %s", error_message)
             nameservers_used = dns_client.resolver.nameservers
-            self._display_result([], user_input, requested_record_type, nameservers_used)
+            self._display_result([], user_input, requested_record_type, nameservers_used) # Shows "No records found" in results area
+            # Override the "No records found" status from _display_result with the actual error for clarity in status row
+            status_subtitle = f"No {requested_record_type} records found for {user_input} (No Answer)."
         elif isinstance(error, DnsResolutionTimeoutError):
-            show_global_error(self, str(error)) # type: ignore
+            show_global_error(self, error_message) # type: ignore
+            status_subtitle = f"Timeout: Could not resolve {user_input}."
         elif isinstance(error, DnsGenericError):
             logger.exception("DNSPage: DNS lookup failed for %s, type %s (DnsGenericError):", user_input, requested_record_type)
-            show_global_error(self, str(error)) # type: ignore
+            show_global_error(self, error_message) # type: ignore
+            status_subtitle = f"DNS Error: {error_message.splitlines()[0]}"
         elif isinstance(error, DnsClientError): # Base client error
             logger.exception("DNSPage: Unexpected DnsClientError for %s, type %s:", user_input, requested_record_type)
-            show_global_error(self, f"DNS Client Error: {str(error)}") # type: ignore
+            show_global_error(self, f"DNS Client Error: {error_message}") # type: ignore
+            status_subtitle = f"Client Error: {error_message.splitlines()[0]}"
         else: # Generic Exception
             logger.exception("DNSPage: Unexpected error during DNS lookup for %s, type %s:", user_input, requested_record_type)
-            show_global_error(self, f"An unexpected error occurred: {str(error)}") # type: ignore
+            error_message_short = f"An unexpected error occurred: {error_message.splitlines()[0]}"
+            show_global_error(self, error_message_short) # type: ignore
+            status_subtitle = error_message_short
+
+        if self.dns_status_row:
+            self.dns_status_row.set_subtitle(status_subtitle) # type: ignore
+
 
     def _perform_lookup(self) -> None: # noqa: C901
         """Perform the DNS lookup based on user input and selected record type.
 
         Orchestrates input validation, client interaction, and result/error display.
         """
-        self._set_loading_state(True)
+        self._set_loading_state(True, "Looking up...")
         user_input = self.domain_entry.get_text().strip() # type: ignore
         requested_record_type = self._get_selected_record_type()
         logger.debug(f"DNSPage: Performing DNS lookup for: {user_input}, type: {requested_record_type}")
 
         if not self._validate_dns_input(user_input):
-            self._set_loading_state(False)
+            self._set_loading_state(False, "Idle - Invalid input.") # Reset status to Idle with specific message
             return
 
         self._clear_error()
@@ -322,10 +434,16 @@ class DNSPage(Adw.PreferencesPage):
         try:
             result_data = dns_client.resolve(user_input, requested_record_type)
             self._handle_dns_lookup_success(result_data, user_input, requested_record_type, dns_client)
+            # Status is set by _handle_dns_lookup_success
         except Exception as e: # Catch all exceptions here and delegate to the handler
             self._handle_dns_lookup_exception(e, user_input, requested_record_type, dns_client)
+            # Status is set by _handle_dns_lookup_exception
         finally:
+            # Ensure loading state is always reset (spinner off, controls on),
+            # but preserve the status message set by success/error handlers.
+            # Call _set_loading_state without a message to achieve this.
             self._set_loading_state(False)
+
 
     def _get_selected_record_type(self) -> str:
         """Get the currently selected DNS record type from the dropdown.
@@ -398,12 +516,24 @@ class DNSPage(Adw.PreferencesPage):
             no_records_row = Adw.ActionRow(title=no_records_message)
             no_records_row.set_selectable(False)
             self.dns_results_box_container.append(no_records_row) # type: ignore
+            # Update button sensitivity: No results, so disable
+            if self.dns_clear_results_button:
+                self.dns_clear_results_button.set_sensitive(False)
+            if self.dns_copy_all_results_button:
+                self.dns_copy_all_results_button.set_sensitive(False)
             return
 
         for record_data in result_records:
             row = self._create_record_row(record_data)
             if row:
                 self.dns_results_box_container.append(row) # type: ignore
+
+        # Update button sensitivity: Results are present, so enable
+        if self.dns_clear_results_button:
+            self.dns_clear_results_button.set_sensitive(True)
+        if self.dns_copy_all_results_button:
+            self.dns_copy_all_results_button.set_sensitive(True)
+
 
     # --- Helper methods for building record rows ---
 

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -22,13 +22,6 @@
               </object>
             </child>
             <child type="suffix">
-              <object class="GtkSpinner" id="dns_lookup_spinner">
-                <property name="spinning">False</property>
-                <property name="valign">center</property>
-                <property name="visible">False</property>
-              </object>
-            </child>
-            <child type="suffix">
               <object class="GtkButton" id="dns_apply_button">
                 <property name="label" translatable="yes">_Lookup</property>
                 <property name="valign">center</property>
@@ -60,11 +53,50 @@
             <property name="title" translatable="yes">Record Type</property>
           </object>
         </child>
+        <child>
+          <object class="AdwActionRow" id="dns_status_row">
+            <property name="title" translatable="yes">Status</property>
+            <property name="subtitle" translatable="yes">Idle</property>
+            <child type="suffix">
+              <object class="GtkSpinner" id="dns_status_spinner">
+                <property name="spinning">False</property>
+                <property name="valign">center</property>
+                <property name="visible">False</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>
       <object class="AdwPreferencesGroup">
         <property name="description" translatable="yes">DNS lookup results will appear below.</property>
+        <property name="header-suffix">
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkButton" id="dns_clear_results_button">
+                <property name="icon-name">edit-clear-all-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Clear Results</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="dns_copy_all_results_button">
+                <property name="icon-name">edit-copy-symbolic</property>
+                <property name="tooltip-text" translatable="yes">Copy All Results</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
+          </object>
+        </property>
         <property name="title" translatable="yes">Results</property>
         <property name="width-request">1000</property>
         <child>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -45,6 +45,19 @@
             <property name="title" translatable="yes">Akamai Debug Headers</property>
           </object>
         </child>
+        <child>
+          <object class="AdwActionRow" id="http_status_row">
+            <property name="title" translatable="yes">Status</property>
+            <property name="subtitle" translatable="yes">Idle</property>
+            <child type="suffix">
+              <object class="GtkSpinner" id="http_status_spinner">
+                <property name="spinning">False</property>
+                <property name="valign">center</property>
+                <property name="visible">False</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child>
@@ -62,6 +75,7 @@
                 <signal name="clicked" handler="_on_clear_results_clicked"/>
                 <style>
                   <class name="destructive-action"/>
+                  <class name="flat"/>
                 </style>
               </object>
             </child>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -22,6 +22,132 @@
           </object>
         </child>
         <child>
+          <object class="AdwPreferencesGroup" id="nmap_scan_parameters_group">
+            <property name="hexpand">True</property>
+            <property name="title" translatable="yes">Scan Parameters</property>
+            <child>
+              <object class="AdwEntryRow" id="nmap_target_entryrow">
+                <property name="activates-default">true</property>
+                <property name="hexpand">true</property>
+                <property name="hexpand-set">true</property>
+                <property name="input-purpose">url</property>
+                <property name="title" translatable="yes">Target (IP/CIDR/Hostname)</property>
+                <child type="suffix">
+                  <object class="GtkButton" id="nmap_apply_button">
+                    <property name="label" translatable="yes">_Scan</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwExpanderRow" id="nmap_advanced_options_expander">
+                <property name="hexpand">true</property>
+                <property name="hexpand-set">true</property>
+                <property name="title" translatable="yes">Advanced Scan Options</property>
+                <child>
+                  <object class="AdwSwitchRow" id="nmap_fingerprint_switchrow">
+                    <property name="subtitle" translatable="yes">Enable this to attempt OS detection (often requires root/administrator privileges)</property>
+                    <property name="title" translatable="yes">OS Fingerprinting</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwSwitchRow" id="nmap_all_ports_switchrow">
+                    <property name="subtitle" translatable="yes">Scan all 65535 TCP ports (default is top ~1000)</property>
+                    <property name="title" translatable="yes">Scan All Ports</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwComboRow" id="nmap_scripts_dropdown">
+                    <property name="icon-name">emblem-documents-symbolic</property>
+                    <property name="model">
+                      <object class="GtkStringList" id="nmap_scripts_list_store">
+                        <property name="strings">None</property>
+                        <items>
+                          <item>default</item>
+                          <item>vuln</item>
+                          <item>discovery</item>
+                          <item>broadcast</item>
+                          <item>exploit</item>
+                          <item>http-grep</item>
+                          <item>http-enum</item>
+                          <item>http-config-backup</item>
+                          <item>http-wordpress-enum</item>
+                          <item>http-cors</item>
+                          <item>http-csrf</item>
+                          <item>http-cross-domain-policy</item>
+                          <item>mysql-users</item>
+                          <item>vulscan/vulscan</item>
+                          <item>firewalk</item>
+                        </items>
+                      </object>
+                    </property>
+                    <property name="selected">0</property>
+                    <property name="subtitle" translatable="yes">Select a script or script category</property>
+                    <property name="title" translatable="yes">Nmap Scripting Engine (NSE)</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwSwitchRow" id="nmap_service_version_switchrow">
+                    <property name="subtitle" translatable="yes">Attempt to determine the version of the service running on port</property>
+                    <property name="title" translatable="yes">Service Version Detection (-sV)</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwSwitchRow" id="nmap_no_ping_switchrow">
+                    <property name="subtitle" translatable="yes">Skip host discovery, scan all targets</property>
+                    <property name="title" translatable="yes">No Ping Scan (-Pn)</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwComboRow" id="nmap_timing_template_comborow">
+                    <property name="model">
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">Polite (T0)</item>
+                          <item translatable="yes">Sneaky (T1)</item>
+                          <item translatable="yes">Paranoid (T2)</item>
+                          <item translatable="yes">Normal (T3)</item>
+                          <item translatable="yes">Aggressive (T4)</item>
+                          <item translatable="yes">Insane (T5)</item>
+                        </items>
+                      </object>
+                    </property>
+                    <property name="selected">3</property>
+                    <property name="title" translatable="yes">Timing Template (-T)</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="status_row">
+                <property name="activatable">False</property>
+                <property name="hexpand">true</property>
+                <property name="hexpand-set">true</property>
+                <property name="subtitle" translatable="yes">Idle</property>
+                <property name="title" translatable="yes">Scan Status</property>
+                <property name="visible">true</property>
+                <child>
+                  <object class="GtkSpinner" id="scan_spinner">
+                    <property name="spinning">False</property>
+                    <property name="visible">False</property>
+                  </object>
+                </child>
+                <child type="suffix">
+                  <object class="GtkButton" id="nmap_cancel_scan_button">
+                    <property name="label" translatable="yes">Cancel</property>
+                    <property name="icon-name">process-stop-symbolic</property>
+                    <property name="visible">False</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="GtkPaned" id="main_paned_view">
             <property name="hexpand">true</property>
             <property name="orientation">horizontal</property>
@@ -40,149 +166,11 @@
                 <property name="vexpand">True</property>
                 <property name="width-request">600</property>
                 <child>
-                  <object class="GtkBox" id="left_vbox_content">
+                  <object class="GtkListBox" id="nmap_host_listbox">
                     <property name="hexpand">true</property>
                     <property name="hexpand-set">true</property>
-                    <property name="margin-bottom">6</property>
-                    <property name="margin-end">6</property>
-                    <property name="margin-start">6</property>
-                    <property name="margin-top">6</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="AdwPreferencesGroup" id="nmap_scan_parameters_group">
-                        <property name="hexpand">True</property>
-                        <property name="title" translatable="yes">Scan Parameters</property>
-                        <child>
-                          <object class="AdwEntryRow" id="nmap_target_entryrow">
-                            <property name="activates-default">true</property>
-                            <property name="hexpand">true</property>
-                            <property name="hexpand-set">true</property>
-                            <property name="input-purpose">url</property>
-                            <property name="title" translatable="yes">Target (IP/CIDR/Hostname)</property>
-                            <child type="suffix">
-                              <object class="GtkButton" id="nmap_apply_button">
-                                <property name="label" translatable="yes">_Scan</property>
-                                <property name="valign">center</property>
-                                <style>
-                                  <class name="suggested-action"/>
-                                </style>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwExpanderRow" id="nmap_advanced_options_expander">
-                            <property name="hexpand">true</property>
-                            <property name="hexpand-set">true</property>
-                            <property name="title" translatable="yes">Advanced Scan Options</property>
-                            <child>
-                              <object class="AdwSwitchRow" id="nmap_fingerprint_switchrow">
-                                <property name="subtitle" translatable="yes">Enable this to attempt OS detection (often requires root/administrator privileges)</property>
-                                <property name="title" translatable="yes">OS Fingerprinting</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwSwitchRow" id="nmap_all_ports_switchrow">
-                                <property name="subtitle" translatable="yes">Scan all 65535 TCP ports (default is top ~1000)</property>
-                                <property name="title" translatable="yes">Scan All Ports</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwComboRow" id="nmap_scripts_dropdown">
-                                <property name="icon-name">emblem-documents-symbolic</property>
-                                <property name="model">
-                                  <object class="GtkStringList" id="nmap_scripts_list_store">
-                                    <property name="strings">None</property>
-                                    <items>
-                                      <item>default</item>
-                                      <item>vuln</item>
-                                      <item>discovery</item>
-                                      <item>broadcast</item>
-                                      <item>exploit</item>
-                                      <item>http-grep</item>
-                                      <item>http-enum</item>
-                                      <item>http-config-backup</item>
-                                      <item>http-wordpress-enum</item>
-                                      <item>http-cors</item>
-                                      <item>http-csrf</item>
-                                      <item>http-cross-domain-policy</item>
-                                      <item>mysql-users</item>
-                                      <item>vulscan/vulscan</item>
-                                      <item>firewalk</item>
-                                    </items>
-                                  </object>
-                                </property>
-                                <property name="selected">0</property>
-                                <property name="subtitle" translatable="yes">Select a script or script category</property>
-                                <property name="title" translatable="yes">Nmap Scripting Engine (NSE)</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwSwitchRow" id="nmap_service_version_switchrow">
-                                <property name="subtitle" translatable="yes">Attempt to determine the version of the service running on port</property>
-                                <property name="title" translatable="yes">Service Version Detection (-sV)</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwSwitchRow" id="nmap_no_ping_switchrow">
-                                <property name="subtitle" translatable="yes">Skip host discovery, scan all targets</property>
-                                <property name="title" translatable="yes">No Ping Scan (-Pn)</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="AdwComboRow" id="nmap_timing_template_comborow">
-                                <property name="model">
-                                  <object class="GtkStringList">
-                                    <items>
-                                      <item translatable="yes">Polite (T0)</item>
-                                      <item translatable="yes">Sneaky (T1)</item>
-                                      <item translatable="yes">Paranoid (T2)</item>
-                                      <item translatable="yes">Normal (T3)</item>
-                                      <item translatable="yes">Aggressive (T4)</item>
-                                      <item translatable="yes">Insane (T5)</item>
-                                    </items>
-                                  </object>
-                                </property>
-                                <property name="selected">3</property>
-                                <property name="title" translatable="yes">Timing Template (-T)</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwActionRow" id="status_row">
-                            <property name="activatable">False</property>
-                            <property name="hexpand">true</property>
-                            <property name="hexpand-set">true</property>
-                            <property name="subtitle" translatable="yes">Idle</property>
-                            <property name="title" translatable="yes">Scan Status</property>
-                            <property name="visible">true</property>
-                            <child>
-                              <object class="GtkSpinner" id="scan_spinner">
-                                <property name="spinning">False</property>
-                                <property name="visible">False</property>
-                              </object>
-                            </child>
-                            <child type="suffix">
-                              <object class="GtkButton" id="nmap_cancel_scan_button">
-                                <property name="label" translatable="yes">Cancel</property>
-                                <property name="icon-name">process-stop-symbolic</property>
-                                <property name="visible">False</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkListBox" id="nmap_host_listbox">
-                        <property name="hexpand">true</property>
-                        <property name="hexpand-set">true</property>
-                        <property name="selection-mode">single</property>
-                        <property name="vexpand">true</property>
-                      </object>
-                    </child>
+                    <property name="selection-mode">single</property>
+                    <property name="vexpand">true</property>
                   </object>
                 </child>
               </object>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -147,6 +147,9 @@
                 <property name="icon-name">edit-clear-all-symbolic</property>
                 <property name="tooltip-text" translatable="yes">Clear Results</property>
                 <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
               </object>
             </child>
             <child>
@@ -154,6 +157,9 @@
                 <property name="icon-name">edit-copy-symbolic</property>
                 <property name="tooltip-text" translatable="yes">Copy Results</property>
                 <property name="valign">center</property>
+                <style>
+                  <class name="flat"/>
+                </style>
               </object>
             </child>
           </object>
@@ -166,6 +172,15 @@
             <property name="min-content-height">200</property>
             <property name="vexpand">True</property>
             <property name="width-request">800</property>
+            <child>
+              <object class="GtkSourceView" id="results_textview">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="monospace">True</property>
+                <property name="show-line-numbers">True</property>
+                <property name="wrap-mode">GTK_WRAP_WORD_CHAR</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -92,6 +92,8 @@ class HttpPage(Adw.PreferencesPage):
     http_results_group = Gtk.Template.Child("http_results_group")
     clear_results_button = Gtk.Template.Child("clear_results_button")
     copy_results_button = Gtk.Template.Child()
+    http_status_row = Gtk.Template.Child()
+    http_status_spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: GObject.GObject):
         """Initialize the HttpPage.
@@ -138,6 +140,12 @@ class HttpPage(Adw.PreferencesPage):
             self._on_host_header_changed(self.http_host_header_row)
         if self.http_user_agent_row:
             self._on_user_agent_changed(self.http_user_agent_row, None)
+
+        if self.http_status_row:
+            self.http_status_row.set_subtitle("Idle") # type: ignore
+        if self.http_status_spinner:
+            self.http_status_spinner.set_spinning(False) # type: ignore
+            self.http_status_spinner.set_visible(False) # type: ignore
 
     def _connect_signals(self) -> None:
         """Connect signals for UI elements to their respective handlers."""
@@ -248,13 +256,12 @@ class HttpPage(Adw.PreferencesPage):
             if not (main_window and hasattr(main_window, "show_toast")):
                 show_global_error(self, toast_message) # type: ignore
             self._update_column_view_model(None)
+            self._set_loading_state(False, "Idle - Invalid URL.")
             return
 
         self._clear_error()
-        self.http_entry_row.set_sensitive(False) # type: ignore
-        if hasattr(self, "http_apply_button") and self.http_apply_button:
-            self.http_apply_button.set_sensitive(False)
-            # self.http_apply_button.set_icon_name("process-working-symbolic") # Removed
+        self._set_loading_state(True, "Fetching headers...")
+
         host_header = self.http_host_header_row.get_text().strip() # type: ignore
         user_agent_to_send: Optional[str] = None
         selected_title_obj = self.http_user_agent_row.get_selected_item() # type: ignore
@@ -482,20 +489,21 @@ class HttpPage(Adw.PreferencesPage):
                 if hasattr(self, "http_entry_row") and self.http_entry_row:
                     self.http_entry_row.add_css_class("error") # type: ignore
                 self._update_column_view_model(None)
+            self._set_loading_state(False, "Error: Failed to process data.")
         except GLib.Error as e:  # Errors set by task.return_new_error_literal in _fetch_headers_task_thread_func
             logger.warning(
                 "HttpPage: Task failed with GLib.Error (Domain: %s, Code: %d, Message: %s)",
                  e.domain, e.code, e.message
             )
             display_message = e.message if e.message else "An unknown error occurred."
-            # Basic sanitization, could be more robust if needed
-            if "<b>" in display_message or "<" in display_message:
+            if "<b>" in display_message or "<" in display_message: # Basic sanitization
                 display_message = GLib.markup_escape_text(display_message)
 
             show_global_error(self, display_message) # type: ignore
             if hasattr(self, "http_entry_row") and self.http_entry_row:
                 self.http_entry_row.add_css_class("error") # type: ignore
-                self._update_column_view_model(None)
+            self._update_column_view_model(None)
+            self._set_loading_state(False, f"Error: {display_message.splitlines()[0]}")
         except Exception as e:  # Catch any other Python exceptions from this callback itself
             logger.exception("HttpPage: Unexpected Python error in _fetch_headers_task_done_cb:")
             error_message = f"An unexpected application error occurred: {e}"
@@ -503,12 +511,42 @@ class HttpPage(Adw.PreferencesPage):
             if hasattr(self, "http_entry_row") and self.http_entry_row:
                 self.http_entry_row.add_css_class("error") # type: ignore
             self._update_column_view_model(None)
+            self._set_loading_state(False, f"Error: {error_message.splitlines()[0]}")
         finally:
-            if hasattr(self, "http_entry_row") and self.http_entry_row:
-                self.http_entry_row.set_sensitive(True) # type: ignore
-            if hasattr(self, "http_apply_button") and self.http_apply_button:
-                self.http_apply_button.set_sensitive(True)
-                # Spinner icon logic for http_apply_button was removed
+            # _set_loading_state(False, ...) called in success/error blocks handles sensitivity
+            # and spinner. If no specific message for success/error, it defaults to "Idle".
+            # If an error occurred, the error message is set as status.
+            # If successful, a success message should be set.
+            if self.current_http_task is None: # Task finished (successfully or with error)
+                 if not propagate_result: # check if success
+                    if self.http_status_row and self.http_status_row.get_subtitle() == "Fetching headers...": # type: ignore
+                        self._set_loading_state(False, "Headers loaded.") # Default success
+                 # Error messages are set above. If no error, and success, subtitle should be "Headers loaded."
+
+    def _set_loading_state(self, active: bool, message: str = "Idle") -> None:
+        """Sets the UI loading state (spinner, status message, sensitivity of input fields)."""
+        if self.http_status_spinner:
+            self.http_status_spinner.set_visible(active) # type: ignore
+            if active:
+                self.http_status_spinner.start() # type: ignore
+            else:
+                self.http_status_spinner.stop() # type: ignore
+
+        if self.http_status_row:
+            self.http_status_row.set_subtitle(message) # type: ignore
+
+        sensitive = not active
+        if self.http_entry_row:
+            self.http_entry_row.set_sensitive(sensitive) # type: ignore
+        if self.http_apply_button:
+            self.http_apply_button.set_sensitive(sensitive) # type: ignore
+        if self.http_host_header_row:
+            self.http_host_header_row.set_sensitive(sensitive) # type: ignore
+        if self.http_user_agent_row:
+            self.http_user_agent_row.set_sensitive(sensitive) # type: ignore
+        if self.http_pragma_switch_row:
+            self.http_pragma_switch_row.set_sensitive(sensitive) # type: ignore
+
 
     @staticmethod
     def _ensure_scheme(url: str) -> str:

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -73,7 +73,6 @@ class NmapPage(Gtk.Box):
     scan_spinner = Gtk.Template.Child("scan_spinner")
     nmap_cancel_scan_button = Gtk.Template.Child()
 
-    left_vbox_content = Gtk.Template.Child("left_vbox_content")
     nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")
     nmap_detail_box = Gtk.Template.Child("nmap_detail_box")
     nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
@@ -426,7 +425,40 @@ class NmapPage(Gtk.Box):
         scrolled_window.set_max_content_height(400)
         scrolled_window.set_vexpand(True)
         expander.add_row(scrolled_window)
+
+        # Add Copy button to the expander's header-suffix
+        header_suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        copy_summary_button = Gtk.Button.new_from_icon_name("edit-copy-symbolic")
+        copy_summary_button.set_tooltip_text("Copy Host Summary")
+        copy_summary_button.get_style_context().add_class("flat")
+        # Pass the summary text to the handler.
+        # Using a lambda that captures human_readable_summary.
+        copy_summary_button.connect("clicked", lambda _btn, text=human_readable_summary: self._on_copy_host_summary_clicked(text))
+        header_suffix_box.append(copy_summary_button)
+        expander.add_suffix(header_suffix_box)
+
         self.nmap_detail_box.append(expander)
+
+    def _on_copy_host_summary_clicked(self, summary_text: str):
+        """Handles the click of the 'Copy Host Summary' button."""
+        logger.info("Copying Nmap host summary to clipboard.")
+        if not summary_text:
+            show_global_toast(self, "No summary text available to copy.") # type: ignore
+            return
+
+        try:
+            clipboard = self.get_clipboard() # type: ignore
+            if clipboard:
+                clipboard.set(summary_text) # type: ignore
+                show_global_toast(self, "Host summary copied to clipboard.") # type: ignore
+                logger.info("Copied Nmap host summary to clipboard.")
+            else:
+                logger.warning("Could not get clipboard for NmapPage.")
+                show_global_toast(self, "Failed to access clipboard.") # type: ignore
+        except Exception as e: # pylint: disable=broad-except
+            logger.exception("Error copying Nmap host summary to clipboard:")
+            show_global_toast(self, f"Error copying: {e}") # type: ignore
+
 
     def _add_host_details_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
         """Add an Adw.ExpanderRow to display general host information."""


### PR DESCRIPTION
This commit addresses a critical runtime error in the WebScanPage related to a missing 'results_textview' widget. It also introduces several UI consistency improvements across multiple pages.

Changes include:

1.  **Bug Fix (WebScanPage):**
    *   Added the missing `results_textview` (GtkSourceView) to `webscan_page.ui`, resolving an `AttributeError` and a Gtk-CRITICAL warning during page initialization.

2.  **UI Consistency Enhancements:**
    *   **Nmap Page:**
        *   Restructured `nmap_page.ui` to move scan parameters into an `AdwPreferencesGroup` positioned above the main `GtkPaned` results view. This aligns its settings presentation with other pages.
        *   The `GtkPaned` now correctly uses the left pane for the host list and the right for host details.
    *   **Clear/Copy Buttons:**
        *   DNS Page: Added "Clear Results" and "Copy All Results" buttons to the `header-suffix` of the results group.
        *   HTTP Page: Ensured existing clear/copy buttons use `flat` style for consistency.
        *   WebScan Page: Ensured existing clear/copy buttons use `flat` style.
        *   Nmap Page: Added a "Copy Host Summary" button to the `header-suffix` of the text summary expander for the selected host.
    *   **Status Indicators:**
        *   DNS Page: Added a dedicated `AdwActionRow` with a spinner and text subtitle for clearer status reporting during DNS lookups.
        *   HTTP Page: Added a similar `AdwActionRow` for status and spinner to provide more explicit feedback during HTTP header fetching.

These changes aim to create a more robust and visually consistent user experience.