### PR TITLE
Refactor: Fix Nikto newlines, replace GtkSource.View, remove highligh…

### DIFF
--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -25,11 +25,6 @@
       <summary>Application theme preference</summary>
       <description>Allows users to choose between System, Light, or Dark themes.</description>
     </key>
-    <key name="source-style-scheme" type="s">
-      <default>'Adwaita'</default>
-      <summary>Syntax Highlighting Colour Scheme</summary>
-      <description>The colour scheme used for syntax highlighting in the GtkSourceView</description>
-    </key>
     <key name="custom-dns-server" type="s">
       <default>''</default>
       <summary>Custom DNS server for lookups</summary>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -39,32 +39,6 @@
               </object>
             </child>
             <child>
-              <object class="AdwComboRow" id="source_style_scheme_combo_row">
-                <property name="halign">baseline-fill</property>
-                <property name="model">
-                  <object class="GtkStringList" id="color_scheme_list">
-                    <property name="strings">Adwaita</property>
-                    <items>
-                      <item>Adwaita-dark</item>
-                      <item>Classic</item>
-                      <item>Classic-dark</item>
-                      <item>Cobalt-light</item>
-                      <item>Cobalt</item>
-                      <item>Kate</item>
-                      <item>Kate-dark</item>
-                      <item>Oblivion</item>
-                      <item>Tango</item>
-                      <item>Solarized-light</item>
-                      <item>solarized-dark</item>
-                    </items>
-                  </object>
-                </property>
-                <property name="selected">0</property>
-                <property name="subtitle">Choose a color scheme for the SourceView</property>
-                <property name="title">Syntax Highlighting Color Scheme</property>
-              </object>
-            </child>
-            <child>
               <object class="AdwComboRow" id="font_scale_combo_row">
                 <property name="title" translatable="yes">Font Size</property>
                 <property name="subtitle" translatable="yes">Select text scaling percentage</property>

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -14,19 +14,20 @@ from typing import Optional, List, Dict, Any
 import yaml
 
 import gi
-from gi.repository import Adw, Gio, GLib, GObject, Gtk, GtkSource
+from gi.repository import Adw, Gio, GLib, GObject, Gtk # Removed GtkSource
 
 import nmap
 
 from .constants import APP_ID, RESOURCE_PREFIX
 from .nmap_scanner import NmapScanner, ScanStatus, ScanCancelledError
-from .style_utils import apply_source_style_scheme
-from .utils import create_source_view, show_global_error, show_global_toast
+# Removed: from .style_utils import apply_source_style_scheme
+# Removed: from .utils import create_source_view
+from .utils import show_global_error, show_global_toast # Keep other utils
 
 
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
-gi.require_version("GtkSource", "5")
+# Removed: gi.require_version("GtkSource", "5")
 
 
 class NmapItem(GObject.Object):
@@ -99,9 +100,10 @@ class NmapPage(Adw.PreferencesPage):
         self.nmap_target_listbox_store = Gio.ListStore(item_type=NmapItem)
         self.scanner = NmapScanner()
         self.settings = Gio.Settings.new(APP_ID)
-        self.style_manager = Adw.StyleManager.get_default()
-        self.style_manager.connect("notify::dark", self._on_nmap_source_style_settings_changed)
-        self.settings.connect(f"changed::source-style-scheme", self._on_nmap_source_style_settings_changed)
+        # self.style_manager = Adw.StyleManager.get_default() # Removed as it's no longer used
+        # Removed GtkSource specific signal connections
+        # self.style_manager.connect("notify::dark", self._on_nmap_source_style_settings_changed)
+        # self.settings.connect(f"changed::source-style-scheme", self._on_nmap_source_style_settings_changed)
 
         self.current_nmap_task: Optional[Gio.Task] = None
         self.current_nmap_cancellable: Optional[Gio.Cancellable] = None
@@ -121,67 +123,8 @@ class NmapPage(Adw.PreferencesPage):
             del self.scanner
         super().__del__() # Important if GObject has its own __del__
 
