### PR TITLE
I've fixed a TypeError in Gio.Task error reporting and ensured consis…

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -236,14 +236,14 @@ class NmapPage(Gtk.Box):
 
         if not params:
             logger.error("NmapPage: _run_nmap_scan_thread_func: _current_nmap_scan_params is None. This indicates a programming error.")
-            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.UNEXPECTED.value, "Internal error: Scan parameters not found.") # type: ignore
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, "Internal error: Scan parameters not found.") # type: ignore
             return
 
         target = params["target"]
         logger.debug(f"_run_nmap_scan_thread_func started for target: {target}")
 
         if cancellable and cancellable.is_cancelled():
-            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value, "Scan cancelled before start.")
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, "Scan cancelled before start.")
             return
 
         try:
@@ -251,18 +251,18 @@ class NmapPage(Gtk.Box):
 
             if cancellable and cancellable.is_cancelled():
                 # This check handles cancellation if run_nmap_scan completed but cancellation was flagged during its execution.
-                task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value, "Scan cancelled during operation.")
+                task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, "Scan cancelled during operation.")
             else:
                 task.return_value(nm) # type: ignore
         except ScanCancelledError as e: # Specific handling for cancellation
             logger.info("Nmap scan for %s was cancelled: %s", target, e)
-            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.CANCELLED.value, str(e))
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, str(e))
         except nmap.PortScannerError as e: # For other Nmap-related errors
             logger.exception("Nmap PortScannerError for %s:", target)
-            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.SCAN_FAILED.value, f"Nmap scan error: {e}")
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.SCAN_FAILED.value, f"Nmap scan error: {e}")
         except Exception as e: # Catch-all for any other unexpected errors
             logger.exception("Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__)
-            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN, NmapScanErrorType.UNEXPECTED.value, f"Scan failed unexpectedly: {e}")
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, f"Scan failed unexpectedly: {e}")
         finally:
             logger.info("Nmap scan thread finished for %s.", target)
             # UI sensitivity updates are handled in _nmap_scan_task_done_cb

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -211,7 +211,7 @@ class WebScanPage(Adw.PreferencesPage):
             logger.error("WebScanPage: _run_scan_task_thread_func: _current_webscan_params is None.")
             # This indicates a programming error if scan_params is None.
             # The task object (if needed for error reporting) is 'task'.
-            task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value, "Missing scan parameters in thread.") # type: ignore
+            task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, "Missing scan parameters in thread.") # type: ignore
             return
 
         target_url = scan_params["target_url"]
@@ -272,7 +272,7 @@ class WebScanPage(Adw.PreferencesPage):
 
         try:
             if cancellable.is_cancelled():
-                task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.CANCELLED.value, "Scan cancelled before Nikto process start.") # type: ignore
+                task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.CANCELLED.value, "Scan cancelled before Nikto process start.") # type: ignore
                 return
 
             process = subprocess.Popen(nikto_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8")
@@ -293,7 +293,7 @@ class WebScanPage(Adw.PreferencesPage):
                             process.kill()
                         except Exception as e_term: # pylint: disable=broad-except # Process termination can have diverse errors
                             logger.error(f"Error terminating Nikto process: {e_term}")
-                    task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.CANCELLED.value, "Scan cancelled by user.") # type: ignore
+                    task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.CANCELLED.value, "Scan cancelled by user.") # type: ignore
                     self.current_nikto_process = None
                     return
 
@@ -307,18 +307,18 @@ class WebScanPage(Adw.PreferencesPage):
 
             if process.returncode != 0:
                  logger.error(f"Nikto process finished with error code {process.returncode}. Stderr: {stderr_str}")
-                 task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value, f"Nikto scan failed. Output:\n{stderr_str or stdout_str}") # type: ignore
+                 task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, f"Nikto scan failed. Output:\n{stderr_str or stdout_str}") # type: ignore
                  return
 
             task.return_value((stdout_str, stderr_str)) # type: ignore
         except FileNotFoundError:
             logger.error("Nikto command not found. Ensure it's in PATH.")
-            task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.NIKTO_NOT_FOUND.value, "Nikto command not found. Please ensure it is installed and in your system's PATH.") # type: ignore
+            task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.NIKTO_NOT_FOUND.value, "Nikto command not found. Please ensure it is installed and in your system's PATH.") # type: ignore
         # TimeoutExpired for process.communicate() is removed as we poll.
         # A global timeout for the entire scan could be implemented by checking time in the polling loop.
         except Exception as e: # pylint: disable=broad-except # Catch all for thread to report error via Gio.Task
             logger.exception(f"An unexpected error occurred during Nikto scan task: {e}")
-            task.return_new_error_literal(WEB_SCAN_ERROR_DOMAIN, WebScanErrorType.GENERIC.value, str(e)) # type: ignore
+            task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, str(e)) # type: ignore
         finally:
             self.current_nikto_process = None # Ensure cleared
 


### PR DESCRIPTION
…tent domain handling in your code.

This addresses a TypeError that occurred in WebScanPage and NmapPage when reporting errors from a Gio.Task background thread. The issue was caused by passing the error domain as a string literal instead of a GQuark.

Here's what I changed:

1.  **WebScanPage (`src/webscan_page.py`):**
    *   I modified `_run_scan_task_thread_func` to use `GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN)` for the domain argument in all calls to `task.return_new_error_literal`.

2.  **NmapPage (`src/nmap_page.py`):**
    *   I modified `_run_nmap_scan_thread_func` to use `GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN)` for the domain argument in all calls to `task.return_new_error_literal`.

3.  **HttpPage (`src/http_page.py`):**
    *   I reviewed this page and confirmed it already correctly uses `GLib.quark_from_string` for its error domain. No changes were needed here.

This ensures that error domains are consistently and correctly passed as GQuarks, preventing runtime TypeErrors and ensuring proper error propagation from background tasks.