### PR TITLE
Fix UI feedback issues and warnings from your report.

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -4,7 +4,7 @@
   <!-- interface-name nmap_page.ui -->
   <requires lib="gtk" version="4.10"/>
   <requires lib="libadwaita" version="1.4"/>
-  <template class="NmapPage" parent="GtkBox">
+  <template class="NmapPage" parent="AdwBin">
     <property name="width-request">700</property>
     <child>
       <object class="GtkBox" id="page_vbox">

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -31,8 +31,9 @@
           </object>
         </child>
         <child>
-          <object class="AdwActionRow">
-            <property name="title">Scan Status</property>
+          <object class="AdwActionRow" id="webscan_status_action_row">
+            <property name="title">Status</property>
+            <!-- Subtitle will be set from Python code -->
             <child type="suffix">
               <object class="GtkBox">
                 <property name="orientation">horizontal</property>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -130,7 +130,7 @@ class HttpPage(Adw.PreferencesPage):
             self.http_column_view.append_column(col_name)
             self.http_column_view.append_column(col_value)
         self._connect_signals()
-        self._clear_error()
+        # self._clear_error() # Removed from __init__
         self._hide_results()
         self._update_user_agent_model()
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._update_user_agent_model())

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -56,7 +56,7 @@ class NmapTargetRow(Gtk.ListBoxRow):
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
-class NmapPage(Gtk.Box):
+class NmapPage(Adw.Bin):
     """Activity page for performing Nmap scans and viewing results."""
 
     __gtype_name__ = "NmapPage"

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -38,6 +38,7 @@ class WebScanPage(Adw.PreferencesPage):
     maxtime_entry_row = Gtk.Template.Child()
     clear_results_button = Gtk.Template.Child()
     copy_results_button = Gtk.Template.Child()
+    webscan_status_action_row = Gtk.Template.Child() # Added
     webscan_status_spinner = Gtk.Template.Child("webscan_status_spinner")
     webscan_cancel_button = Gtk.Template.Child()
 
@@ -51,9 +52,14 @@ class WebScanPage(Adw.PreferencesPage):
         # self._temp_scan_data was used previously; now using self._current_webscan_params
         logger.debug("WebScanPage initialized")
 
+        if self.webscan_status_action_row:
+            self.webscan_status_action_row.set_subtitle("Idle") # type: ignore
         if self.webscan_status_spinner:
             self.webscan_status_spinner.set_spinning(False) # type: ignore
             self.webscan_status_spinner.set_visible(False) # type: ignore
+        if self.webscan_cancel_button:
+             self.webscan_cancel_button.set_visible(False) # type: ignore
+             self.webscan_cancel_button.set_sensitive(False) # type: ignore
 
 
         if self.results_textview:
@@ -64,7 +70,7 @@ class WebScanPage(Adw.PreferencesPage):
                 if language:
                     buffer.set_language(language)
                 else:
-                    logger.warning("GtkSource language 'text' not found. Syntax highlighting may not apply.")
+                    logger.warning("GtkSource language '%s' not found. Syntax highlighting may not apply.", "text")
 
             self.results_textview.set_show_line_numbers(True)
             self.results_textview.set_monospace(True)
@@ -163,13 +169,16 @@ class WebScanPage(Adw.PreferencesPage):
         buffer = self.results_textview.get_buffer()
         buffer.set_text(f"Scanning {target_url}...\n\n")
 
-        self.scan_button.set_sensitive(False)
-
         self.scan_button.set_sensitive(False) # type: ignore
-        if hasattr(self, 'webscan_cancel_button'):
-            self.webscan_cancel_button.set_visible(True)
-            self.webscan_cancel_button.set_sensitive(True)
-        if self.webscan_status_spinner: self.webscan_status_spinner.start() # type: ignore
+
+        if self.webscan_status_action_row:
+            self.webscan_status_action_row.set_subtitle("Scanning...") # type: ignore
+        if self.webscan_status_spinner:
+            self.webscan_status_spinner.set_visible(True) # type: ignore
+            self.webscan_status_spinner.start() # type: ignore
+        if self.webscan_cancel_button:
+            self.webscan_cancel_button.set_visible(True) # type: ignore
+            self.webscan_cancel_button.set_sensitive(True) # type: ignore
 
 
         if self.current_web_scan_task and not self.current_web_scan_task.is_done():
@@ -355,6 +364,8 @@ class WebScanPage(Adw.PreferencesPage):
 
             if stdout is not None or stderr is not None: # If successful (even with stderr info)
                 self._update_textview(stdout, stderr, is_error_message=False)
+                if self.webscan_status_action_row:
+                    self.webscan_status_action_row.set_subtitle("Scan complete.") # type: ignore
 
         except GLib.Error as e:
             logger.warning(f"Nikto scan task for {target_url} failed or was cancelled: {e.message} (Domain: {e.domain}, Code: {e.code})")
@@ -379,22 +390,34 @@ class WebScanPage(Adw.PreferencesPage):
                     nikto_log_output = e.message.split(nikto_failure_prefix, 1)[-1]
                     detailed_output_for_textview = f"Error: Nikto scan failed.\n--- Output ---\n{nikto_log_output}"
                 else: # Generic error that isn't a Nikto output failure
-                    brief_user_message = f"Scan failed for {target_url}: {e.message}"
+                    brief_user_message = f"Scan failed for {target_url}: {e.message}" # type: ignore
                     detailed_output_for_textview = f"Error: {brief_user_message}"
 
+            if self.webscan_status_action_row:
+                self.webscan_status_action_row.set_subtitle(brief_user_message) # type: ignore
             show_global_error(self, brief_user_message) # type: ignore
             self._update_textview(None, detailed_output_for_textview, is_error_message=True) # Display error in textview as well
         except Exception: # Catch any other Python exceptions from this callback itself # pylint: disable=broad-except # Ensure UI updates if callback logic fails
             logger.exception(f"Unexpected Python error in _on_scan_task_done for {target_url}:")
-            user_message = "An unexpected error occurred while processing scan results."
-            show_global_error(self, user_message) # type: ignore
+            user_message = "An unexpected error occurred." # Kept brief for status row
+            if self.webscan_status_action_row:
+                self.webscan_status_action_row.set_subtitle(user_message) # type: ignore
+            show_global_error(self, user_message + " Check logs for details.") # type: ignore
             self._update_textview(None, f"Error: {user_message}", is_error_message=True)
         finally:
             self.scan_button.set_sensitive(True) # type: ignore
-            if hasattr(self, 'webscan_cancel_button'):
-                self.webscan_cancel_button.set_sensitive(False)
-                self.webscan_cancel_button.set_visible(False)
-            if self.webscan_status_spinner: self.webscan_status_spinner.stop() # type: ignore
+            if self.webscan_cancel_button:
+                self.webscan_cancel_button.set_sensitive(False) # type: ignore
+                self.webscan_cancel_button.set_visible(False) # type: ignore
+            if self.webscan_status_spinner:
+                self.webscan_status_spinner.stop() # type: ignore
+                self.webscan_status_spinner.set_visible(False) # type: ignore
+
+            # Set status to Idle or Finished if it was still "Scanning..."
+            if self.webscan_status_action_row :
+                current_subtitle = self.webscan_status_action_row.get_subtitle() # type: ignore
+                if current_subtitle == "Scanning...":
+                     self.webscan_status_action_row.set_subtitle("Scan finished.") # type: ignore
 
             self.current_web_scan_task = None
             self.current_web_scan_cancellable = None


### PR DESCRIPTION
This commit addresses several issues identified in recent feedback you provided, including scan status updates, warning messages, and UI element visibility.

Changes:

1.  **WebScanPage (`webscan_page.py`, `src/gtk/webscan_page.ui`):**
    *   Implemented comprehensive scan status updates. An `AdwActionRow`
        (id: `webscan_status_action_row`) now displays textual status
        (e.g., "Scanning...", "Scan complete", error messages) alongside
        the existing spinner.
    *   Ensured the "Cancel Scan" button (`webscan_cancel_button`) is
        now correctly made visible only during an active scan and
        hidden otherwise.

2.  **HTTPPage (`src/http_page.py`):**
    *   Removed the early call to `_clear_error()` from the `__init__`
        method. This resolves a warning (`Could not find main window or
        hide_error method`) that occurred when the method was called
        before the page was fully attached to the window hierarchy.

3.  **NmapPage (`src/nmap_page.py`, `src/gtk/nmap_page.ui`):**
    *   Changed the root element of the `NmapPage` template from `GtkBox`
        to `AdwBin`. This is intended to resolve Gtk warnings about
        a `GtkBox` not having scroll-related properties (e.g.,
        `hadjustment`), which were likely triggered during template
        initialization due to the page's structure.
    *   Verified that the `nmap_cancel_scan_button` visibility logic
        was already correctly implemented (shows only during active scans).

4.  **GtkSourceView Language Warning (`src/webscan_page.py`):**
    *   Updated the warning message in `WebScanPage` for consistency when
        the "text" GtkSourceView language definition is not found. The
        code correctly requests "text"; the warning's persistence is
        likely an environment issue (missing `.lang` files). The
        corresponding utility in `utils.py` was already updated.

These changes aim to improve UI responsiveness, reduce console warnings, and enhance the overall experience based on the feedback you provided. The SVGA "context mismatch" errors and Nikto failing with error code 1 on the specific target `http://127.0.0.1` are considered external to these application fixes.