-    def _on_nmap_source_style_settings_changed(self, _source: GObject.Object, _pspec: GObject.ParamSpec):
-        """Handle theme or style scheme changes for Nmap's GtkSourceView.
-
-        Currently, this method primarily logs the change. Style application
-        is handled at view creation time in _add_raw_output_expander.
-
-        :param _source: The GObject source of the signal.
-        :type _source: GObject.Object
-        :param _pspec: The GObject.ParamSpec of the property that changed.
-        :type _pspec: GObject.ParamSpec
-        """
-        logger.info("NmapPage: Dark theme or source style scheme changed. New views will use updated style.")
-        # If we were to update existing views, we'd iterate them here and call
-        # self._apply_source_view_style_to_buffer(buffer)
-
-    def _apply_source_view_style_to_buffer(self, buffer: GtkSource.Buffer):
-        """Apply the appropriate GtkSourceView style scheme to a given buffer,
-        considering the current theme (dark/light) and user settings.
-
-        :param buffer: The GtkSource.Buffer to apply the style to.
-        :type buffer: GtkSource.Buffer
-        """
-        is_dark = self.style_manager.get_dark()
-        user_scheme_name = self.settings.get_string("source-style-scheme")
-        scheme_manager = GtkSource.StyleSchemeManager.get_default()
-        final_scheme_name = "Adwaita" # Default fallback
-
-        if is_dark:
-            if user_scheme_name.lower() in ["adwaita", "default", "classic", "light"]: # Common names for light default themes
-                final_scheme_name = "Adwaita-dark"
-            else:
-                # Check if user's preferred scheme exists
-                if scheme_manager.get_scheme(user_scheme_name):
-                    final_scheme_name = user_scheme_name
-                else:
-                    logger.warning(
-                        f"NmapPage: User scheme '{user_scheme_name}' not found for dark theme, falling back to Adwaita-dark."
-                    )
-                    final_scheme_name = "Adwaita-dark" # Fallback for dark
-        else: # Light theme
-            if user_scheme_name.lower() in ["adwaita-dark", "dark"]: # Common names for dark default themes
-                final_scheme_name = "Adwaita"
-            else:
-                # Check if user's preferred scheme exists
-                if scheme_manager.get_scheme(user_scheme_name):
-                    final_scheme_name = user_scheme_name
-                else:
-                    logger.warning(
-                        f"NmapPage: User scheme '{user_scheme_name}' not found for light theme, falling back to Adwaita."
-                    )
-                    final_scheme_name = "Adwaita" # Fallback for light
-
-        # Final check if the determined scheme actually exists, else use a built-in Adwaita
-        if not scheme_manager.get_scheme(final_scheme_name):
-            logger.error(
-                f"NmapPage: Scheme '{final_scheme_name}' could not be loaded. Defaulting to basic Adwaita (light/dark)."
-            )
-            final_scheme_name = "Adwaita-dark" if is_dark else "Adwaita"
-
-        logger.debug(f"NmapPage: Applying source style scheme: {final_scheme_name} (Dark: {is_dark}, User: {user_scheme_name})")
-        apply_source_style_scheme(scheme_manager, buffer, final_scheme_name)
+    # Removed _on_nmap_source_style_settings_changed method
+    # Removed _apply_source_view_style_to_buffer method
 
     def _init_page_ui(self):
         logger.debug("Initializing NmapPage UI components.")
@@ -518,13 +461,25 @@ class NmapPage(Adw.PreferencesPage):
         expander = Adw.ExpanderRow(title=f"Text Scan Summary - {host_key}")
         expander.set_expanded(False)
         human_readable_summary = self._generate_human_readable_host_summary(host_data_dict)
-        source_view, source_buffer = create_source_view(language_name="txt")
-        source_buffer.set_text(human_readable_summary, -1)
-        self._apply_source_view_style_to_buffer(source_buffer)
+
+        # Replace create_source_view with direct Gtk.TextView instantiation
+        source_view = Gtk.TextView()
+        source_buffer = Gtk.TextBuffer()
+        source_view.set_buffer(source_buffer)
+
+        source_view.set_monospace(True)
+        source_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         source_view.set_editable(False)
+        source_view.set_hexpand(True) # Assuming this is desired for layout
+        source_view.set_vexpand(True) # Assuming this is desired for layout
+
+        source_buffer.set_text(human_readable_summary, -1)
+        # Removed: self._apply_source_view_style_to_buffer(source_buffer)
+        # source_view.set_editable(False) # Already set above
+
         scrolled_window = Gtk.ScrolledWindow()
         scrolled_window.set_child(source_view)
