### PR TITLE
Fix: Resolve WebScanPage visibility by correcting template error

### DIFF
--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -9,7 +9,7 @@
     <property name="hexpand">True</property>
     <property name="title">Web Scan</property>
     <child>
-      <object class="AdwPreferencesGroup" id="scan_target_group_widget">
+      <object class="AdwPreferencesGroup">
         <property name="description" translatable="yes">Enter a URL to scan for common web vulnerabilities using Nikto.</property>
         <property name="hexpand">True</property>
         <property name="title">Scan Target</property>
@@ -17,7 +17,6 @@
         <child>
           <object class="AdwEntryRow" id="url_entry">
             <property name="title">Target URL</property>
-            <property name="min-width-chars">30</property>
             <child type="suffix">
               <object class="GtkButton" id="scan_button">
                 <property name="halign">end</property>
@@ -182,7 +181,7 @@
       </object>
     </child>
     <child>
-      <object class="AdwPreferencesGroup" id="scan_results_group_widget">
+      <object class="AdwPreferencesGroup">
         <property name="description">Output from the web vulnerability scan will appear here.</property>
         <property name="header-suffix">
           <object class="GtkBox">

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -49,16 +49,10 @@ class WebScanPage(Adw.PreferencesPage):
     nikto_format_combo_row = Gtk.Template.Child()
     no404_switch = Gtk.Template.Child()
     auth_bypass_switch = Gtk.Template.Child()
-    scan_target_group_widget = Gtk.Template.Child()
-    scan_results_group_widget = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
         """Initialize the WebScanPage."""
         super().__init__(**kwargs)
-        logger.debug(f"WebScanPage diagnostic: self.scan_target_group_widget is {self.scan_target_group_widget}")
-        logger.debug(f"WebScanPage diagnostic: self.url_entry is {self.url_entry}") # url_entry is inside scan_target_group_widget
-        logger.debug(f"WebScanPage diagnostic: self.scan_results_group_widget is {self.scan_results_group_widget}")
-        logger.debug(f"WebScanPage diagnostic: self.results_textview is {self.results_textview}") # results_textview is inside scan_results_group_widget
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
         self.current_nikto_process: Optional[subprocess.Popen] = None


### PR DESCRIPTION
The WebScanPage widgets were not appearing due to a GtkBuilder error during template instantiation. An invalid property `min-width-chars` was specified for an `AdwEntryRow` (`id="url_entry"`) in `src/gtk/webscan_page.ui`.

This error prevented the WebScanPage's widget tree from being correctly built, leading to `Gtk.Template.Child()` bindings (e.g., `self.url_entry`) being `None` and causing subsequent `AttributeError`s when trying to access methods on these None objects.

This commit:
1. Removes the invalid `min-width-chars` property from the `AdwEntryRow` in `webscan_page.ui`.
2. Reverts temporary diagnostic code (IDs in UI, Template.Child bindings and logging in Python) that was used to identify this issue.

With the template parsing error resolved, the WebScanPage and its widgets should now initialize and display correctly.