### PR TITLE
Refactor: Standardize docstrings to reStructuredText format.

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,10 @@
-"""Global constants for the Woes application."""
+"""
+Global constants for the Woes application.
+
+This module defines various global constants used throughout the Woes application,
+including application identifiers, resource paths, theme names, version information,
+URLs, and predefined User-Agent strings.
+"""
 import os
 
 from gi.repository import Gtk

--- a/src/custom_dns_adapter.py
+++ b/src/custom_dns_adapter.py
@@ -1,4 +1,9 @@
-"""Custom HTTPAdapter for 'requests' with custom DNS resolution and SNI handling."""
+"""
+Custom HTTPAdapter for 'requests' with custom DNS resolution and SNI handling.
+
+This module provides a custom HTTPAdapter that allows for specifying a DNS server
+for hostname resolution and handles Server Name Indication (SNI) for HTTPS connections.
+"""
 
 import logging
 import socket
@@ -20,35 +25,36 @@ logger = logging.getLogger(__name__)
 
 
 class CustomDNSAdapter(HTTPAdapter):
-    """A custom HTTPAdapter for `requests` that enables custom DNS resolution and SNI handling.
+    """
+    A custom HTTPAdapter for `requests` that enables custom DNS resolution and SNI handling.
 
     This adapter intercepts requests to:
