### PR TITLE
fix: Correct Nikto options UI element order for Nmap consistency

### DIFF
--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -31,37 +31,6 @@
           </object>
         </child>
         <child>
-          <object class="AdwActionRow" id="webscan_status_action_row">
-            <property name="title">Status</property>
-            <!-- Subtitle will be set from Python code -->
-            <child type="suffix">
-              <object class="GtkBox">
-                <property name="orientation">horizontal</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkButton" id="webscan_cancel_button">
-                    <property name="icon-name">process-stop-symbolic</property>
-                    <property name="label" translatable="yes">Cancel Scan</property>
-                    <property name="sensitive">False</property>
-                    <property name="valign">center</property>
-                    <property name="visible">False</property>
-                    <style>
-                      <class name="destructive-action"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSpinner" id="webscan_status_spinner">
-                    <property name="spinning">False</property>
-                    <property name="valign">center</property>
-                    <property name="visible">False</property>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
           <object class="AdwExpanderRow" id="nikto_options_expander">
             <property name="title">Nikto Scan Options</property>
             <property name="expanded">false</property>
@@ -171,6 +140,37 @@
                 <child>
                   <object class="GtkSwitch" id="auth_bypass_switch">
                     <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwActionRow" id="webscan_status_action_row">
+            <property name="title">Status</property>
+            <!-- Subtitle will be set from Python code -->
+            <child type="suffix">
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkButton" id="webscan_cancel_button">
+                    <property name="icon-name">process-stop-symbolic</property>
+                    <property name="label" translatable="yes">Cancel Scan</property>
+                    <property name="sensitive">False</property>
+                    <property name="valign">center</property>
+                    <property name="visible">False</property>
+                    <style>
+                      <class name="destructive-action"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinner" id="webscan_status_spinner">
+                    <property name="spinning">False</property>
+                    <property name="valign">center</property>
+                    <property name="visible">False</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
This commit adjusts the order of elements within the 'Scan Target' group on the Webscan page. The 'Nikto Scan Options' expander is now positioned immediately after the target URL entry row, and the scan status row is positioned after the expander.

This ordering precisely matches the layout of similar elements on the Nmap page, as per your feedback.

This change only affects `src/gtk/webscan_page.ui`. The Python logic in `src/webscan_page.py` remains unchanged.

NOTE: I was unable to interactively test these changes, along with the feature introduction in previous commits, due to persistent application launch failures in the development environment (ImportError related to _gi).