### PR TITLE
Diagnostic: Simplify WebScanPage content to test visibility

### DIFF
--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -9,6 +9,8 @@
     <property name="width_request">800</property>
     <property name="hexpand">True</property>
     <property name="title">Web Scan</property>
+    <!-- Original children commented out for diagnostic purposes -->
+    <!--
     <child>
       <object class="AdwPreferencesGroup">
         <property name="description" translatable="yes">Enter a URL to scan for common web vulnerabilities using Nikto.</property>
@@ -230,6 +232,19 @@
             </child>
           </object>
         </child>
+      </object>
+    </child>
+    -->
+    <child>
+      <object class="GtkLabel">
+        <property name="label" translatable="yes">VISIBLE TEST LABEL FOR WEBSCANPAGE</property>
+        <property name="height_request">100</property>
+        <property name="width_request">300</property> <!-- Also give it some width -->
+        <property name="visible">True</property>
+        <property name="halign">center</property> <!-- Center it for good measure -->
+        <property name="valign">center</property> <!-- Center it for good measure -->
+        <property name="hexpand">True</property> <!-- Allow expansion -->
+        <property name="vexpand">True</property> <!-- Allow expansion -->
       </object>
     </child>
   </template>


### PR DESCRIPTION
This is a temporary diagnostic commit.

To help diagnose why WebScanPage widgets are not appearing, this change temporarily modifies `src/gtk/webscan_page.ui`.

- The original two AdwPreferencesGroup children of WebScanPage have been commented out.
- A single GtkLabel with test text ("VISIBLE TEST LABEL FOR WEBSCANPAGE") and explicit size/visibility properties has been added as the sole child of WebScanPage.

This will help determine if the WebScanPage container itself can show any content when embedded in the main window. The outcome of this will guide the next steps.