### PR TITLE
Fix: Prevent window resizing smaller than widget content

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -58,6 +58,7 @@ class DNSPage(Adw.PreferencesPage):
         :type kwargs: GObject.GObject
         """
         super().__init__(**kwargs)
+        self.set_size_request(1000, -1)
         logger.debug("DNSPage initialized.")
         self._connect_signals()
         self.settings = Gio.Settings.new(APP_ID)

--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -184,10 +184,10 @@
     </property>
     <property name="default-height">1000</property>
     <property name="default-width">1000</property>
-    <property name="height-request">500</property>
+    <property name="height-request">600</property>
     <property name="overflow">hidden</property>
     <property name="title" translatable="yes">Woes</property>
-    <property name="width-request">800</property>
+    <property name="width-request">1000</property>
     <child>
       <object class="AdwBreakpoint">
         <!-- Custom object fragments -->

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -107,6 +107,7 @@ class HttpPage(Adw.PreferencesPage):
         :type kwargs: GObject.GObject
         """
         super().__init__(**kwargs)
+        self.set_size_request(800, -1)
         logger.debug("HttpPage initialized.")
         self.current_http_task: Optional[Gio.Task] = None
         self._current_header_items: List[HeaderItem] = []

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -80,6 +80,7 @@ class NmapPage(Adw.Bin):
     def __init__(self, **kwargs):
         """Initialize the NmapPage."""
         super().__init__(**kwargs)
+        self.set_size_request(700, 600)
         logger.info("Initializing NmapPage...")
         self.results_by_host = {}
         self.nmap_target_listbox_store = Gio.ListStore(item_type=NmapItem)

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -52,6 +52,7 @@ class WebScanPage(Adw.PreferencesPage):
     def __init__(self, **kwargs):
         """Initialize the WebScanPage."""
         super().__init__(**kwargs)
+        self.set_size_request(800, -1)
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
         self.current_nikto_process: Optional[subprocess.Popen] = None


### PR DESCRIPTION
Ensures that the main application window and its constituent pages cannot be resized to a dimension smaller than their content, preventing widget overlap and maintaining usability.

Modifications:
- Added explicit `set_size_request(width, height)` calls in the `__init__` method of `DNSPage`, `HttpPage`, `NmapPage`, and `WebScanPage` based on their content's minimum needs.
- Updated the `width-request` and `height-request` properties for the `WoesWindow` in `src/gtk/window.ui` to be the maximum of the minimums required by any page. This ensures the window is always large enough.