### PR TITLE
Refactor: Move static UI initializations to .ui files

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -61,21 +61,9 @@ class DNSPage(Adw.PreferencesPage):
         logger.debug("DNSPage initialized.")
         self._connect_signals()
         self.settings = Gio.Settings.new(APP_ID)
-        if self.dns_apply_button:
-            self.dns_apply_button.set_use_underline(True)
 
         # Initialize new status row and spinner
-        if self.dns_status_row:
-            self.dns_status_row.set_subtitle("Idle") # type: ignore
-        if self.dns_status_spinner:
-            self.dns_status_spinner.set_spinning(False) # type: ignore
-            self.dns_status_spinner.set_visible(False) # type: ignore
-
         # Initially disable clear/copy buttons as there are no results
-        if self.dns_clear_results_button:
-            self.dns_clear_results_button.set_sensitive(False)
-        if self.dns_copy_all_results_button:
-            self.dns_copy_all_results_button.set_sensitive(False)
 
     def _connect_signals(self) -> None:
         """Connect signals for UI elements to their respective handlers."""

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -25,6 +25,7 @@
             <child type="suffix">
               <object class="GtkButton" id="dns_apply_button">
                 <property name="label" translatable="yes">_Lookup</property>
+                <property name="use_underline">True</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="suggested-action"/>
@@ -79,6 +80,7 @@
             <child>
               <object class="GtkButton" id="dns_clear_results_button">
                 <property name="icon-name">edit-clear-all-symbolic</property>
+                <property name="sensitive">False</property>
                 <property name="tooltip-text" translatable="yes">Clear Results</property>
                 <property name="valign">center</property>
                 <style>
@@ -89,6 +91,7 @@
             <child>
               <object class="GtkButton" id="dns_copy_all_results_button">
                 <property name="icon-name">edit-copy-symbolic</property>
+                <property name="sensitive">False</property>
                 <property name="tooltip-text" translatable="yes">Copy All Results</property>
                 <property name="valign">center</property>
                 <style>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -22,6 +22,7 @@
             <child type="suffix">
               <object class="GtkButton" id="http_apply_button">
                 <property name="label" translatable="yes">_Fetch</property>
+                <property name="use_underline">True</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="suggested-action"/>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -36,6 +36,7 @@
                 <child type="suffix">
                   <object class="GtkButton" id="nmap_apply_button">
                     <property name="label" translatable="yes">_Scan</property>
+                    <property name="use_underline">True</property>
                     <property name="valign">center</property>
                     <style>
                       <class name="suggested-action"/>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -152,7 +152,7 @@
         <child>
           <object class="AdwActionRow" id="webscan_status_action_row">
             <property name="title">Status</property>
-            <!-- Subtitle will be set from Python code -->
+            <property name="subtitle" translatable="yes">Idle</property>
             <child type="suffix">
               <object class="GtkBox">
                 <property name="orientation">horizontal</property>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -131,21 +131,12 @@ class HttpPage(Adw.PreferencesPage):
             self.http_column_view.append_column(col_name)
             self.http_column_view.append_column(col_value)
         self._connect_signals()
-        self._hide_results()
         self._update_user_agent_model()
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._update_user_agent_model())
-        if self.http_apply_button:
-            self.http_apply_button.set_use_underline(True)
         if self.http_host_header_row:
             self._on_host_header_changed(self.http_host_header_row)
         if self.http_user_agent_row:
             self._on_user_agent_changed(self.http_user_agent_row, None)
-
-        if self.http_status_row:
-            self.http_status_row.set_subtitle("Idle") # type: ignore
-        if self.http_status_spinner:
-            self.http_status_spinner.set_spinning(False) # type: ignore
-            self.http_status_spinner.set_visible(False) # type: ignore
 
         self.column_view_helper = Helper(widget=self.http_column_view, parent_window=self.get_native()) # type: ignore
 

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -92,8 +92,6 @@ class NmapPage(Adw.Bin):
 
         self._init_page_ui()
         self._connect_signals()
-        if self.nmap_apply_button:
-            self.nmap_apply_button.set_use_underline(True)
         logger.info("NmapPage initialized.")
         logger.debug("NmapPage __init__ completed.")
 
@@ -125,14 +123,10 @@ class NmapPage(Adw.Bin):
     def _init_page_ui(self):
         logger.debug("Initializing NmapPage UI components.")
         self.nmap_host_listbox.bind_model(self.nmap_target_listbox_store, self._create_target_listbox_row)
-        self.nmap_detail_placeholder.set_visible(True)
         child = self.nmap_detail_box.get_first_child()
         while child and child != self.nmap_detail_placeholder:
             self.nmap_detail_box.remove(child)
             child = self.nmap_detail_box.get_first_child()
-        self.scan_spinner.set_spinning(False)
-        self.scan_spinner.set_visible(False)
-        self.status_row.set_subtitle("Idle")
 
         logger.debug("NmapPage _init_page_ui completed.")
 

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -58,16 +58,6 @@ class WebScanPage(Adw.PreferencesPage):
         self._current_webscan_params: Optional[Dict[str, Any]] = None
         logger.debug("WebScanPage initialized")
 
-        if self.webscan_status_action_row:
-            self.webscan_status_action_row.set_subtitle("Idle") # type: ignore
-        if self.webscan_status_spinner:
-            self.webscan_status_spinner.set_spinning(False) # type: ignore
-            self.webscan_status_spinner.set_visible(False) # type: ignore
-        if self.webscan_cancel_button:
-             self.webscan_cancel_button.set_visible(False) # type: ignore
-             self.webscan_cancel_button.set_sensitive(False) # type: ignore
-
-
         if self.results_textview:
             buffer = self.results_textview.get_buffer()
             if buffer:
@@ -77,10 +67,6 @@ class WebScanPage(Adw.PreferencesPage):
                     buffer.set_language(language)
                 else:
                     logger.warning("GtkSource language '%s' not found. Syntax highlighting may not apply.", "text")
-
-            self.results_textview.set_show_line_numbers(True)
-            self.results_textview.set_monospace(True)
-            self.results_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
 
         self.url_entry.connect("entry-activated", self.on_scan_button_clicked)
         # Connect signal for the cancel button now that it's a template child


### PR DESCRIPTION
This commit refactors the initialization of several UI elements across multiple pages (DNS, HTTP, Nmap, WebScan) to ensure that static properties are defined in the .ui files rather than programmatically in Python.

Changes include:
- Removing programmatic setting of initial states such as:
    - Default subtitles for AdwActionRows (e.g., "Idle").
    - Initial visibility and spinning state for GtkSpinners.
    - Initial sensitivity and visibility for various GtkButtons (e.g., clear/copy/cancel buttons).
    - `use_underline` property for GtkButtons.
    - Initial properties for GtkSourceView (show-line-numbers, monospace, wrap-mode).
    - Initial visibility of AdwPreferencesGroups.
- Adding or verifying these properties directly in the corresponding .ui XML files for each widget.

This change makes the .ui files a more complete source of truth for the static UI design, improving maintainability and aligning with GTK best practices. The application's initial visual state and runtime dynamic behavior remain unchanged.