-        scrolled_window.set_min_content_height(200)
+        scrolled_window.set_min_content_height(200) # Keep existing size constraints
         scrolled_window.set_max_content_height(400)
         scrolled_window.set_vexpand(True)
         expander.add_row(scrolled_window)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -54,7 +54,7 @@ class Preferences(Adw.PreferencesWindow):
 
     font_scale_combo_row = Gtk.Template.Child("font_scale_combo_row")
     theme_combo_row = Gtk.Template.Child("theme_combo_row")
-    source_style_scheme_combo_row = Gtk.Template.Child("source_style_scheme_combo_row")
+    # Removed: source_style_scheme_combo_row = Gtk.Template.Child("source_style_scheme_combo_row")
     dns_server_entryrow = Gtk.Template.Child("dns_server_entryrow")
     prefs_dns_apply_button = Gtk.Template.Child("prefs_dns_apply_button")
     preferences_error_banner = Gtk.Template.Child("preferences_error_banner")
@@ -126,9 +126,7 @@ class Preferences(Adw.PreferencesWindow):
         """
         self.font_scale_combo_row.connect("notify::selected", self.on_font_scale_changed)
         self.theme_combo_row.connect("notify::selected", self.on_theme_preference_changed)
-        self.source_style_scheme_combo_row.connect(
-            "notify::selected", self.on_source_style_scheme_changed
-        )
+        # Removed: self.source_style_scheme_combo_row.connect(...)
         self.dns_server_entryrow.connect("entry-activated", self.on_dns_server_changed)
         self.prefs_dns_apply_button.connect("clicked", self.on_dns_server_changed)
 
@@ -287,21 +285,7 @@ class Preferences(Adw.PreferencesWindow):
                 selected_theme_str,
             )
 
-    def on_source_style_scheme_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
-        """
-        Handle changes in the source style scheme preference ComboRow.
-
-        Saves the selected style scheme name string to GSettings.
-
-        :param combo_row: The Adw.ComboRow whose selection changed.
-        :type combo_row: Adw.ComboRow
-        :param _gparam: The GLib.ParamSpec of the property that changed (unused).
-        :type _gparam: GObject.ParamSpec
-        """
-        selected_item = combo_row.get_selected_item()
-        if isinstance(selected_item, Gtk.StringObject):
-            source_style_scheme = selected_item.get_string()
-            self.settings.set_string("source-style-scheme", source_style_scheme)
+    # Removed on_source_style_scheme_changed method
 
     @staticmethod
     def _rgba_to_hex(rgba: Gdk.RGBA) -> str:
@@ -526,20 +510,7 @@ class Preferences(Adw.PreferencesWindow):
         if not self._select_combo_row_item(self.theme_combo_row, theme_pref_value):
             self.theme_combo_row.set_selected(0)
 
-        source_style_scheme = self.settings.get_string("source-style-scheme")
-        if not self._select_combo_row_item(
-            self.source_style_scheme_combo_row,
-            source_style_scheme,
-            case_sensitive=False,
-        ):
-            logging.warning(
-                "Style scheme '%s' not found in ComboRow or model is not Gtk.StringList. "
-                "Defaulting might not apply or be index 0.",
-                source_style_scheme,
-            )
-            # Original code didn't set a default for source_style_scheme_combo_row if not found, so we replicate that.
-            # If a default selection (e.g., index 0) is desired, it could be added here:
-            # else: self.source_style_scheme_combo_row.set_selected(0)
+        # Removed loading and setting for source_style_scheme_combo_row
 
         dns_server = self.settings.get_string("custom-dns-server")
         self.dns_server_entryrow.set_text(dns_server)

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,59 +6,16 @@ from urllib.parse import urlparse
 from typing import Tuple, List, Optional # Added Optional
 
 import gi
-from gi.repository import Gtk, GtkSource, Adw
+from gi.repository import Gtk, Adw # Removed GtkSource
 
 gi.require_version("Gtk", "4.0")
-gi.require_version("GtkSource", "5")
+# Removed: gi.require_version("GtkSource", "5")
 gi.require_version("Adw", "1")
 
 logger = logging.getLogger(__name__)
 
 
-def create_source_view(language_name: str = "text") -> Tuple[GtkSource.View, GtkSource.Buffer]:
-    """Create and configure a GtkSource.View and its associated GtkSource.Buffer.
-
-    Sets up common properties for the source view like line numbers, monospace font,
-    wrap mode, auto-indent, and tab behavior. Configures syntax highlighting
-    for the specified language.
-
-    :param language_name: The language ID for syntax highlighting
-                          (e.g., "yaml", "python", "text"). Defaults to "text".
-    :type language_name: str
-    :return: A tuple containing the configured :class:`GtkSource.View` and
-             :class:`GtkSource.Buffer`.
-    :rtype: Tuple[GtkSource.View, GtkSource.Buffer]
-    """
-    language_manager = GtkSource.LanguageManager.get_default()
-    if language_name is None:  # Ensure fallback even if None is explicitly passed
-        language_name = "text" # Changed from "txt"
-    language = language_manager.get_language(language_name)
-
-    if language is None:
-        # Ensure the warning message accurately reflects what was searched for, esp. if default was overridden
-        searched_lang_id = language_name if language_name else "text" # Use "text" if language_name became None then defaulted
-        logger.warning(
-            "GtkSource language '%s' not found. Falling back to a plain buffer.",
-            searched_lang_id, # Use the actual ID that was searched
-        )
-        source_buffer = GtkSource.Buffer()
-    else:
-        source_buffer = GtkSource.Buffer.new_with_language(language)
-        source_buffer.set_highlight_syntax(True)
-
-    source_view = GtkSource.View.new_with_buffer(source_buffer)
-    source_view.set_show_line_numbers(True)
-    source_view.set_monospace(True)
-    source_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-    source_view.set_auto_indent(True)
-    source_view.set_smart_backspace(True)
-    source_view.set_indent_on_tab(True)
-    source_view.set_tab_width(4)
-    source_view.set_insert_spaces_instead_of_tabs(True)
-    source_view.set_highlight_current_line(True)
-    source_view.set_vexpand(True)
-
-    return source_view, source_buffer
+# Removed create_source_view function
 
 
 def show_global_error(widget: Gtk.Widget, message: str):

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -13,15 +13,15 @@ import time # Added for polling loop
 from enum import Enum
 
 import gi
-from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, GtkSource
+from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk # Removed GtkSource
 
 from .constants import RESOURCE_PREFIX, APP_ID
 from .utils import show_global_error, show_global_toast, is_valid_url
-from .style_utils import apply_source_style_scheme
+# Removed: from .style_utils import apply_source_style_scheme
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-gi.require_version("GtkSource", "5")
+# Removed: gi.require_version("GtkSource", "5")
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/webscan_page.ui")
@@ -58,49 +58,40 @@ class WebScanPage(Adw.PreferencesPage):
         """
 
         super().__init__(**kwargs)
