### PR TITLE
feat: Integrate Ruff for linting and Tox for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,17 @@ sudo ninja -C build install --verbose
 # Follow instructions in the flatpak directory to install and run.
 ```
 
+## Testing and Linting
+
+This project uses [Tox](https://tox.wiki/) for managing testing and linting environments.
+
+To run all tests and linters, simply execute the following command in the root of the project:
+
+```bash
+tox
+```
+
+This will run the unit tests and the Ruff linter.
+
 ## Development Status
 Early development. HTTP Headers, Nmap, and DNS tools are functional. More features planned.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ target-version = "py310"
 select = ["E4", "E7", "E9", "F", "D"]
 ignore = [
     "E402", # Module level import not at top of file (often needed with Gtk gi.require_version)
+    "D203", # Conflicts with D211
+    "D212", # Conflicts with D213
 ]
 
 # Allow fixes for all enabled rules
@@ -99,3 +101,7 @@ docstring-code-format = false
 
 # Set the line length limit used when formatting code snippets in docstrings.
 docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint.per-file-ignores]
+"src/dns_page.py" = ["C901"]
+"src/http_page.py" = ["E501"]

--- a/run_linter.sh
+++ b/run_linter.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Running Ruff linter..."
-ruff check src/*.py --fix

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Running unit tests..."
-python -m unittest discover -s src/tests

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -482,7 +482,7 @@ class DNSPage(Adw.PreferencesPage):
             self.dns_status_row.set_subtitle(status_subtitle) # type: ignore
 
 
-    def _perform_lookup(self) -> None: # noqa: C901
+    def _perform_lookup(self) -> None:
         """Perform the DNS lookup based on user input and selected record type.
 
         Orchestrates input validation, client interaction, and result/error display.

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -7,7 +7,6 @@ via a :class:`.custom_dns_adapter.CustomDNSAdapter`.
 """
 
 # pylint: disable=too-many-lines
-# ruff: noqa: E501
 import logging
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py310, lint
+isolated_build = True
+
+[testenv]
+deps =
+    requests
+commands =
+    python -m unittest discover -s tests
+
+[testenv:lint]
+deps =
+    ruff
+commands =
+    ruff check .


### PR DESCRIPTION
This commit introduces Ruff for code linting and Tox for managing testing and linting environments.

Key changes:
- Configured Ruff in `pyproject.toml`, including moving in-code linting directives to the configuration file.
- Added a `tox.ini` file to define linting and testing environments.
- Updated `README.md` with instructions on how to use Tox.
- Removed the old `run_linter.sh` and `run_tests.sh` scripts, as their functionality is now covered by Tox.

This setup will help maintain code quality and consistency, and make it easier to run tests and linters in a standardized way.