### PR TITLE
fix: Ensure correct data types from Nikto scan thread

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -563,7 +563,10 @@ class WebScanPage(Adw.PreferencesPage):
                 )
                 return
 
-            task.return_value((main_report_content, aux_output))
+            task.return_value((
+                str(main_report_content) if main_report_content is not None else "",
+                str(aux_output) if aux_output is not None else None
+            ))
         except FileNotFoundError:
             logger.error("Nikto command not found. Ensure it's in PATH.")
             task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.NIKTO_NOT_FOUND.value, "Nikto command not found. Please ensure it is installed and in your system's PATH.") # type: ignore


### PR DESCRIPTION
Corrects the data types returned by `_run_scan_task_thread_func` for the Nikto web scan. This now consistently returns a tuple of (string, Optional[string]) for the main report and auxiliary output, respectively.

This resolves warnings in `_on_scan_task_done` related to unexpected boolean or tuple types and should improve the reliability of UI updates and subsequent scan operations.