-        self.source_view = GtkSource.View()
-        # Every GtkSource.View needs a GtkSource.Buffer
-        source_buffer = GtkSource.Buffer()
+        self.source_view = Gtk.TextView() # Changed from GtkSource.View
+        # Every Gtk.TextView needs a Gtk.TextBuffer
+        source_buffer = Gtk.TextBuffer() # Changed from GtkSource.Buffer
         self.source_view.set_buffer(source_buffer)
 
         self.source_view.set_hexpand(True)
         self.source_view.set_vexpand(True)
         self.source_view.set_monospace(True)
-        self.source_view.set_show_line_numbers(True)
+        # Removed: self.source_view.set_show_line_numbers(True) # GtkSource.View specific
         self.source_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self.source_view.set_editable(False) # Make text view read-only for results
 
         if self.results_scrolled_window:
             self.results_scrolled_window.set_child(self.source_view)
         else:
             # This case should ideally log an error if logger is available
-            # For subtask, direct print might be visible if it runs in a context that shows stdout.
-            print("ERROR: results_scrolled_window is None in __init__, cannot add GtkSource.View.")
+            print("ERROR: results_scrolled_window is None in __init__, cannot add Gtk.TextView.")
 
-        # The existing call to self._apply_webscan_source_view_style() in __init__ will handle
-        # applying the language and style scheme after this setup.
+        # GtkSource.View specific style and language setup is removed.
 
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
         self.current_nikto_process: Optional[subprocess.Popen] = None
         self._current_webscan_params: Optional[Dict[str, Any]] = None
         self.settings = Gio.Settings.new(APP_ID)
