### PR TITLE
Refactor: Improve UI consistency for button accent colors

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -84,7 +84,7 @@
                 <property name="tooltip-text" translatable="yes">Clear Results</property>
                 <property name="valign">center</property>
                 <style>
-                  <class name="flat"/>
+                  <class name="destructive-action"/>
                 </style>
               </object>
             </child>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -77,7 +77,6 @@
                 <signal name="clicked" handler="_on_clear_results_clicked"/>
                 <style>
                   <class name="destructive-action"/>
-                  <class name="flat"/>
                 </style>
               </object>
             </child>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -143,6 +143,9 @@
                     <property name="label" translatable="yes">Cancel</property>
                     <property name="icon-name">process-stop-symbolic</property>
                     <property name="visible">False</property>
+                    <style>
+                      <class name="destructive-action"/>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -192,7 +192,7 @@
                 <property name="tooltip-text" translatable="yes">Clear Results</property>
                 <property name="valign">center</property>
                 <style>
-                  <class name="flat"/>
+                  <class name="destructive-action"/>
                 </style>
               </object>
             </child>


### PR DESCRIPTION
I ensured that buttons across different pages consistently use Libadwaita's `suggested-action` and `destructive-action` style classes to display appropriate accent colors.

Key changes:
- Modified `src/gtk/http_page.ui`: Removed `flat` class from the `clear_results_button` to allow its `destructive-action` style to be visible.
- Modified `src/gtk/nmap_page.ui`: Added `destructive-action` class to the `nmap_cancel_scan_button` to clearly indicate its function.
- Modified `src/gtk/dns_page.ui` and `src/gtk/webscan_page.ui`: Changed `clear_results_button` from `flat` to `destructive-action` for better visual feedback and consistency with other data-clearing actions.

These changes address inconsistencies where some buttons were not displaying accent colors as expected, leading to a more modern and visually coherent user interface. No CSS overrides were found or needed modification for this issue.