### PR TITLE
Refactor NmapPage to use Adw.PreferencesPage for consistent styling

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -4,7 +4,7 @@
   <!-- interface-name nmap_page.ui -->
   <requires lib="gtk" version="4.10"/>
   <requires lib="libadwaita" version="1.4"/>
-  <template class="NmapPage" parent="AdwBin">
+  <template class="NmapPage" parent="AdwPreferencesPage">
     <property name="width-request">700</property>
     <property name="height_request">600</property>
     <child>

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -66,7 +66,7 @@ class NmapTargetRow(Gtk.ListBoxRow):
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
-class NmapPage(Adw.Bin):
+class NmapPage(Adw.PreferencesPage):
     """Activity page for performing Nmap scans and viewing results."""
 
     __gtype_name__ = "NmapPage"
@@ -90,7 +90,7 @@ class NmapPage(Adw.Bin):
     def __init__(self, **kwargs):
         """Initialize the NmapPage.
 
-        :param kwargs: Keyword arguments passed to the :class:`Adw.Bin` constructor.
+        :param kwargs: Keyword arguments passed to the :class:`Adw.PreferencesPage` constructor.
         :type kwargs: Any
         """
         super().__init__(**kwargs)


### PR DESCRIPTION
I changed NmapPage to inherit from Adw.PreferencesPage instead of Adw.Bin. This aligns its base class with other pages in your application (DNSPage, HttpPage, WebScanPage).

This change is intended to address inconsistencies in the application of Adwaita styling, particularly the accent colors for buttons with 'suggested-action' and 'destructive-action' classes, ensuring a more consistent look and feel, especially under GNOME 48.

The UI structure within nmap_page.ui (where buttons are nested inside AdwPreferencesGroup and AdwActionRow/AdwEntryRow) remains largely the same, but the page now benefits from being a child of the more style-aware Adw.PreferencesPage container.