-        self.style_manager = Adw.StyleManager.get_default()
+        self.style_manager = Adw.StyleManager.get_default() # Keep for theme checks if needed, or remove if unused
         logger.debug("WebScanPage initialized")
 
-        if self.source_view:
-            buffer = self.source_view.get_buffer()
-            if buffer:
-                lm = GtkSource.LanguageManager.get_default()
-                language = lm.get_language("text")
-                if language:
-                    buffer.set_language(language)
-                else:
-                    logger.warning("GtkSource language '%s' not found. Syntax highlighting may not apply.", "text")
+        # Removed GtkSource.View specific language and style setup
+        # Removed self._apply_webscan_source_view_style() call
 
-        self._apply_webscan_source_view_style() # Initial application
-
-        self.style_manager.connect("notify::dark", self._on_webscan_source_style_settings_changed)
-        self.settings.connect("changed::source-style-scheme", self._on_webscan_source_style_settings_changed)
+        # Removed signal handlers for GtkSourceView style changes
+        # self.style_manager.connect("notify::dark", self._on_webscan_source_style_settings_changed)
+        # self.settings.connect("changed::source-style-scheme", self._on_webscan_source_style_settings_changed)
         self.url_entry.connect("entry-activated", self.on_scan_button_clicked)
         # Connect signal for the cancel button now that it's a template child
         if self.webscan_cancel_button:
@@ -110,56 +101,8 @@ class WebScanPage(Adw.PreferencesPage):
         if self.copy_results_button:
             self.copy_results_button.connect("clicked", self._on_copy_results_clicked)
 
-    def _on_webscan_source_style_settings_changed(self, _manager_or_settings, _param_spec_or_key):
-        """Handle theme or style scheme changes for WebScan's GtkSourceView.
-
-        :param _manager_or_settings: The Adw.StyleManager or Gio.Settings object that emitted the signal.
-        :type _manager_or_settings: Adw.StyleManager or Gio.Settings
-        :param _param_spec_or_key: The GObject.ParamSpec or GSettings key that changed.
-        :type _param_spec_or_key: GObject.ParamSpec or str
-        """
-        logger.info("WebScanPage: Dark theme or source style scheme changed. Applying new style.")
-        self._apply_webscan_source_view_style()
-
-    def _apply_webscan_source_view_style(self):
-        if not hasattr(self, 'source_view') or not self.source_view:
-            # print("DEBUG: _apply_webscan_source_view_style: self.source_view not ready")
-            return
-        buffer = self.source_view.get_buffer()
-        if not buffer:
-            # print("DEBUG: _apply_webscan_source_view_style: buffer not ready")
-            return
-
-        is_dark = self.style_manager.get_dark()
-        user_scheme_name = self.settings.get_string("source-style-scheme")
-        scheme_manager = GtkSource.StyleSchemeManager.get_default()
-        final_scheme_name = "Adwaita" # Default fallback
-
-        if is_dark:
-            if user_scheme_name.lower() in ["adwaita", "default", "classic", "light"]:
-                final_scheme_name = "Adwaita-dark"
-            else:
-                if scheme_manager.get_scheme(user_scheme_name):
-                    final_scheme_name = user_scheme_name
-                else:
-                    # print(f"DEBUG: User scheme '{user_scheme_name}' not found for dark theme, falling back to Adwaita-dark.")
-                    final_scheme_name = "Adwaita-dark"
-        else: # Light theme
-            if user_scheme_name.lower() in ["adwaita-dark", "dark"]:
-                final_scheme_name = "Adwaita"
-            else:
-                if scheme_manager.get_scheme(user_scheme_name):
-                    final_scheme_name = user_scheme_name
-                else:
-                    # print(f"DEBUG: User scheme '{user_scheme_name}' not found for light theme, falling back to Adwaita.")
-                    final_scheme_name = "Adwaita"
-
-        if not scheme_manager.get_scheme(final_scheme_name):
-            # print(f"DEBUG: Scheme '{final_scheme_name}' could not be loaded. Defaulting to basic Adwaita (light/dark).")
-            final_scheme_name = "Adwaita-dark" if is_dark else "Adwaita"
-
-        # print(f"DEBUG: Applying source style scheme: {final_scheme_name} (Dark: {is_dark}, User: {user_scheme_name})")
-        apply_source_style_scheme(scheme_manager, buffer, final_scheme_name)
+    # Removed _on_webscan_source_style_settings_changed method
+    # Removed _apply_webscan_source_view_style method
 
     def __del__(self):
         """Clean up when the WebScanPage is destroyed."""
@@ -584,6 +527,14 @@ class WebScanPage(Adw.PreferencesPage):
                 else:
                     final_stdout = s_out
 
+                # Explicitly unescape literal '\\n' to actual '\n'
+                # This handles cases where ast.literal_eval resulted in a string that still
+                # contains '\\n' (from double-escaped newlines in original source)
+                # or if direct stdout_str contained literal '\\n'.
+                if final_stdout: # Check if not None after potential str() conversion
+                    final_stdout = final_stdout.replace('\\n', '\n')
+                    logger.debug("Applied final .replace('\\\\n', '\\n') to stdout content.")
+
             final_stderr: Optional[str] = None
             if s_err is not None:
                 if not isinstance(s_err, str):
@@ -591,6 +542,9 @@ class WebScanPage(Adw.PreferencesPage):
                     final_stderr = str(s_err)
                 else:
                     final_stderr = s_err
+                # Typically, stderr for Nikto (if not the primary output channel) wouldn't need this,
+                # but if it could also contain such content, apply here too.
+                # For now, focusing on final_stdout as per problem description.
 
             if final_stdout is not None or final_stderr is not None:
                 self._update_textview(final_stdout, final_stderr, is_error_message=False)


### PR DESCRIPTION
…ting prefs

This commit addresses your feedback and refactors UI components:

1.  **Fix Nikto Output Newline Rendering**:
    *   Ensured that Nikto scan output in `WebScanPage` correctly renders newline characters. Literal `\n` sequences in the output string are now converted to actual newlines before display in the `Gtk.TextView`.

2.  **Replace `GtkSource.View` with `Gtk.TextView`**:
    *   In `WebScanPage`, the results display area now uses a standard `Gtk.TextView` instead of `GtkSource.View`. All `GtkSource.View`-specific code, including language settings and style scheme applications, has been removed from this page.
    *   In `NmapPage`, the "Text Scan Summary" expander now uses a standard `Gtk.TextView` for displaying raw Nmap output, replacing the previous `GtkSource.View` instance. `GtkSource.View`-specific styling code has been removed from this page.

3.  **Update `src/utils.py`**:
    *   Removed the `create_source_view` function and its `GtkSource` dependencies as it is no longer used by any part of the application.

4.  **Remove Syntax Highlighting Preferences**:
    *   Removed the "source-style-scheme" GSettings key from `data/com.github.mclellac.woes.gschema.xml`.
    *   Removed the corresponding "Style Scheme" `AdwComboRow` from the preferences dialog UI in `src/gtk/preferences.ui`.
    *   Removed the associated Python code (template child, signal handlers, and preference logic) from `src/preferences.py`.
    *   Removed related signal connections and handlers from `NmapPage` and `WebScanPage` (these were largely cleaned up during the GtkSource.View replacement).

These changes simplify the UI dependencies by removing `GtkSource.View` where it was used for basic text display, make the Nikto output more readable, and streamline your preferences.