### PR TITLE
feat: Add Nikto options expander and new scan options

### DIFF
--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -61,75 +61,123 @@
             </child>
           </object>
         </child>
-        <child>
-          <object class="AdwActionRow" id="evasion_row">
-            <property name="activatable-widget">evasion_switch</property>
-            <property name="subtitle">Pass -evasion 1 to Nikto</property>
-            <property name="title">IDS Evasion (type 1)</property>
-            <child>
-              <object class="GtkSwitch" id="evasion_switch">
-                <property name="valign">center</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow" id="mutate_row">
-            <property name="activatable-widget">mutate_switch</property>
-            <property name="subtitle">Pass -mutate 1 to Nikto</property>
-            <property name="title">Mutation (type 1)</property>
-            <child>
-              <object class="GtkSwitch" id="mutate_switch">
-                <property name="valign">center</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwEntryRow" id="maxtime_entry_row">
-            <property name="input-purpose">number</property>
-            <property name="title">Max Scan Time (seconds)</property>
-          </object>
-        </child>
       </object>
     </child>
     <child>
       <object class="AdwPreferencesGroup">
         <property name="title">Scan Options</property>
         <child>
-          <object class="AdwActionRow">
-            <property name="activatable-widget">force_ssl_switch</property>
-            <property name="subtitle">Equivalent to Nikto's -ssl option</property>
-            <property name="title">Force SSL Scan</property>
+          <object class="AdwExpanderRow" id="nikto_options_expander">
+            <property name="title">Nikto Scan Options</property>
+            <property name="expanded">false</property>
             <child>
-              <object class="GtkSwitch" id="force_ssl_switch">
-                <property name="valign">center</property>
+              <object class="AdwActionRow">
+                <property name="activatable-widget">force_ssl_switch</property>
+                <property name="subtitle">Equivalent to Nikto's -ssl option</property>
+                <property name="title">Force SSL Scan</property>
+                <child>
+                  <object class="GtkSwitch" id="force_ssl_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow">
-            <property name="activatable-widget">cgi_vulns_switch</property>
-            <property name="subtitle">Nikto Tuning Option: 2 (Misconfiguration/Default File)</property>
-            <property name="title">Check CGI Vulnerabilities</property>
             <child>
-              <object class="GtkSwitch" id="cgi_vulns_switch">
-                <property name="active">true</property>
-                <property name="valign">center</property>
+              <object class="AdwActionRow">
+                <property name="activatable-widget">cgi_vulns_switch</property>
+                <property name="subtitle">Nikto Tuning Option: 2 (Misconfiguration/Default File)</property>
+                <property name="title">Check CGI Vulnerabilities</property>
+                <child>
+                  <object class="GtkSwitch" id="cgi_vulns_switch">
+                    <property name="active">true</property>
+                    <property name="valign">center</property>
+                  </object>
+                </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow">
-            <property name="activatable-widget">interesting_content_switch</property>
-            <property name="subtitle">Nikto Tuning Option: 1 (Interesting File / Seen in logs)</property>
-            <property name="title">Check Interesting Files/Directories</property>
             <child>
-              <object class="GtkSwitch" id="interesting_content_switch">
-                <property name="active">true</property>
-                <property name="valign">center</property>
+              <object class="AdwActionRow">
+                <property name="activatable-widget">interesting_content_switch</property>
+                <property name="subtitle">Nikto Tuning Option: 1 (Interesting File / Seen in logs)</property>
+                <property name="title">Check Interesting Files/Directories</property>
+                <child>
+                  <object class="GtkSwitch" id="interesting_content_switch">
+                    <property name="active">true</property>
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="evasion_row">
+                <property name="activatable-widget">evasion_switch</property>
+                <property name="subtitle">Pass -evasion 1 to Nikto</property>
+                <property name="title">IDS Evasion (type 1)</property>
+                <child>
+                  <object class="GtkSwitch" id="evasion_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="mutate_row">
+                <property name="activatable-widget">mutate_switch</property>
+                <property name="subtitle">Pass -mutate 1 to Nikto</property>
+                <property name="title">Mutation (type 1)</property>
+                <child>
+                  <object class="GtkSwitch" id="mutate_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwEntryRow" id="maxtime_entry_row">
+                <property name="input-purpose">number</property>
+                <property name="title">Max Scan Time (seconds)</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwComboRow" id="nikto_format_combo_row">
+                <property name="title">Output Format</property>
+                <property name="subtitle">Select Nikto's output format</property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item>default (text)</item>
+                      <item>txt (text)</item>
+                      <item>csv</item>
+                      <item>xml</item>
+                      <item>html</item>
+                    </items>
+                  </object>
+                </property>
+                <property name="selected">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="no404_row">
+                <property name="title">Disable 404 Checking</property>
+                <property name="subtitle">Pass -no404 to Nikto</property>
+                <property name="activatable-widget">no404_switch</property>
+                <child>
+                  <object class="GtkSwitch" id="no404_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="auth_bypass_row">
+                <property name="title">Authentication Bypass</property>
+                <property name="subtitle">Nikto Tuning Option: 9 (Authentication Bypass)</property>
+                <property name="activatable-widget">auth_bypass_switch</property>
+                <child>
+                  <object class="GtkSwitch" id="auth_bypass_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -44,6 +44,11 @@ class WebScanPage(Adw.PreferencesPage):
     webscan_status_spinner = Gtk.Template.Child("webscan_status_spinner")
     webscan_cancel_button = Gtk.Template.Child()
 
+    # New UI elements for Nikto options
+    nikto_format_combo_row = Gtk.Template.Child()
+    no404_switch = Gtk.Template.Child()
+    auth_bypass_switch = Gtk.Template.Child()
+
     def __init__(self, **kwargs):
         """Initialize the WebScanPage."""
         super().__init__(**kwargs)
@@ -189,7 +194,11 @@ class WebScanPage(Adw.PreferencesPage):
             "interesting_content": self.interesting_content_switch.get_active(), # type: ignore
             "evasion": self.evasion_switch.get_active(), # type: ignore
             "mutate": self.mutate_switch.get_active(), # type: ignore
-            "maxtime": self.maxtime_entry_row.get_text().strip() # type: ignore
+            "maxtime": self.maxtime_entry_row.get_text().strip(), # type: ignore
+            # New options for task_data_for_thread
+            "nikto_format": self.nikto_format_combo_row.get_selected_item().get_string() if self.nikto_format_combo_row.get_selected_item() else "default (text)", # type: ignore
+            "no404": self.no404_switch.get_active(), # type: ignore
+            "auth_bypass": self.auth_bypass_switch.get_active() # type: ignore
         }
         self._current_webscan_params = task_data_for_thread # Store params in instance variable
         task.run_in_thread(self._run_scan_task_thread_func) # type: ignore
@@ -220,6 +229,10 @@ class WebScanPage(Adw.PreferencesPage):
         evasion_active = scan_params.get("evasion", False)
         mutate_active = scan_params.get("mutate", False)
         maxtime_str = scan_params.get("maxtime", "")
+        # New params from scan_params
+        nikto_format_str = scan_params.get("nikto_format", "default (text)")
+        no404_active = scan_params.get("no404", False)
+        auth_bypass_active = scan_params.get("auth_bypass", False)
 
         # is_valid_url (used in on_scan_button_clicked) ensures target_url has a scheme from
         # ['http', 'https', 'ftp']. Nikto prepends 'http://' if no scheme is given,
@@ -258,6 +271,9 @@ class WebScanPage(Adw.PreferencesPage):
         tuning_options = []
         if cgi_vulns: tuning_options.append('2') # Corresponds to Nikto's "Misconfiguration / Default File"
         if interesting_content: tuning_options.append('1') # Corresponds to Nikto's "Interesting File / Seen in logs"
+        # Add new tuning options
+        if auth_bypass_active:
+            tuning_options.append('9') # '9' for Authentication Bypass
 
         # Nikto's -Tuning option takes a string of numbers (e.g., "12") to specify checks.
         # If no tuning switches are active, the -Tuning option is omitted.
@@ -266,6 +282,20 @@ class WebScanPage(Adw.PreferencesPage):
             tuning_string = "".join(sorted(list(set(tuning_options))))
             if tuning_string:
                 nikto_command.extend(['-Tuning', tuning_string])
+
+        # Add format option
+        if nikto_format_str and nikto_format_str not in ["default (text)", "txt (text)"]:
+            format_cli_value = nikto_format_str
+            if nikto_format_str == "html":
+                format_cli_value = "htm" # Nikto uses 'htm' for HTML
+            # 'csv', 'xml' are fine as is. 'txt' is default, so no need to add.
+            # Other formats like 'nbe' could be added here if UI supports them.
+            if format_cli_value not in ["txt"]: # Nikto's default is text, -Format txt is redundant
+                 nikto_command.extend(['-Format', format_cli_value])
+
+        # Add no404 option
+        if no404_active:
+            nikto_command.append('-no404')
 
         logger.debug(f"Constructed Nikto command: {nikto_command}")
 


### PR DESCRIPTION
This commit introduces an AdwExpanderRow to the Webscan page to organize Nikto scan options, improving UI clarity as more options are added.

Key changes:
- Existing Nikto options (Force SSL, CGI Vulns, Interesting Content, Evasion, Mutate, Max Scan Time) have been moved into the new "Nikto Scan Options" expander.
- Added new Nikto scan options:
    - Output Format: A combo box to select Nikto's output format (TXT, CSV, XML, HTML).
    - Disable 404 Checking: A switch to add the -no404 flag.
    - Authentication Bypass: A switch to add tuning option '9'.
- Updated `webscan_page.py` to correctly read values from these new UI elements and integrate them into the Nikto command arguments.

NOTE: I could not interactively test these changes due to persistent application launch failures in the development environment (ImportError related to _gi). I implemented the code based on the project's structure and GTK/Adwaita patterns.