### PR TITLE
Fix: Prevent text wrapping in DNS record display

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -226,7 +226,7 @@ class DNSPage(Adw.PreferencesPage):
         """Adds a standard suffix box (label, copy value button, copy summary button) to an ActionRow."""
         suffix_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
 
-        value_label = Gtk.Label(label=main_value_text, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
+        value_label = Gtk.Label(label=main_value_text, halign=Gtk.Align.START, selectable=True, wrap=False)
         suffix_box.append(value_label)
 
         copy_value_button = self._create_copy_button(main_value_text, f"{main_value_tooltip_prefix}: {main_value_text}", row)
@@ -258,7 +258,7 @@ class DNSPage(Adw.PreferencesPage):
         """Adds a detail row (Adw.ActionRow) to an Adw.ExpanderRow."""
         detail_row = Adw.ActionRow(title=title if title else None) # type: ignore
 
-        value_label = Gtk.Label(label=value_text, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
+        value_label = Gtk.Label(label=value_text, halign=Gtk.Align.START, selectable=True, wrap=False)
         copy_button = self._create_copy_button(value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row)
 
         content_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -637,7 +637,7 @@ class DNSPage(Adw.PreferencesPage):
 
         # MX detail row is specific
         mx_detail_row_title_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        mx_detail_row_title_box.append(Gtk.Label(label=exchange_value, halign=Gtk.Align.START, selectable=True))
+        mx_detail_row_title_box.append(Gtk.Label(label=exchange_value, halign=Gtk.Align.START, selectable=True, wrap=False))
         copy_button_exchange = self._create_copy_button(exchange_value, f"Copy Exchange: {exchange_value}", row)
         mx_detail_row_title_box.append(copy_button_exchange)
 


### PR DESCRIPTION
The DNS record values in the output widget were wrapping, making it difficult for you to read long records like CNAMEs or TXT records.

This change modifies the Gtk.Label widgets responsible for displaying DNS record data in `src/dns_page.py`. The `wrap` property has been set to `False` (and `wrap_mode` removed where it was previously set) for these labels:
- The main value label in `_add_standard_suffix_box_to_row`.
- The value label in `_add_expander_detail_row` (used for TXT record segments and SOA record fields).
- The exchange value label in `_build_mx_record_row`.

This ensures that the full record data is displayed on a single line without wrapping or truncation.

Output: