### PR TITLE
Refactor: Define page minimum sizes in .ui files

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -58,7 +58,6 @@ class DNSPage(Adw.PreferencesPage):
         :type kwargs: GObject.GObject
         """
         super().__init__(**kwargs)
-        self.set_size_request(1000, -1)
         logger.debug("DNSPage initialized.")
         self._connect_signals()
         self.settings = Gio.Settings.new(APP_ID)

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -5,6 +5,7 @@
   <requires lib="gtk" version="4.10"/>
   <requires lib="libadwaita" version="1.4"/>
   <template class="DNSPage" parent="AdwPreferencesPage">
+    <property name="width_request">1000</property>
     <property name="icon-name">org.gnome.Epiphany-symbolic</property>
     <property name="title" translatable="yes">DNS Lookup</property>
     <child>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -5,6 +5,7 @@
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>
   <template class="HttpPage" parent="AdwPreferencesPage">
+    <property name="width_request">800</property>
     <property name="icon-name">network-transmit-receive-symbolic</property>
     <property name="title" translatable="yes">HTTP Headers</property>
     <child>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -6,6 +6,7 @@
   <requires lib="libadwaita" version="1.4"/>
   <template class="NmapPage" parent="AdwBin">
     <property name="width-request">700</property>
+    <property name="height_request">600</property>
     <child>
       <object class="GtkBox" id="page_vbox">
         <property name="hexpand">true</property>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -6,6 +6,7 @@
   <requires lib="gtk" version="4.0"/>
   <requires lib="libadwaita" version="1.0"/>
   <template class="WebScanPage" parent="AdwPreferencesPage">
+    <property name="width_request">800</property>
     <property name="hexpand">True</property>
     <property name="title">Web Scan</property>
     <child>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -107,7 +107,6 @@ class HttpPage(Adw.PreferencesPage):
         :type kwargs: GObject.GObject
         """
         super().__init__(**kwargs)
-        self.set_size_request(800, -1)
         logger.debug("HttpPage initialized.")
         self.current_http_task: Optional[Gio.Task] = None
         self._current_header_items: List[HeaderItem] = []

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -80,7 +80,6 @@ class NmapPage(Adw.Bin):
     def __init__(self, **kwargs):
         """Initialize the NmapPage."""
         super().__init__(**kwargs)
-        self.set_size_request(700, 600)
         logger.info("Initializing NmapPage...")
         self.results_by_host = {}
         self.nmap_target_listbox_store = Gio.ListStore(item_type=NmapItem)

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -52,7 +52,6 @@ class WebScanPage(Adw.PreferencesPage):
     def __init__(self, **kwargs):
         """Initialize the WebScanPage."""
         super().__init__(**kwargs)
-        self.set_size_request(800, -1)
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
         self.current_nikto_process: Optional[subprocess.Popen] = None


### PR DESCRIPTION
Moves the minimum size request definitions for application pages (DNS, HTTP, Nmap, WebScan) from Python programmatic settings (`set_size_request()`) into their respective .ui files.

This change adheres to GTK best practices by making the .ui files the source of truth for static UI properties.

- Removed `set_size_request()` calls from page Python classes.
- Added/updated `<property name="width_request">` and `<property name="height_request">` in the root <template> tags of `dns_page.ui`, `http_page.ui`, `nmap_page.ui`, and `webscan_page.ui`.

The main window's (`window.ui`) minimum size requests remain as previously set, ensuring it accommodates all page minimums. This refactoring does not change the application's behavior regarding minimum window size but improves code structure.