-    1.  Resolve the hostname using a specified custom DNS server if `dnspython` is available.
-        If resolution occurs, the request URL is internally modified to use the resolved IP address
-        for the connection, while the original hostname is saved for SNI and Host header purposes.
-    2.  Configure Server Name Indication (SNI) for HTTPS connections:
-        - If a hostname was resolved to an IP, the original hostname is used for SNI.
-        - If the request URL is already an IP address, a `default_sni` (typically from the
-          user's 'Host' header input) can be used for SNI.
-    3.  Set `assert_hostname` for `urllib3`'s connection pool to ensure the SSL certificate
-        is validated against the correct hostname (either the original or the specified SNI).
+    1. Resolve the hostname using a specified custom DNS server if `dnspython` is available.
+       If resolution occurs, the request URL is internally modified to use the resolved IP address
+       for the connection, while the original hostname is saved for SNI and Host header purposes.
+    2. Configure Server Name Indication (SNI) for HTTPS connections:
+       - If a hostname was resolved to an IP, the original hostname is used for SNI.
+       - If the request URL is already an IP address, a `default_sni` (typically from the
+         user's 'Host' header input) can be used for SNI.
+    3. Set `assert_hostname` for `urllib3`'s connection pool to ensure the SSL certificate
+       is validated against the correct hostname (either the original or the specified SNI).
 
     If custom DNS is not used or resolution fails, it behaves like a standard HTTPAdapter.
     """
 
     def __init__(self, *args, custom_dns_server: Optional[str] = None, default_sni: Optional[str] = None, **kwargs):
-        """Initialize the CustomDNSAdapter.
+        """
+        Initialize the CustomDNSAdapter.
 
-        Args:
-        ----
-            *args: Positional arguments to pass to the parent HTTPAdapter.
-            custom_dns_server: IP address of the custom DNS server. If None, or if `dns` (dnspython)
-                               module is unavailable, system DNS will be used.
-            default_sni: The hostname to use for SNI and certificate validation if the request URL
-                         is already an IP address. This is typically derived from the user's
-                         'Host' header input.
-            **kwargs: Keyword arguments to pass to the parent HTTPAdapter.
-
+        :param args: Positional arguments to pass to the parent HTTPAdapter.
+        :param custom_dns_server: IP address of the custom DNS server. If None, or if `dns` (dnspython)
+                                  module is unavailable, system DNS will be used.
+        :type custom_dns_server: Optional[str]
+        :param default_sni: The hostname to use for SNI and certificate validation if the request URL
+                            is already an IP address. This is typically derived from the user's
+                            'Host' header input.
+        :type default_sni: Optional[str]
+        :param kwargs: Keyword arguments to pass to the parent HTTPAdapter.
         """
         self.custom_dns_server = custom_dns_server
         self.default_sni_for_ip_url = default_sni
@@ -57,19 +63,16 @@ class CustomDNSAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def _resolve_hostname_to_ip(self, hostname: str) -> Optional[str]:
-        """Resolve a hostname using the custom DNS server.
+        """
+        Resolve a hostname using the custom DNS server.
 
         Attempts to resolve AAAA records first, then A records.
 
-        Args:
-        ----
-            hostname: The hostname to resolve.
-
-        Returns:
-        -------
-            The first resolved IP address (preferring IPv6) as a string, or None if
-            resolution fails, custom DNS is not configured, or `dnspython` is unavailable.
-
+        :param hostname: The hostname to resolve.
+        :type hostname: str
+        :return: The first resolved IP address (preferring IPv6) as a string, or None if
+                 resolution fails, custom DNS is not configured, or `dnspython` is unavailable.
+        :rtype: Optional[str]
         """
         if not self.custom_dns_server or not dns:
             logger.debug("CustomDNSAdapter: Skipping custom DNS (server: %s, dnspython available: %s) for %s.",
@@ -107,7 +110,34 @@ class CustomDNSAdapter(HTTPAdapter):
         return None
 
     def send(self, request: requests.models.PreparedRequest, stream: bool = False, timeout: Optional[float] = None, verify: bool = True, cert: Optional[Tuple[str, str] | str] = None, proxies=None):
-        """Override HTTPAdapter.send method."""
+        """
+        Send a prepared request.
+
+        This method handles the sending of a request, potentially using a custom DNS resolver
+        to modify the destination IP address and configuring SNI. It overrides the base
+        HTTPAdapter's send method.
+
+        :param request: The :class:`PreparedRequest <requests.PreparedRequest>` object to send.
+        :type request: requests.models.PreparedRequest
+        :param stream: (optional) Whether to stream the request content. Defaults to False.
+        :type stream: bool
+        :param timeout: (optional) How long to wait for the server to send data
+                        before giving up, as a float, or a :ref:`(connect timeout, read
+                        timeout) <timeouts>` tuple. Defaults to None.
+        :type timeout: Optional[float]
+        :param verify: (optional) Either a boolean, in which case it controls whether we verify
+                       the server's TLS certificate, or a string, in which case it must be a path
+                       to a CA bundle to use. Defaults to True.
+        :type verify: bool or str
+        :param cert: (optional) Any user-provided SSL certificate to be trusted.
+                     Can be a single file (containing the private key and the certificate)
+                     or a tuple of (cert file, key file) paths. Defaults to None.
+        :type cert: Optional[Tuple[str, str] | str]
+        :param proxies: (optional) The proxies dictionary to apply to the request. Defaults to None.
+        :type proxies: Optional[dict]
+        :return: The :class:`Response <requests.Response>` object.
+        :rtype: requests.Response
+        """
         parsed_url = requests.utils.urlparse(request.url)
         original_hostname = parsed_url.hostname
         self._resolved_sni = None  # Reset for each request
@@ -135,7 +165,16 @@ class CustomDNSAdapter(HTTPAdapter):
         return super().send(request, stream, timeout, verify, cert, proxies)
 
     def get_connection(self, url: str, proxies=None):
-        """Override HTTPAdapter.get_connection for custom IP resolution."""
+        """
+        Override HTTPAdapter.get_connection for custom IP resolution.
+
+        :param url: The URL to connect to.
+        :type url: str
+        :param proxies: Proxies configuration.
+        :type proxies: Optional[dict]
+        :return: The connection object.
+        :rtype: urllib3.connectionpool.HTTPConnectionPool or urllib3.connectionpool.HTTPSConnectionPool
+        """
         parsed_url = requests.utils.urlparse(url)
         original_hostname = parsed_url.hostname
 
@@ -166,7 +205,17 @@ class CustomDNSAdapter(HTTPAdapter):
             return super().get_connection(url, proxies=proxies)
 
     def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs):
-        """Initialize the `urllib3.PoolManager` with SNI and certificate validation settings."""
+        """
+        Initialize the `urllib3.PoolManager` with SNI and certificate validation settings.
+
+        :param connections: The number of `urllib3` connection pools to cache.
+        :type connections: int
+        :param maxsize: The maximum number of connections to save in the pool.
+        :type maxsize: int
+        :param block: Whether the connection pool should block for connections.
+        :type block: bool
+        :param pool_kwargs: Extra keyword arguments used to initialize the PoolManager.
+        """
         sni_hostname_for_pool = None
         if self._resolved_sni:
             sni_hostname_for_pool = self._resolved_sni

--- a/src/dns_client.py
+++ b/src/dns_client.py
@@ -48,7 +48,7 @@ class DnsResolverClient:
         """Initialize DnsResolverClient.
 
         :param custom_dns_server: Optional IP address of a custom DNS server.
-        :type custom_dns_server: str, optional
+        :type custom_dns_server: Optional[str]
         """
         self.resolver = dns.resolver.Resolver()
         if custom_dns_server:

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -76,7 +76,11 @@ class DNSPage(Adw.PreferencesPage):
             self.dns_copy_all_results_button.connect("clicked", self._on_copy_all_results_clicked)
 
     def _on_clear_results_clicked(self, _button: Gtk.Button) -> None:
-        """Clear all DNS lookup results from the UI."""
+        """Clear all DNS lookup results from the UI.
+
+        :param _button: The Gtk.Button that was clicked (unused).
+        :type _button: Gtk.Button
+        """
         logger.info("Clearing DNS results.")
         while (child := self.dns_results_box_container.get_first_child()): # type: ignore
             self.dns_results_box_container.remove(child) # type: ignore
@@ -87,7 +91,11 @@ class DNSPage(Adw.PreferencesPage):
             self.dns_copy_all_results_button.set_sensitive(False)
 
     def _on_copy_all_results_clicked(self, _button: Gtk.Button) -> None:
-        """Copy all displayed DNS results to the clipboard."""
+        """Copy all displayed DNS results to the clipboard.
+
+        :param _button: The Gtk.Button that was clicked (unused).
+        :type _button: Gtk.Button
+        """
         logger.info("Copying all DNS results to clipboard.")
         all_results_text = []
 
@@ -189,7 +197,17 @@ class DNSPage(Adw.PreferencesPage):
     # --- Helper methods for building record rows ---
 
     def _create_copy_button(self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget) -> Gtk.Button:
-        """Creates a Gtk.Button for copying text."""
+        """Creates a Gtk.Button for copying text.
+
+        :param text_to_copy: The text to be copied when the button is clicked.
+        :type text_to_copy: str
+        :param tooltip_text: The tooltip text for the button.
+        :type tooltip_text: str
+        :param widget_for_clipboard: The widget from which to get the clipboard.
+        :type widget_for_clipboard: Gtk.Widget
+        :return: A new Gtk.Button configured for copying.
+        :rtype: Gtk.Button
+        """
         button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         button.set_valign(Gtk.Align.CENTER)
         button.set_tooltip_text(tooltip_text)
@@ -197,7 +215,19 @@ class DNSPage(Adw.PreferencesPage):
         return button
 
     def _create_base_action_row(self, name: str, record_type_label: str, base_subtitle_text: str, icon_name: Optional[str]) -> Adw.ActionRow:
-        """Creates a basic Adw.ActionRow with title, subtitle, and optional icon."""
+        """Creates a basic Adw.ActionRow with title, subtitle, and optional icon.
+
+        :param name: The title for the ActionRow, typically the record name.
+        :type name: str
+        :param record_type_label: The string representation of the record type (e.g., "A", "MX").
+        :type record_type_label: str
+        :param base_subtitle_text: Base text for the subtitle (e.g., class and TTL info).
+        :type base_subtitle_text: str
+        :param icon_name: Optional icon name for the prefix of the row.
+        :type icon_name: Optional[str]
+        :return: A new Adw.ActionRow.
+        :rtype: Adw.ActionRow
+        """
         row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type_label}, {base_subtitle_text}") # type: ignore
         if icon_name:
             row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
@@ -211,7 +241,17 @@ class DNSPage(Adw.PreferencesPage):
         main_value_tooltip_prefix: str,
         full_summary_text: str
     ) -> None:
-        """Adds a standard suffix box (label, copy value button, copy summary button) to an ActionRow."""
+        """Adds a standard suffix box (label, copy value button, copy summary button) to an ActionRow.
+
+        :param row: The Adw.ActionRow to add suffixes to.
+        :type row: Adw.ActionRow
+        :param main_value_text: The main value to display as a label and for the value copy button.
+        :type main_value_text: str
+        :param main_value_tooltip_prefix: The prefix for the tooltip of the value copy button.
+        :type main_value_tooltip_prefix: str
+        :param full_summary_text: The full summary text for the summary copy button.
+        :type full_summary_text: str
+        """
         value_label = Gtk.Label(label=main_value_text, halign=Gtk.Align.FILL, hexpand=True, selectable=True, wrap=False, lines=1, ellipsize=Pango.EllipsizeMode.END)
         # suffix_box removed
         row.add_suffix(value_label) # type: ignore
@@ -219,7 +259,19 @@ class DNSPage(Adw.PreferencesPage):
         row.add_suffix(self._create_copy_button(full_summary_text, "Copy Full Record Summary", row)) # type: ignore
 
     def _create_base_expander_row(self, name: str, subtitle_text: str, icon_name: Optional[str], full_summary_text: str) -> Adw.ExpanderRow:
-        """Creates a basic Adw.ExpanderRow with title, subtitle, icon, and a full summary copy button."""
+        """Creates a basic Adw.ExpanderRow with title, subtitle, icon, and a full summary copy button.
+
+        :param name: The title for the ExpanderRow.
+        :type name: str
+        :param subtitle_text: The subtitle for the ExpanderRow.
+        :type subtitle_text: str
+        :param icon_name: Optional icon name for the prefix of the row.
+        :type icon_name: Optional[str]
+        :param full_summary_text: The full summary text for the summary copy button.
+        :type full_summary_text: str
+        :return: A new Adw.ExpanderRow.
+        :rtype: Adw.ExpanderRow
+        """
         row = Adw.ExpanderRow(title=name, subtitle=subtitle_text) # type: ignore
         if icon_name:
             row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
@@ -236,7 +288,20 @@ class DNSPage(Adw.PreferencesPage):
             copy_tooltip_prefix: str,
             is_value_primary_content: bool = False
         ):
-        """Adds a detail row (Adw.ActionRow) to an Adw.ExpanderRow."""
+        """Adds a detail row (Adw.ActionRow) to an Adw.ExpanderRow.
+
+        :param expander_row: The Adw.ExpanderRow to add the detail row to.
+        :type expander_row: Adw.ExpanderRow
+        :param title: Optional title for the detail ActionRow.
+        :type title: Optional[str]
+        :param value_text: The value text to display in the detail row.
+        :type value_text: str
+        :param copy_tooltip_prefix: The prefix for the tooltip of the copy button for the value.
+        :type copy_tooltip_prefix: str
+        :param is_value_primary_content: If True, value_text is the primary content (e.g., TXT segments).
+                                         Otherwise, it's a suffix to the title (e.g., SOA fields).
+        :type is_value_primary_content: bool
+        """
         detail_row = Adw.ActionRow(title=title if title else None) # type: ignore
 
         value_label = Gtk.Label(label=value_text, halign=Gtk.Align.FILL, hexpand=True, selectable=True, wrap=False, lines=1, ellipsize=Pango.EllipsizeMode.END)
@@ -254,7 +319,13 @@ class DNSPage(Adw.PreferencesPage):
         expander_row.add_row(detail_row) # type: ignore
 
     def _set_loading_state(self, active: bool, message: Optional[str] = None) -> None:
-        """Sets the UI loading state (spinner, status message, sensitivity)."""
+        """Sets the UI loading state (spinner, status message, sensitivity).
+
+        :param active: True to set loading state, False to unset.
+        :type active: bool
+        :param message: Optional message to display in the status row.
+        :type message: Optional[str]
+        """
         if self.dns_status_spinner:
             self.dns_status_spinner.set_visible(active) # type: ignore
             if active:
@@ -281,7 +352,11 @@ class DNSPage(Adw.PreferencesPage):
 
     def _validate_dns_input(self, user_input: str) -> bool:
         """Validates the DNS user input. Shows global error/toast if invalid.
+
+        :param user_input: The user input string to validate.
+        :type user_input: str
         :return: True if valid, False otherwise.
+        :rtype: bool
         """
         if not user_input:
             show_global_toast(self, "Input cannot be empty.") # type: ignore
@@ -301,6 +376,13 @@ class DNSPage(Adw.PreferencesPage):
     def _update_ptr_dropdown(self, user_input: str, requested_record_type: str) -> str:
         """Updates the record type dropdown to PTR if an IP was entered and PTR was requested.
         Returns the record type that was effectively used or set.
+
+        :param user_input: The user input string (domain or IP).
+        :type user_input: str
+        :param requested_record_type: The record type initially requested by the user.
+        :type requested_record_type: str
+        :return: The record type string that is effectively used or set in the UI.
+        :rtype: str
         """
         actual_record_type_used = requested_record_type
         if is_valid_ip(user_input) and requested_record_type.upper() == "PTR":
@@ -320,7 +402,17 @@ class DNSPage(Adw.PreferencesPage):
         requested_record_type: str, # The type initially selected by user
         dns_client: DnsResolverClient
     ) -> None:
-        """Handles successful DNS lookup results."""
+        """Handles successful DNS lookup results.
+
+        :param result_data: The list of DNS records obtained from the lookup.
+        :type result_data: List[Dict[str, Any]]
+        :param user_input: The domain or IP address that was queried.
+        :type user_input: str
+        :param requested_record_type: The DNS record type that was requested.
+        :type requested_record_type: str
+        :param dns_client: The DnsResolverClient instance used for the lookup.
+        :type dns_client: DnsResolverClient
+        """
         # Determine the actual type used, especially if PTR was auto-selected for an IP.
         # DnsResolverClient internally handles reverse name for PTR if domain_or_ip is an IP.
         # So, if user selected PTR for an IP, requested_record_type is already "PTR".
@@ -346,7 +438,17 @@ class DNSPage(Adw.PreferencesPage):
         requested_record_type: str,
         dns_client: DnsResolverClient # Pass client to get nameservers for NoAnswer
     ) -> None:
-        """Handles exceptions from DnsResolverClient."""
+        """Handles exceptions from DnsResolverClient.
+
+        :param error: The exception object that was raised.
+        :type error: Exception
+        :param user_input: The domain or IP address that was queried.
+        :type user_input: str
+        :param requested_record_type: The DNS record type that was requested.
+        :type requested_record_type: str
+        :param dns_client: The DnsResolverClient instance used for the lookup.
+        :type dns_client: DnsResolverClient
+        """
         error_message = str(error) # Original full error message
         status_subtitle = f"Error: {error_message.splitlines()[0]}" # Default status: first line of error
 
@@ -504,7 +606,17 @@ class DNSPage(Adw.PreferencesPage):
     # --- Helper methods for building record rows ---
 
     def _create_copy_button(self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget) -> Gtk.Button:
-        """Creates a Gtk.Button for copying text."""
+        """Creates a Gtk.Button for copying text.
+
+        :param text_to_copy: The text to be copied when the button is clicked.
+        :type text_to_copy: str
+        :param tooltip_text: The tooltip text for the button.
+        :type tooltip_text: str
+        :param widget_for_clipboard: The widget from which to get the clipboard.
+        :type widget_for_clipboard: Gtk.Widget
+        :return: A new Gtk.Button configured for copying.
+        :rtype: Gtk.Button
+        """
         button = Gtk.Button.new_from_icon_name("content-copy-symbolic")
         button.set_valign(Gtk.Align.CENTER)
         button.set_tooltip_text(tooltip_text)
@@ -512,7 +624,19 @@ class DNSPage(Adw.PreferencesPage):
         return button
 
     def _create_base_action_row(self, name: str, record_type_label: str, base_subtitle_text: str, icon_name: Optional[str]) -> Adw.ActionRow:
-        """Creates a basic Adw.ActionRow with title, subtitle, and optional icon."""
+        """Creates a basic Adw.ActionRow with title, subtitle, and optional icon.
+
+        :param name: The title for the ActionRow, typically the record name.
+        :type name: str
+        :param record_type_label: The string representation of the record type (e.g., "A", "MX").
+        :type record_type_label: str
+        :param base_subtitle_text: Base text for the subtitle (e.g., class and TTL info).
+        :type base_subtitle_text: str
+        :param icon_name: Optional icon name for the prefix of the row.
+        :type icon_name: Optional[str]
+        :return: A new Adw.ActionRow.
+        :rtype: Adw.ActionRow
+        """
         row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type_label}, {base_subtitle_text}") # type: ignore
         if icon_name:
             row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
@@ -526,7 +650,17 @@ class DNSPage(Adw.PreferencesPage):
         main_value_tooltip_prefix: str,
         full_summary_text: str
     ) -> None:
-        """Adds a standard suffix box (label, copy value button, copy summary button) to an ActionRow."""
+        """Adds a standard suffix box (label, copy value button, copy summary button) to an ActionRow.
+
+        :param row: The Adw.ActionRow to add suffixes to.
+        :type row: Adw.ActionRow
+        :param main_value_text: The main value to display as a label and for the value copy button.
+        :type main_value_text: str
+        :param main_value_tooltip_prefix: The prefix for the tooltip of the value copy button.
+        :type main_value_tooltip_prefix: str
+        :param full_summary_text: The full summary text for the summary copy button.
+        :type full_summary_text: str
+        """
         value_label = Gtk.Label(label=main_value_text, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)
         # suffix_box is removed. Widgets will be added directly to the row.
 
@@ -538,7 +672,19 @@ class DNSPage(Adw.PreferencesPage):
         row.add_suffix(copy_full_summary_button) # type: ignore
 
     def _create_base_expander_row(self, name: str, subtitle_text: str, icon_name: Optional[str], full_summary_text: str) -> Adw.ExpanderRow:
-        """Creates a basic Adw.ExpanderRow with title, subtitle, icon, and a full summary copy button."""
+        """Creates a basic Adw.ExpanderRow with title, subtitle, icon, and a full summary copy button.
+
+        :param name: The title for the ExpanderRow.
+        :type name: str
+        :param subtitle_text: The subtitle for the ExpanderRow.
+        :type subtitle_text: str
+        :param icon_name: Optional icon name for the prefix of the row.
+        :type icon_name: Optional[str]
+        :param full_summary_text: The full summary text for the summary copy button.
+        :type full_summary_text: str
+        :return: A new Adw.ExpanderRow.
+        :rtype: Adw.ExpanderRow
+        """
         row = Adw.ExpanderRow(title=name, subtitle=subtitle_text) # type: ignore
         if icon_name:
             row.add_prefix(Gtk.Image(icon_name=icon_name)) # type: ignore
@@ -556,7 +702,20 @@ class DNSPage(Adw.PreferencesPage):
             copy_tooltip_prefix: str,
             is_value_primary_content: bool = False
         ):
-        """Adds a detail row (Adw.ActionRow) to an Adw.ExpanderRow."""
+        """Adds a detail row (Adw.ActionRow) to an Adw.ExpanderRow.
+
+        :param expander_row: The Adw.ExpanderRow to add the detail row to.
+        :type expander_row: Adw.ExpanderRow
+        :param title: Optional title for the detail ActionRow.
+        :type title: Optional[str]
+        :param value_text: The value text to display in the detail row.
+        :type value_text: str
+        :param copy_tooltip_prefix: The prefix for the tooltip of the copy button for the value.
+        :type copy_tooltip_prefix: str
+        :param is_value_primary_content: If True, value_text is the primary content (e.g., TXT segments).
+                                         Otherwise, it's a suffix to the title (e.g., SOA fields).
+        :type is_value_primary_content: bool
+        """
         detail_row = Adw.ActionRow(title=title if title else None) # type: ignore
 
         value_label = Gtk.Label(label=value_text, halign=Gtk.Align.START, selectable=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR)

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -522,7 +522,13 @@ class HttpPage(Adw.PreferencesPage):
                     self._set_loading_state(False, "Idle - operation ended.")
 
     def _set_loading_state(self, active: bool, message: str = "Idle") -> None:
-        """Sets the UI loading state (spinner, status message, sensitivity of input fields)."""
+        """Sets the UI loading state (spinner, status message, sensitivity of input fields).
+
+        :param active: True to set loading state, False to unset.
+        :type active: bool
+        :param message: Optional message to display in the status row. Defaults to "Idle".
+        :type message: str
+        """
         if self.http_status_spinner:
             self.http_status_spinner.set_visible(active) # type: ignore
             if active:

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -36,7 +36,13 @@ class NmapItem(GObject.Object):
     value = GObject.Property(type=str)
 
     def __init__(self, key: str, value: str):
-        """Initialize an NmapItem."""
+        """Initialize an NmapItem.
+
+        :param key: The key string.
+        :type key: str
+        :param value: The value string.
+        :type value: str
+        """
         super().__init__()
         self.key = key
         self.value = value
@@ -48,7 +54,11 @@ class NmapTargetRow(Gtk.ListBoxRow):
     nmap_item = GObject.Property(type=NmapItem)
 
     def __init__(self, nmap_item: NmapItem, **kwargs):
-        """Initialize an NmapTargetRow."""
+        """Initialize an NmapTargetRow.
+
+        :param nmap_item: The NmapItem to display.
+        :type nmap_item: NmapItem
+        """
         super().__init__(**kwargs)
         self.nmap_item = nmap_item
         label = Gtk.Label(label=nmap_item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
@@ -78,7 +88,11 @@ class NmapPage(Adw.Bin):
     nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
 
     def __init__(self, **kwargs):
-        """Initialize the NmapPage."""
+        """Initialize the NmapPage.
+
+        :param kwargs: Keyword arguments passed to the :class:`Adw.Bin` constructor.
+        :type kwargs: Any
+        """
         super().__init__(**kwargs)
         logger.info("Initializing NmapPage...")
         self.results_by_host = {}
@@ -109,8 +123,14 @@ class NmapPage(Adw.Bin):
 
     def _on_nmap_source_style_settings_changed(self, _source: GObject.Object, _pspec: GObject.ParamSpec):
         """Handle theme or style scheme changes for Nmap's GtkSourceView.
+
         Currently, this method primarily logs the change. Style application
         is handled at view creation time in _add_raw_output_expander.
+
+        :param _source: The GObject source of the signal.
+        :type _source: GObject.Object
+        :param _pspec: The GObject.ParamSpec of the property that changed.
+        :type _pspec: GObject.ParamSpec
         """
         logger.info("NmapPage: Dark theme or source style scheme changed. New views will use updated style.")
         # If we were to update existing views, we'd iterate them here and call
@@ -119,6 +139,9 @@ class NmapPage(Adw.Bin):
     def _apply_source_view_style_to_buffer(self, buffer: GtkSource.Buffer):
         """Apply the appropriate GtkSourceView style scheme to a given buffer,
         considering the current theme (dark/light) and user settings.
+
+        :param buffer: The GtkSource.Buffer to apply the style to.
+        :type buffer: GtkSource.Buffer
         """
         is_dark = self.style_manager.get_dark()
         user_scheme_name = self.settings.get_string("source-style-scheme")
@@ -189,7 +212,11 @@ class NmapPage(Adw.Bin):
             self.nmap_cancel_scan_button.connect("clicked", self._on_cancel_scan_clicked)
 
     def _on_cancel_scan_clicked(self, _button: Gtk.Button) -> None:
-        """Handle the 'Cancel Scan' button click."""
+        """Handle the 'Cancel Scan' button click.
+
+        :param _button: The Gtk.Button that was clicked (unused).
+        :type _button: Gtk.Button
+        """
         logger.info("Cancel scan button clicked.")
         if self.current_nmap_cancellable and not self.current_nmap_cancellable.is_cancelled():
             self.current_nmap_cancellable.cancel()
@@ -264,7 +291,17 @@ class NmapPage(Adw.Bin):
         _task_data: Optional[Dict[str, Any]], # pylint: disable=unused-argument # This arg from run_in_thread is not used
         cancellable: Optional[Gio.Cancellable]
     ):
-        """Execute the Nmap scan in a separate thread via NmapScanner, for Gio.Task."""
+        """Execute the Nmap scan in a separate thread via NmapScanner, for Gio.Task.
+
+        :param task: The Gio.Task associated with this operation.
+        :type task: Gio.Task
+        :param _source_object: The GObject source of the task.
+        :type _source_object: GObject.Object
+        :param _task_data: Additional data passed to the task (unused).
+        :type _task_data: Optional[Dict[str, Any]]
+        :param cancellable: A Gio.Cancellable object to monitor for cancellation.
+        :type cancellable: Optional[Gio.Cancellable]
+        """
         page_instance: NmapPage = _source_object # type: ignore
         params = page_instance._current_nmap_scan_params
 
@@ -302,7 +339,15 @@ class NmapPage(Adw.Bin):
             # UI sensitivity updates are handled in _nmap_scan_task_done_cb
 
     def _nmap_scan_task_done_cb(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Optional[Any]): # type: ignore # pylint: disable=unused-argument
-        """Callback for when the Nmap scan Gio.Task completes."""
+        """Callback for when the Nmap scan Gio.Task completes.
+
+        :param _source_object: The GObject source of the task.
+        :type _source_object: GObject.Object
+        :param result: The Gio.AsyncResult from the completed task.
+        :type result: Gio.AsyncResult
+        :param _user_data: User data passed with the callback (unused).
+        :type _user_data: Optional[Any]
+        """
         original_target = self._current_nmap_scan_params["target"] if self._current_nmap_scan_params else "unknown target"
 
         logger.info(f"Nmap scan task done for {original_target}.")
@@ -353,7 +398,13 @@ class NmapPage(Adw.Bin):
 
 
     def _process_scan_results(self, nm: nmap.PortScanner, original_target: str):
-        """Process the Nmap scan results received from the scanner task."""
+        """Process the Nmap scan results received from the scanner task.
+
+        :param nm: The nmap.PortScanner object containing the scan results.
+        :type nm: nmap.PortScanner
+        :param original_target: The original target string for the scan.
+        :type original_target: str
+        """
         logger.debug("Processing Nmap scan results for target: %s", original_target)
         hosts_found = nm.all_hosts()
         logger.debug("Hosts found by Nmap: %s", hosts_found)
@@ -383,13 +434,25 @@ class NmapPage(Adw.Bin):
         )
 
     def _handle_scan_error(self, target: str, error_message: str):
-        """Handle errors reported from the Nmap scan task."""
+        """Handle errors reported from the Nmap scan task.
+
+        :param target: The target string for which the scan failed.
+        :type target: str
+        :param error_message: The error message to display.
+        :type error_message: str
+        """
         logger.debug("Handling Nmap scan error for target %s: %s", target, error_message)
         show_global_error(self, f"Error scanning {target}: {error_message}")
         self._set_scan_status(ScanStatus.FAILED, f"Scan failed for {target}")
 
     def _on_target_selected(self, _listbox: Gtk.ListBox, row: Optional[Gtk.ListBoxRow]):
-        """Handle selection of a host in the Nmap results ListBox."""
+        """Handle selection of a host in the Nmap results ListBox.
+
+        :param _listbox: The Gtk.ListBox that emitted the signal.
+        :type _listbox: Gtk.ListBox
+        :param row: The selected Gtk.ListBoxRow, or None if deselected.
+        :type row: Optional[Gtk.ListBoxRow]
+        """
         self._clear_dynamic_details()
         if row is None:
             self.nmap_detail_placeholder.set_title("No Host Selected")
@@ -444,7 +507,13 @@ class NmapPage(Adw.Bin):
             self.nmap_detail_placeholder.set_visible(True)
 
     def _add_raw_output_expander(self, host_data_dict: Dict[str, Any], host_key: str):
-        """Add an Adw.ExpanderRow to display the human-readable text summary for a host."""
+        """Add an Adw.ExpanderRow to display the human-readable text summary for a host.
+
+        :param host_data_dict: The dictionary containing data for the host.
+        :type host_data_dict: Dict[str, Any]
+        :param host_key: The identifier for the host (e.g., IP address).
+        :type host_key: str
+        """
         logger.debug("Adding text scan summary expander for %s", host_key)
         expander = Adw.ExpanderRow(title=f"Text Scan Summary - {host_key}")
         expander.set_expanded(False)
@@ -472,7 +541,11 @@ class NmapPage(Adw.Bin):
         self.nmap_detail_box.append(expander)
 
     def _on_copy_host_summary_clicked(self, summary_text: str):
-        """Handles the click of the 'Copy Host Summary' button."""
+        """Handles the click of the 'Copy Host Summary' button.
+
+        :param summary_text: The summary text to copy to the clipboard.
+        :type summary_text: str
+        """
         logger.info("Copying Nmap host summary to clipboard.")
         if not summary_text:
             show_global_toast(self, "No summary text available to copy.") # type: ignore
@@ -493,7 +566,13 @@ class NmapPage(Adw.Bin):
 
 
     def _add_host_details_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
-        """Add an Adw.ExpanderRow to display general host information."""
+        """Add an Adw.ExpanderRow to display general host information.
+
+        :param host_data: The dictionary containing data for the host.
+        :type host_data: Dict[str, Any]
+        :param host_key: The identifier for the host (e.g., IP address).
+        :type host_key: str
+        """
         logger.debug("Adding host details expander for %s", host_key)
         expander = Adw.ExpanderRow(title=f"Host Information - {host_key}")
         expander.set_expanded(True)
@@ -519,7 +598,13 @@ class NmapPage(Adw.Bin):
         self.nmap_detail_box.append(expander)
 
     def _add_ports_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
-        """Add an Adw.ExpanderRow to display detected network ports and their details."""
+        """Add an Adw.ExpanderRow to display detected network ports and their details.
+
+        :param host_data: The dictionary containing data for the host.
+        :type host_data: Dict[str, Any]
+        :param host_key: The identifier for the host (e.g., IP address).
+        :type host_key: str
+        """
         logger.debug("Adding ports expander for %s", host_key)
         expander = Adw.ExpanderRow(title=f"Network Ports - {host_key}")
         expander.set_expanded(True)
@@ -547,7 +632,13 @@ class NmapPage(Adw.Bin):
         self.nmap_detail_box.append(expander)
 
     def _add_os_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
-        """Add an Adw.ExpanderRow to display OS detection results."""
+        """Add an Adw.ExpanderRow to display OS detection results.
+
+        :param host_data: The dictionary containing data for the host.
+        :type host_data: Dict[str, Any]
+        :param host_key: The identifier for the host (e.g., IP address).
+        :type host_key: str
+        """
         osmatch_data = host_data.get("osmatch", [])
         if not osmatch_data:
             logger.debug("No OS data for host %s, skipping OS expander.", host_key)
@@ -586,7 +677,13 @@ class NmapPage(Adw.Bin):
         self.nmap_detail_box.append(expander)
 
     def _update_results_view(self, hosts: List[str], results_map: Dict[str, str]):
-        """Update the host ListBox with new scan results."""
+        """Update the host ListBox with new scan results.
+
+        :param hosts: A list of host identifiers (e.g., IP addresses).
+        :type hosts: List[str]
+        :param results_map: A dictionary mapping host identifiers to their YAML scan data.
+        :type results_map: Dict[str, str]
+        """
         logger.info("Updating Nmap results view for hosts: %s", hosts)
         self.nmap_target_listbox_store.remove_all()
         self.results_by_host.clear()
@@ -614,12 +711,24 @@ class NmapPage(Adw.Bin):
             self.nmap_detail_placeholder.set_visible(True)
 
     def _set_scan_status(self, status_type: ScanStatus, message: str): # type: ignore
-        """Set the scan status and update the UI via GLib.idle_add."""
+        """Set the scan status and update the UI via GLib.idle_add.
+
+        :param status_type: The ScanStatus enum member representing the current status.
+        :type status_type: ScanStatus
+        :param message: The message to display in the status row.
+        :type message: str
+        """
         logger.info("Setting Nmap scan status: %s - %s", status_type.name, message)
         GLib.idle_add(self._update_status_ui, status_type, message)
 
     def _update_status_ui(self, status_type: ScanStatus, message: str):
-        """Update the status row and spinner in the UI."""
+        """Update the status row and spinner in the UI.
+
+        :param status_type: The ScanStatus enum member.
+        :type status_type: ScanStatus
+        :param message: The message to display.
+        :type message: str
+        """
         self.status_row.set_subtitle(message)
         status_css_classes = ["success-color", "warning-color", "error-color", "accent-color"]
         style_context = self.status_row.get_style_context()
@@ -688,11 +797,23 @@ class NmapPage(Adw.Bin):
             logger.warning("Could not find main window or hide_error method to clear error.")
 
     def _create_target_listbox_row(self, item: NmapItem) -> Gtk.ListBoxRow:
-        """Create an NmapTargetRow for the host ListBox."""
+        """Create an NmapTargetRow for the host ListBox.
+
+        :param item: The NmapItem to create a row for.
+        :type item: NmapItem
+        :return: A new NmapTargetRow.
+        :rtype: NmapTargetRow
+        """
         return NmapTargetRow(nmap_item=item)
 
     def _generate_human_readable_host_summary(self, host_data_dict: dict) -> str:
-        """Generate a human-readable summary of host scan data."""
+        """Generate a human-readable summary of host scan data.
+
+        :param host_data_dict: A dictionary containing the scan data for a host.
+        :type host_data_dict: dict
+        :return: A string containing the human-readable summary.
+        :rtype: str
+        """
         summary_lines = []
         status_info = host_data_dict.get("status", {})
         state = status_info.get("state", "N/A")

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -1,4 +1,5 @@
-"""Provides the NmapScanner class and related utilities for performing Nmap scans.
+"""
+Provides the NmapScanner class and related utilities for performing Nmap scans.
 
 This module includes functionality for building Nmap commands, handling
 privilege escalation, executing scans, and processing results.
@@ -31,8 +32,9 @@ from .utils import is_valid_ip, is_valid_domain
 
 
 class ScanOptions(Enum):
-    """Enumeration of common Nmap command-line option fragments."""
-
+    """
+    Enumeration of common Nmap command-line option fragments.
+    """
     DEFAULT = "-T4"
     OS_FINGERPRINTING = "-O -A"
     ALL_PORTS = "-p-"
@@ -40,23 +42,43 @@ class ScanOptions(Enum):
 
 
 class ScanStatus(Enum):
-    """Enumeration representing the status of an Nmap scan."""
-
+    """
+    Enumeration representing the status of an Nmap scan.
+    """
     IN_PROGRESS = (0.0, "Scanning {target}...")
     COMPLETE = (1.0, "Scan complete")
     FAILED = (1.0, "Scan failed unexpectedly")
     IDLE = (0.0, "Idle")
 
 
-class ScanCancelledError(PortScannerError): # Inherit from PortScannerError for consistency if desired
-    """Exception raised when an Nmap scan is cancelled."""
-
+class ScanCancelledError(PortScannerError):
+    """
+    Exception raised when an Nmap scan is cancelled.
+    """
     pass
 
 
 class NmapScanParameters(TypedDict, total=False):
-    """TypedDict for Nmap scan parameters."""
+    """
+    TypedDict for Nmap scan parameters.
 
+    :param target: The target for the Nmap scan.
+    :type target: str
+    :param os_fingerprinting: Whether to enable OS fingerprinting.
+    :type os_fingerprinting: bool
+    :param scan_all_ports: Whether to scan all ports.
+    :type scan_all_ports: bool
+    :param selected_script: The Nmap script to use.
+    :type selected_script: Optional[str]
+    :param service_version: Whether to detect service versions.
+    :type service_version: bool
+    :param no_ping: Whether to disable host discovery ping.
+    :type no_ping: bool
+    :param timing_template: The timing template to use (e.g., "T3", "T4").
+    :type timing_template: str
+    :param custom_dns_server: Custom DNS server to use for the scan.
+    :type custom_dns_server: Optional[str]
+    """
     target: str
     os_fingerprinting: bool
     scan_all_ports: bool
@@ -68,7 +90,14 @@ class NmapScanParameters(TypedDict, total=False):
 
 
 def _is_scan_root_required(nmap_args_list: List[str]) -> bool:
-    """Check if the given Nmap arguments require root privileges."""
+    """
+    Check if the given Nmap arguments require root privileges.
+
+    :param nmap_args_list: A list of Nmap command arguments.
+    :type nmap_args_list: List[str]
+    :return: True if root privileges are required, False otherwise.
+    :rtype: bool
+    """
     logger.debug("Checking if root is required for args: %s", nmap_args_list)
     # Common options requiring root: -sS (TCP SYN scan), -O (OS detection), -A (Aggressive scan)
     root_options = ["-sS", "-O", "-A"]
@@ -78,7 +107,16 @@ def _is_scan_root_required(nmap_args_list: List[str]) -> bool:
 
 
 def get_escalated_command(command_parts: List[str]) -> List[str]:
-    """Construct a command list for privilege escalation based on the OS."""
+    """
+    Construct a command list for privilege escalation based on the OS.
+
+    :param command_parts: The command parts to escalate.
+    :type command_parts: List[str]
+    :raises FileNotFoundError: If nmap or a required escalation tool (pkexec, osascript) is not found.
+    :raises NotImplementedError: If privilege escalation is not supported on the current platform.
+    :return: The command list with privilege escalation.
+    :rtype: List[str]
+    """
     system = platform.system()
     logger.debug("Getting escalated command for: %s on system: %s", command_parts, system)
     if not command_parts:
@@ -115,7 +153,13 @@ def get_escalated_command(command_parts: List[str]) -> List[str]:
 
 
 class NmapScanner:
-    """A wrapper around the python-nmap library to perform network scans."""
+    """
+    A wrapper around the python-nmap library to perform network scans.
+
+    This class manages the execution of Nmap scans, including building
+    command arguments, handling privilege escalation if needed, running
+    the scan process, and parsing the results.
+    """
 
     def __init__(self):
         """Initialize the NmapScanner."""
@@ -127,7 +171,9 @@ class NmapScanner:
 
 
     def __del__(self):
-        """Ensure the ThreadPoolExecutor is shut down and any running Nmap process is terminated."""
+        """
+        Ensure the ThreadPoolExecutor is shut down and any running Nmap process is terminated.
+        """
         logger.debug("NmapScanner.__del__ called.")
         if self.current_process and self.current_process.poll() is None:
             logger.info("Terminating active Nmap process during NmapScanner deletion.")
@@ -147,7 +193,18 @@ class NmapScanner:
 
 
     def validate_target_input(self, target: str) -> bool:
-        """Validate the target string for Nmap scanning."""
+        """
+        Validate the target string for Nmap scanning.
+
+        The target can be an IP address, a domain name, a CIDR block,
+        or 'localhost'. Multiple targets can be specified, separated by
+        commas or spaces.
+
+        :param target: The target string to validate.
+        :type target: str
+        :return: True if the target string is valid, False otherwise.
+        :rtype: bool
+        """
         if not target or not isinstance(target, str): # Handle empty or non-string input early
             return False
 
@@ -187,7 +244,18 @@ class NmapScanner:
     def build_nmap_options(
         self, os_fingerprinting: bool, scan_all_ports: bool, selected_script: str
     ) -> str:
-        """Construct Nmap command-line options string."""
+        """
+        Construct Nmap command-line options string based on boolean flags.
+
+        :param os_fingerprinting: If True, add OS fingerprinting options.
+        :type os_fingerprinting: bool
+        :param scan_all_ports: If True, add all ports scan option.
+        :type scan_all_ports: bool
+        :param selected_script: Name of the Nmap script to use (or "None").
+        :type selected_script: str
+        :return: A string of Nmap command-line options.
+        :rtype: str
+        """
         options = ScanOptions.DEFAULT.value
         if os_fingerprinting:
             options += f" {ScanOptions.OS_FINGERPRINTING.value}"
@@ -199,7 +267,14 @@ class NmapScanner:
         return options
 
     def _build_nmap_arguments(self, params: NmapScanParameters) -> List[str]:
-        """Build the list of arguments for the Nmap command."""
+        """
+        Build the list of arguments for the Nmap command.
+
+        :param params: A dictionary of Nmap scan parameters.
+        :type params: NmapScanParameters
+        :return: A list of arguments for the Nmap command.
+        :rtype: List[str]
+        """
         nmap_args_list = ["nmap", "-sS"] # -sS (TCP SYN scan) requires root.
 
         if params.get("os_fingerprinting"): nmap_args_list.append("-O")
@@ -225,7 +300,18 @@ class NmapScanner:
         return nmap_args_list
 
     def _prepare_final_nmap_command(self, nmap_args_list: List[str], needs_escalation: bool) -> List[str]:
-        """Prepares the final Nmap command list, including path resolution and escalation."""
+        """
+        Prepare the final Nmap command list, including path resolution and escalation.
+
+        :param nmap_args_list: The base list of Nmap arguments.
+        :type nmap_args_list: List[str]
+        :param needs_escalation: Whether privilege escalation is required.
+        :type needs_escalation: bool
+        :raises PortScannerError: If escalation fails or nmap executable is not found.
+        :raises FileNotFoundError: If nmap executable is not found for non-escalated command.
+        :return: The final list of command parts for execution.
+        :rtype: List[str]
+        """
         final_command_parts: List[str] = []
         if needs_escalation:
             logger.info("Escalation required for Nmap scan execution.")
@@ -248,7 +334,20 @@ class NmapScanner:
     def _parse_nmap_error_message(
         self, returncode: int, nmap_xml_output: str, nmap_stderr: str, needs_escalation: bool,
     ) -> str:
-        """Construct a detailed error message from Nmap's output when a scan fails."""
+        """
+        Construct a detailed error message from Nmap's output when a scan fails.
+
+        :param returncode: The exit code from the Nmap process.
+        :type returncode: int
+        :param nmap_xml_output: The stdout (XML output) from Nmap.
+        :type nmap_xml_output: str
+        :param nmap_stderr: The stderr output from Nmap.
+        :type nmap_stderr: str
+        :param needs_escalation: Whether the scan attempted privilege escalation.
+        :type needs_escalation: bool
+        :return: A detailed error message string.
+        :rtype: str
+        """
         error_message = f"Nmap scan failed with exit code {returncode}."
         if "QUITTING" in nmap_xml_output or "requires root privileges" in nmap_xml_output:
             output_lines = nmap_xml_output.strip().split("\n")
@@ -270,6 +369,22 @@ class NmapScanner:
         self, params: NmapScanParameters,
         cancellable: Optional[Gio.Cancellable] = None,
     ) -> nmap.PortScanner:
+        """
+        Run an Nmap scan with the given parameters and handle cancellation.
+
+        This method constructs the Nmap command, executes it as a subprocess,
+        monitors for cancellation, and parses the XML output.
+
+        :param params: The parameters for the Nmap scan.
+        :type params: NmapScanParameters
+        :param cancellable: An optional Gio.Cancellable object to monitor for cancellation requests.
+        :type cancellable: Optional[Gio.Cancellable]
+        :raises ScanCancelledError: If the scan is cancelled.
+        :raises PortScannerError: If the Nmap scan fails, prerequisites are missing,
+                                  or output parsing fails.
+        :return: An nmap.PortScanner object containing the scan results.
+        :rtype: nmap.PortScanner
+        """
         logger.debug(
             "run_nmap_scan called with params: %s, Cancellable: %s",
             params, bool(cancellable)
@@ -353,7 +468,15 @@ class NmapScanner:
 
 
     def convert_results_to_yaml(self, nm: nmap.PortScanner) -> Dict[str, str]:
-        """Convert Nmap scan results to YAML for each host."""
+        """
+        Convert Nmap scan results to YAML for each host.
+
+        :param nm: The nmap.PortScanner object containing the scan results.
+        :type nm: nmap.PortScanner
+        :return: A dictionary where keys are host IPs and values are YAML strings
+                 representing the scan results for that host.
+        :rtype: Dict[str, str]
+        """
         logger.debug(f"Converting Nmap results to YAML for {len(nm.all_hosts())} hosts.")
         all_results = {}
         prescan_scripts_data = nm.scaninfo().get('prescript', [])
@@ -369,7 +492,16 @@ class NmapScanner:
         return all_results
 
     def to_plain_dict(self, data: Any) -> Union[Dict[str, Any], Any]:
-        """Recursively convert Nmap data to plain dicts/lists for serialization."""
+        """
+        Recursively convert Nmap data (potentially custom nmap types) to plain dicts/lists.
+
+        This is necessary for proper serialization to formats like YAML or JSON.
+
+        :param data: The Nmap data to convert.
+        :type data: Any
+        :return: The data converted to plain Python dicts, lists, and primitive types.
+        :rtype: Union[Dict[str, Any], Any]
+        """
         # logger.debug(f"to_plain_dict called with data of type: {type(data)}") # Can be very verbose
         if isinstance(data, nmap.PortScannerHostDict):
             return {k: self.to_plain_dict(v) for k, v in data.items()}

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -1,8 +1,10 @@
-"""Manages the application's preferences window and settings.
+"""
+Manages the application's preferences window and settings.
 
-Provides UI for adjusting font scaling, theme, source view style schemes,
-custom DNS server, and HTTP output colors. Interacts with GSettings to
-load and save these preferences.
+This module provides the UI and logic for adjusting application-wide
+preferences such as font scaling, color themes, source view style schemes,
+custom DNS server settings, and HTTP output colors. It interacts with
+GSettings to persist these preferences.
 """
 import logging
 import re
@@ -26,11 +28,26 @@ except ImportError:
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/preferences.ui")
 class Preferences(Adw.PreferencesWindow):
-    """Adw.PreferencesWindow subclass for managing application settings.
+    """
+    Adw.PreferencesWindow subclass for managing application settings.
 
     This class defines the structure and behavior of the preferences dialog,
     allowing users to customize various aspects of the application.
     It binds UI elements to GSettings for persistence.
+
+    :ivar font_scale_combo_row: ComboRow for font scaling.
+    :ivar theme_combo_row: ComboRow for theme selection.
+    :ivar source_style_scheme_combo_row: ComboRow for source style scheme.
+    :ivar dns_server_entryrow: EntryRow for custom DNS server.
+    :ivar prefs_dns_apply_button: Button to apply DNS server settings.
+    :ivar preferences_error_banner: Banner for displaying errors.
+    :ivar http_header_key_color_button: Button for header key color.
+    :ivar http_header_value_color_button: Button for header value color.
+    :ivar http_special_row_color_button: Button for special row color.
+    :ivar new_custom_ua_title_entry: Entry for new custom User-Agent title.
+    :ivar new_custom_ua_value_entry: Entry for new custom User-Agent value.
+    :ivar add_custom_ua_button: Button to add custom User-Agent.
+    :ivar custom_ua_list_container: Container for custom User-Agent list.
     """
 
     __gtype_name__ = "Preferences"
@@ -54,12 +71,11 @@ class Preferences(Adw.PreferencesWindow):
     custom_ua_list_container = Gtk.Template.Child("custom_ua_list_container")
 
     def __init__(self, main_window: Gtk.Window = None):
-        """Initialize the Preferences window.
+        """
+        Initialize the Preferences window.
 
-        Args:
-        ----
-            main_window: The parent Gtk.Window for this dialog.
-
+        :param main_window: The parent Gtk.Window for this dialog.
+        :type main_window: Optional[Gtk.Window]
         """
         super().__init__(modal=True)
         self.main_window = main_window
@@ -102,7 +118,8 @@ class Preferences(Adw.PreferencesWindow):
 
 
     def load_ui(self):
-        """Connect signals for UI elements.
+        """
+        Connect signals for UI elements.
 
         This method sets up connections for various UI elements to their
         respective handler functions, and initializes GSettings listeners.
@@ -139,26 +156,24 @@ class Preferences(Adw.PreferencesWindow):
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._render_custom_ua_list())
 
     def on_error_banner_dismiss_clicked(self, _banner: Adw.Banner, *_args):
-        """Handle the click event for dismissing the error banner.
+        """
+        Handle the click event for dismissing the error banner.
 
-        Args:
-        ----
-            _banner: The Adw.Banner that was clicked (or its dismiss button).
-            *_args: Additional arguments (unused).
-
+        :param _banner: The Adw.Banner that was clicked (or its dismiss button).
+        :type _banner: Adw.Banner
+        :param _args: Additional arguments (unused).
         """
         self.hide_banner_and_clear_error_state()
 
     def on_dns_server_changed(self, _widget: Gtk.Widget):  # pylint: disable=unused-argument
-        """Handle changes to the custom DNS server entry.
+        """
+        Handle changes to the custom DNS server entry.
 
         Validates the entered IP address. If valid, saves it to GSettings.
-        If invalid, displays an error banner and clears the entry after a delay.
+        If invalid, displays an error banner.
 
-        Args:
-        ----
-            _widget: The widget that triggered the change (Adw.EntryRow or Gtk.Button).
-
+        :param _widget: The widget that triggered the change (Adw.EntryRow or Gtk.Button).
+        :type _widget: Gtk.Widget
         """
         dns_server = self.dns_server_entryrow.get_text().strip()
 
@@ -194,21 +209,18 @@ class Preferences(Adw.PreferencesWindow):
             )
 
     def hide_banner_and_clear_error_state(self, entry_row_widget: Optional[Adw.EntryRow] = None) -> bool:
-        """Hide the error banner and remove 'error' CSS class from an entry row.
+        """
+        Hide the error banner and remove 'error' CSS class from an entry row.
 
         This method is also used as a GLib.timeout_add_seconds callback,
         in which case it must return GLib.SOURCE_REMOVE.
 
-        Args:
-        ----
-            entry_row_widget: The Adw.EntryRow to clear the error state from.
-                              If None, defaults to `self.dns_server_entryrow`.
-
-        Returns:
-        -------
-            GLib.SOURCE_REMOVE if called as a timeout, indicating the timer should not repeat.
-            Implicitly returns None otherwise.
-
+        :param entry_row_widget: The Adw.EntryRow to clear the error state from.
+                                 If None, defaults to `self.dns_server_entryrow`.
+        :type entry_row_widget: Optional[Adw.EntryRow]
+        :return: GLib.SOURCE_REMOVE if called as a timeout, indicating the timer should not repeat.
+                 Implicitly returns None otherwise.
+        :rtype: bool
         """
         self.preferences_error_banner.set_revealed(False)
         target_entry_row = entry_row_widget if entry_row_widget else self.dns_server_entryrow
@@ -218,16 +230,13 @@ class Preferences(Adw.PreferencesWindow):
 
     @staticmethod
     def is_valid_ipv4(ip_address: str) -> bool:
-        """Validate if the input string is a syntactically valid IPv4 address.
+        """
+        Validate if the input string is a syntactically valid IPv4 address.
 
-        Args:
-        ----
-            ip_address: The string to validate.
-
-        Returns:
-        -------
-            True if the string is a valid IPv4 address, False otherwise.
-
+        :param ip_address: The string to validate.
+        :type ip_address: str
+        :return: True if the string is a valid IPv4 address, False otherwise.
+        :rtype: bool
         """
         parts = ip_address.split(".")
         if len(parts) != 4:
@@ -242,15 +251,15 @@ class Preferences(Adw.PreferencesWindow):
         return True
 
     def on_font_scale_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
-        """Handle changes in the font scale preference ComboRow.
+        """
+        Handle changes in the font scale preference ComboRow.
 
         Saves the selected font scaling percentage string to GSettings.
 
-        Args:
-        ----
-            combo_row: The Adw.ComboRow whose selection changed.
-            _gparam: The GLib.ParamSpec of the property that changed (unused).
-
+        :param combo_row: The Adw.ComboRow whose selection changed.
+        :type combo_row: Adw.ComboRow
+        :param _gparam: The GLib.ParamSpec of the property that changed (unused).
+        :type _gparam: GObject.ParamSpec
         """
         selected_item_obj = combo_row.get_selected_item()
         if isinstance(selected_item_obj, Gtk.StringObject):
@@ -259,15 +268,15 @@ class Preferences(Adw.PreferencesWindow):
             logging.debug("Font scaling preference set to %s.", selected_scale_str)
 
     def on_theme_preference_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
-        """Handle changes in the theme preference ComboRow.
+        """
+        Handle changes in the theme preference ComboRow.
 
         Saves the selected theme name string (e.g., "Light", "Dark") to GSettings.
 
-        Args:
-        ----
-            combo_row: The Adw.ComboRow whose selection changed.
-            _gparam: The GLib.ParamSpec of the property that changed (unused).
-
+        :param combo_row: The Adw.ComboRow whose selection changed.
+        :type combo_row: Adw.ComboRow
+        :param _gparam: The GLib.ParamSpec of the property that changed (unused).
+        :type _gparam: GObject.ParamSpec
         """
         selected_item_obj = combo_row.get_selected_item()
         if isinstance(selected_item_obj, Gtk.StringObject):
@@ -279,15 +288,15 @@ class Preferences(Adw.PreferencesWindow):
             )
 
     def on_source_style_scheme_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
-        """Handle changes in the source style scheme preference ComboRow.
+        """
+        Handle changes in the source style scheme preference ComboRow.
 
         Saves the selected style scheme name string to GSettings.
 
-        Args:
-        ----
-            combo_row: The Adw.ComboRow whose selection changed.
-            _gparam: The GLib.ParamSpec of the property that changed (unused).
-
+        :param combo_row: The Adw.ComboRow whose selection changed.
+        :type combo_row: Adw.ComboRow
+        :param _gparam: The GLib.ParamSpec of the property that changed (unused).
+        :type _gparam: GObject.ParamSpec
         """
         selected_item = combo_row.get_selected_item()
         if isinstance(selected_item, Gtk.StringObject):
@@ -296,7 +305,14 @@ class Preferences(Adw.PreferencesWindow):
 
     @staticmethod
     def _rgba_to_hex(rgba: Gdk.RGBA) -> str:
-        """Convert a Gdk.RGBA object to a hex color string (e.g., #RRGGBB)."""
+        """
+        Convert a Gdk.RGBA object to a hex color string (e.g., #RRGGBB).
+
+        :param rgba: The Gdk.RGBA object to convert.
+        :type rgba: Gdk.RGBA
+        :return: The hex color string.
+        :rtype: str
+        """
         # Ensure values are scaled to 0-255 and are integers
         red = int(rgba.red * 255)
         green = int(rgba.green * 255)
@@ -307,7 +323,16 @@ class Preferences(Adw.PreferencesWindow):
         return f"#{red:02x}{green:02x}{blue:02x}"
 
     def on_http_color_changed(self, button: Gtk.ColorDialogButton, _gparam: GObject.ParamSpec, gsettings_key: str):
-        """Handle RGBA color change from a Gtk.ColorDialogButton and save as hex."""
+        """
+        Handle RGBA color change from a Gtk.ColorDialogButton and save as hex.
+
+        :param button: The Gtk.ColorDialogButton that emitted the signal.
+        :type button: Gtk.ColorDialogButton
+        :param _gparam: The GLib.ParamSpec of the property that changed (unused).
+        :type _gparam: GObject.ParamSpec
+        :param gsettings_key: The GSettings key to save the color to.
+        :type gsettings_key: str
+        """
         rgba = button.get_rgba()
         if rgba:
             color_hex_string = self._rgba_to_hex(rgba)
@@ -315,7 +340,14 @@ class Preferences(Adw.PreferencesWindow):
             logging.debug(f"HTTP color for {gsettings_key} set to hex: {color_hex_string}")
 
     def _load_color_button_preference(self, button: Gtk.ColorDialogButton, gsettings_key: str):
-        """Load a color from GSettings (stored as hex) and apply to Gtk.ColorDialogButton."""
+        """
+        Load a color from GSettings (stored as hex) and apply to Gtk.ColorDialogButton.
+
+        :param button: The Gtk.ColorDialogButton to apply the color to.
+        :type button: Gtk.ColorDialogButton
+        :param gsettings_key: The GSettings key to load the color from.
+        :type gsettings_key: str
+        """
         color_string = self.settings.get_string(gsettings_key)
         if color_string:
             color = Gdk.RGBA()
@@ -328,7 +360,8 @@ class Preferences(Adw.PreferencesWindow):
                 logging.warning(f"Failed to parse color string '{color_string}' for GSettings key '{gsettings_key}': {e}.")
 
     def _render_custom_ua_list(self):
-        """Clear and repopulate the list of custom User-Agents in the UI.
+        """
+        Clear and repopulate the list of custom User-Agents in the UI.
 
         Retrieves User-Agent pairs (title, value) from GSettings,
         creates an Adw.ActionRow for each, and adds them to the
@@ -358,13 +391,17 @@ class Preferences(Adw.PreferencesWindow):
             row.set_activatable_widget(remove_button)
             self.custom_ua_list_container.append(row)
 
-    def _on_add_custom_ua_clicked(self, _widget):
-        """Handle the 'Add User Agent' button click or entry activation.
+    def _on_add_custom_ua_clicked(self, _widget: Gtk.Widget):
+        """
+        Handle the 'Add User Agent' button click or entry activation.
 
         Retrieves text from the title and value entry fields.
         If both are non-empty and the title is unique, adds the new
         User-Agent pair to GSettings and updates the UI list.
         Provides visual feedback for empty fields or duplicate titles.
+
+        :param _widget: The widget that triggered the signal.
+        :type _widget: Gtk.Widget
         """
         if not self.new_custom_ua_title_entry or not self.new_custom_ua_value_entry:
             return
@@ -415,10 +452,14 @@ class Preferences(Adw.PreferencesWindow):
             logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {title_text}")
 
     def _on_remove_custom_ua_clicked(self, title_to_remove: str):
-        """Handle the click of a 'remove' button for a custom User-Agent.
+        """
+        Handle the click of a 'remove' button for a custom User-Agent.
 
         Removes the User-Agent pair identified by title_to_remove from
         GSettings and updates the UI list.
+
+        :param title_to_remove: The title of the User-Agent to remove.
+        :type title_to_remove: str
         """
         variant = self.settings.get_value("custom-user-agents")
         current_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
@@ -439,21 +480,20 @@ class Preferences(Adw.PreferencesWindow):
     def _select_combo_row_item(
         self, combo_row: Adw.ComboRow, setting_value: str, case_sensitive: bool = True
     ) -> bool:
-        """Select an item in an Adw.ComboRow based on its string value.
+        """
+        Select an item in an Adw.ComboRow based on its string value.
 
         Iterates through the items in the ComboRow's model (expected to be Gtk.StringList).
         If a match is found (case-sensitive or insensitive), the item is selected.
 
-        Args:
-        ----
-            combo_row: The Adw.ComboRow to operate on.
-            setting_value: The string value of the item to select.
-            case_sensitive: Whether the string comparison should be case-sensitive.
-
-        Returns:
-        -------
-            True if an item was successfully found and selected, False otherwise.
-
+        :param combo_row: The Adw.ComboRow to operate on.
+        :type combo_row: Adw.ComboRow
+        :param setting_value: The string value of the item to select.
+        :type setting_value: str
+        :param case_sensitive: Whether the string comparison should be case-sensitive.
+        :type case_sensitive: bool
+        :return: True if an item was successfully found and selected, False otherwise.
+        :rtype: bool
         """
         model = combo_row.get_model()
         if isinstance(model, Gtk.StringList):
@@ -471,7 +511,8 @@ class Preferences(Adw.PreferencesWindow):
         return False
 
     def load_preferences(self):
-        """Load preferences from GSettings and update the UI elements accordingly.
+        """
+        Load preferences from GSettings and update the UI elements accordingly.
 
         For each preference (font scale, theme, style scheme, DNS server),
         it retrieves the value from GSettings and sets the corresponding

--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -1,4 +1,5 @@
-"""Utility functions for managing application styling.
+"""
+Utility functions for managing application styling.
 
 This module provides functions for applying font preferences, themes,
 and GtkSourceView style schemes. It interacts with GSettings to retrieve
@@ -28,19 +29,16 @@ HIGH_CONTRAST_KEY = "high-contrast"
 def _get_linux_font_preferences(
     base_font_size_pt: float,
 ) -> Tuple[Optional[str], float]:
-    """Get font preferences from GNOME settings on Linux.
+    """
+    Get font preferences from GNOME settings on Linux.
 
     Retrieves font family and size from `org.gnome.desktop.interface` schema.
     Applies GNOME's text scaling factor.
 
-    Args:
-    ----
-        base_font_size_pt: The base font size to use if system settings are unavailable.
-
-    Returns:
-    -------
-        A tuple containing the font family (str or None) and the calculated font size in points.
-
+    :param base_font_size_pt: The base font size to use if system settings are unavailable.
+    :type base_font_size_pt: float
+    :return: A tuple containing the font family (str or None) and the calculated font size in points.
+    :rtype: Tuple[Optional[str], float]
     """
     font_family = None
     font_size_pt = base_font_size_pt
@@ -78,19 +76,16 @@ def _get_linux_font_preferences(
 
 
 def _get_app_font_scaling(app_settings: Gio.Settings) -> float:
-    """Get app-specific font scaling percentage from GSettings.
+    """
+    Get app-specific font scaling percentage from GSettings.
 
     Parses the 'font-scaling-percentage' string (e.g., "100%") and returns it as a float.
     Defaults to 100.0 if parsing fails.
 
-    Args:
-    ----
-        app_settings: The application's Gio.Settings object.
-
-    Returns:
-    -------
-        The font scaling percentage as a float (e.g., 100.0, 120.0).
-
+    :param app_settings: The application's Gio.Settings object.
+    :type app_settings: Gio.Settings
+    :return: The font scaling percentage as a float (e.g., 100.0, 120.0).
+    :rtype: float
     """
     font_scale_percentage_str = app_settings.get_string("font-scaling-percentage")
     parsed_app_percentage = 100.0
@@ -112,16 +107,15 @@ def _get_app_font_scaling(app_settings: Gio.Settings) -> float:
 
 
 def apply_system_font_preferences(app_settings: Gio.Settings):
-    """Apply font preferences system-wide.
+    """
+    Apply font preferences system-wide.
 
     Considers system-wide GNOME settings (if on Linux) for base font family and size,
     then applies the application's own font scaling percentage from GSettings.
     The resulting font style is applied globally using a Gtk.CssProvider.
 
-    Args:
-    ----
-        app_settings: The application's Gio.Settings object.
-
+    :param app_settings: The application's Gio.Settings object.
+    :type app_settings: Gio.Settings
     """
     font_family_to_apply = None
     font_size_to_apply_pt = BASE_FONT_SIZE_PT
@@ -160,26 +154,25 @@ def apply_system_font_preferences(app_settings: Gio.Settings):
 
 
 def apply_font_size(settings: Gio.Settings):
-    """Apply font size preferences based on system and application settings.
+    """
+    Apply font size preferences based on system and application settings.
 
     This function is a wrapper around `apply_system_font_preferences`.
 
-    Args:
-    ----
-        settings: The application's Gio.Settings object.
-
+    :param settings: The application's Gio.Settings object.
+    :type settings: Gio.Settings
     """
     apply_system_font_preferences(settings)
 
 
 def apply_theme(style_manager: Adw.StyleManager, theme_preference: str):
-    """Apply the selected color scheme (theme) to the application.
+    """
+    Apply the selected color scheme (theme) to the application.
 
-    Args:
-    ----
-        style_manager: The Adw.StyleManager instance for the application.
-        theme_preference: The theme preference string ("Light", "Dark", or "System").
-
+    :param style_manager: The Adw.StyleManager instance for the application.
+    :type style_manager: Adw.StyleManager
+    :param theme_preference: The theme preference string ("Light", "Dark", or "System").
+    :type theme_preference: str
     """
     if theme_preference == "Light":
         style_manager.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
@@ -194,16 +187,17 @@ def apply_source_style_scheme(
     buffer: GtkSource.Buffer,
     source_style_scheme: str,
 ):
-    """Apply the selected style scheme to a GtkSource.Buffer.
+    """
+    Apply the selected style scheme to a GtkSource.Buffer.
 
     If the specified scheme is not found, it attempts to fall back to "Adwaita".
 
-    Args:
-    ----
-        scheme_manager: The GtkSource.StyleSchemeManager.
-        buffer: The GtkSource.Buffer to apply the scheme to.
-        source_style_scheme: The name of the style scheme to apply.
-
+    :param scheme_manager: The GtkSource.StyleSchemeManager.
+    :type scheme_manager: GtkSource.StyleSchemeManager
+    :param buffer: The GtkSource.Buffer to apply the scheme to.
+    :type buffer: GtkSource.Buffer
+    :param source_style_scheme: The name of the style scheme to apply.
+    :type source_style_scheme: str
     """
     # Handle common Adwaita variations that might not strictly match IDs
     if source_style_scheme not in ["Adwaita", "Adwaita-dark"]:
@@ -228,13 +222,13 @@ def apply_source_style_scheme(
 
 
 def set_widget_visibility(visible: bool, *widgets: Gtk.Widget):
-    """Set the visibility of one or more Gtk.Widgets.
+    """
+    Set the visibility of one or more Gtk.Widgets.
 
-    Args:
-    ----
-        visible: True to make widgets visible, False to hide them.
-        *widgets: The Gtk.Widget(s) to modify. None values are logged and skipped.
-
+    :param visible: True to make widgets visible, False to hide them.
+    :type visible: bool
+    :param widgets: The Gtk.Widget(s) to modify. None values are logged and skipped.
+    :type widgets: Gtk.Widget
     """
     for widget in widgets:
         if widget:
@@ -244,16 +238,13 @@ def set_widget_visibility(visible: bool, *widgets: Gtk.Widget):
 
 
 def create_listbox_row(item_text: str) -> Gtk.ListBoxRow:
-    """Create a simple Gtk.ListBoxRow containing a Gtk.Label.
+    """
+    Create a simple Gtk.ListBoxRow containing a Gtk.Label.
 
-    Args:
-    ----
-        item_text: The text to display in the label of the list box row.
-
-    Returns:
-    -------
-        A Gtk.ListBoxRow with the specified label.
-
+    :param item_text: The text to display in the label of the list box row.
+    :type item_text: str
+    :return: A Gtk.ListBoxRow with the specified label.
+    :rtype: Gtk.ListBoxRow
     """
     label = Gtk.Label(label=item_text)
     row = Gtk.ListBoxRow()
@@ -262,17 +253,14 @@ def create_listbox_row(item_text: str) -> Gtk.ListBoxRow:
 
 
 def init_source_buffer(language: str = "yaml") -> GtkSource.Buffer:
-    """Initialize a GtkSource.Buffer with syntax highlighting for a given language.
+    """
+    Initialize a GtkSource.Buffer with syntax highlighting for a given language.
 
-    Args:
-    ----
-        language: The language ID for syntax highlighting (e.g., "yaml", "python").
-                  Defaults to "yaml".
-
-    Returns:
-    -------
-        A GtkSource.Buffer configured for the specified language.
-
+    :param language: The language ID for syntax highlighting (e.g., "yaml", "python").
+                     Defaults to "yaml".
+    :type language: str
+    :return: A GtkSource.Buffer configured for the specified language.
+    :rtype: GtkSource.Buffer
     """
     source_buffer = GtkSource.Buffer()
     lang_manager = GtkSource.LanguageManager.get_default()

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -51,7 +51,11 @@ class WebScanPage(Adw.PreferencesPage):
     auth_bypass_switch = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
-        """Initialize the WebScanPage."""
+        """Initialize the WebScanPage.
+
+        :param kwargs: Keyword arguments passed to the :class:`Adw.PreferencesPage` constructor.
+        :type kwargs: Any
+        """
 
         super().__init__(**kwargs)
         self.source_view = GtkSource.View()
@@ -107,7 +111,13 @@ class WebScanPage(Adw.PreferencesPage):
             self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
 
     def _on_webscan_source_style_settings_changed(self, _manager_or_settings, _param_spec_or_key):
-        """Handle theme or style scheme changes for WebScan's GtkSourceView."""
+        """Handle theme or style scheme changes for WebScan's GtkSourceView.
+
+        :param _manager_or_settings: The Adw.StyleManager or Gio.Settings object that emitted the signal.
+        :type _manager_or_settings: Adw.StyleManager or Gio.Settings
+        :param _param_spec_or_key: The GObject.ParamSpec or GSettings key that changed.
+        :type _param_spec_or_key: GObject.ParamSpec or str
+        """
         logger.info("WebScanPage: Dark theme or source style scheme changed. Applying new style.")
         self._apply_webscan_source_view_style()
 
@@ -159,7 +169,11 @@ class WebScanPage(Adw.PreferencesPage):
             self.current_web_scan_cancellable.cancel()
 
     def _on_cancel_scan_clicked(self, _button: Gtk.Button) -> None:
-        """Handles click on the 'Cancel Scan' button."""
+        """Handles click on the 'Cancel Scan' button.
+
+        :param _button: The Gtk.Button that was clicked (unused).
+        :type _button: Gtk.Button
+        """
         logger.info("Cancel scan button clicked.")
         if self.current_web_scan_cancellable and \
            not self.current_web_scan_cancellable.is_cancelled():
@@ -172,6 +186,11 @@ class WebScanPage(Adw.PreferencesPage):
             logger.warning("No active scan or cancellable to cancel.")
 
     def _on_clear_results_clicked(self, _button: Gtk.Button):
+        """Handle click of the 'Clear Results' button.
+
+        :param _button: The Gtk.Button that was clicked (unused).
+        :type _button: Gtk.Button
+        """
         if not hasattr(self, 'source_view') or not self.source_view:
             # print(f"DEBUG: _on_clear_results_clicked - source_view not found")
             return
@@ -179,13 +198,17 @@ class WebScanPage(Adw.PreferencesPage):
         if not buffer:
             # print(f"DEBUG: _on_clear_results_clicked - buffer not found")
             return
-        """Handle click of the 'Clear Results' button."""
         logger.info("Webscan results cleared by user action.")
         if self.source_view:
             buffer = self.source_view.get_buffer()
             buffer.set_text("")
 
     def _on_copy_results_clicked(self, _button: Gtk.Button):
+        """Handle click of the 'Copy Results' button.
+
+        :param _button: The Gtk.Button that was clicked (unused).
+        :type _button: Gtk.Button
+        """
         if not hasattr(self, 'source_view') or not self.source_view:
             # print(f"DEBUG: _on_copy_results_clicked - source_view not found")
             return
@@ -193,7 +216,6 @@ class WebScanPage(Adw.PreferencesPage):
         if not buffer:
             # print(f"DEBUG: _on_copy_results_clicked - buffer not found")
             return
-        """Handle click of the 'Copy Results' button."""
         logger.info("Copying webscan results to clipboard.")
         if self.source_view:
             buffer = self.source_view.get_buffer()
@@ -215,6 +237,11 @@ class WebScanPage(Adw.PreferencesPage):
                 logger.info("No webscan results to copy.")
 
     def on_scan_button_clicked(self, _widget: Gtk.Button):
+        """Handle the 'Scan' button click event.
+
+        :param _widget: The Gtk.Button that was clicked (unused).
+        :type _widget: Gtk.Button
+        """
         if not hasattr(self, 'source_view') or not self.source_view:
             # print(f"DEBUG: on_scan_button_clicked - source_view not found")
             return
@@ -222,7 +249,6 @@ class WebScanPage(Adw.PreferencesPage):
         if not buffer:
             # print(f"DEBUG: on_scan_button_clicked - buffer not found")
             return
-        """Handle the 'Scan' button click event."""
         logger.debug(f"WebScanPage scan button clicked. URL: '{self.url_entry.get_text()}'")
         target_url = self.url_entry.get_text().strip()
 
@@ -289,7 +315,17 @@ class WebScanPage(Adw.PreferencesPage):
                                    _source_object: GObject.Object,
                                    _task_data_unused: Any, # Parameter from Gio.Task.run_in_thread, not used for params
                                    cancellable: Gio.Cancellable):
-        """Execute the Nikto scan in a separate thread, with cancellation support."""
+        """Execute the Nikto scan in a separate thread, with cancellation support.
+
+        :param task: The Gio.Task associated with this operation.
+        :type task: Gio.Task
+        :param _source_object: The GObject source of the task.
+        :type _source_object: GObject.Object
+        :param _task_data_unused: Additional data passed to the task (unused).
+        :type _task_data_unused: Any
+        :param cancellable: A Gio.Cancellable object to monitor for cancellation.
+        :type cancellable: Gio.Cancellable
+        """
         logger.debug("WebScanPage._run_scan_task_thread_func started")
 
         page_instance: WebScanPage = _source_object # type: ignore
@@ -500,7 +536,15 @@ class WebScanPage(Adw.PreferencesPage):
             self.current_nikto_process = None # Ensure cleared
 
     def _on_scan_task_done(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: object): # type: ignore
-        """Handle completion of the Nikto scan task."""
+        """Handle completion of the Nikto scan task.
+
+        :param _source_object: The GObject source of the task.
+        :type _source_object: GObject.Object
+        :param result: The Gio.AsyncResult from the completed task.
+        :type result: Gio.AsyncResult
+        :param _user_data: User data passed with the callback (unused).
+        :type _user_data: object
+        """
         target_url = "Unknown URL"
         # Retrieve target_url from instance variable
         if self._current_webscan_params:
@@ -626,6 +670,16 @@ class WebScanPage(Adw.PreferencesPage):
             self.current_nikto_process = None # Ensure cleared
 
     def _update_textview(self, stdout_content: Optional[str], stderr_content: Optional[str], is_error_message: bool = False):
+        """Update the results TextView with Nikto's stdout and error messages/stderr.
+
+        :param stdout_content: The standard output content from Nikto.
+        :type stdout_content: Optional[str]
+        :param stderr_content: The standard error content from Nikto or a pre-formatted error message.
+        :type stderr_content: Optional[str]
+        :param is_error_message: If True, stderr_content is treated as a pre-formatted error for display.
+                                 Otherwise, it's treated as raw stderr output from Nikto.
+        :type is_error_message: bool
+        """
         if not hasattr(self, 'source_view') or not self.source_view:
             # print("DEBUG: _update_textview - source_view not found")
             return
@@ -633,7 +687,6 @@ class WebScanPage(Adw.PreferencesPage):
         if not buffer:
             # print("DEBUG: _update_textview - buffer not found")
             return
-        """Update the results TextView with Nikto's stdout and error messages/stderr."""
         buffer = self.source_view.get_buffer()
         if stdout_content:
             buffer.insert(buffer.get_end_iter(), stdout_content)


### PR DESCRIPTION
I ensured all module, class, and function/method docstrings within the 'src' directory consistently use the reStructuredText format (e.g., :param:, :type:, :return:, :rtype:, :raises:).

This change involved:
- Converting files previously using Google-style or basic docstrings.
- Reviewing all files for adherence to the chosen standard.
- Making minor corrections to wording, capitalization, and punctuation for overall consistency.