### PR TITLE
Fix: Ensure WebScanPage content is visible

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -162,6 +162,8 @@
                     <property name="icon-name" bind-source="webscan_page" bind-property="icon-name" bind-flags="sync-create">org.gnome.Loupe-symbolic</property>
                     <property name="title" bind-source="webscan_page" bind-property="title" bind-flags="sync-create">Web Scanner</property>
                     <property name="valign">start</property>
+                    <property name="vexpand">true</property>
+                    <property name="vexpand-set">true</property>
                   </object>
                 </property>
                 <property name="icon-name">face-cool</property>


### PR DESCRIPTION
The widgets within the WebScanPage were not being displayed. This was due to the AdwStatusPage container (`webscan_status_page`) for the WebScanPage content in `window.ui` not having the `vexpand` property set to true. Without it, the container would not expand vertically to allocate space to its children.

This commit adds `vexpand="true"` and `vexpand-set="true"` to the `webscan_status_page` AdwStatusPage in `src/gtk/window.ui`. This allows the container to properly allocate vertical space, making the WebScanPage and its internal widgets visible.