### PR TITLE
Revert UI button placement changes

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -22,6 +22,16 @@
                 <property name="valign">center</property>
               </object>
             </child>
+            <child type="suffix">
+              <object class="GtkButton" id="dns_apply_button">
+                <property name="label" translatable="yes">_Lookup</property>
+                <property name="use_underline">True</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
         <child>
@@ -54,24 +64,6 @@
                 <property name="spinning">False</property>
                 <property name="valign">center</property>
                 <property name="visible">False</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow">
-            <property name="activatable">False</property>
-            <property name="focusable">False</property>
-            <property name="hexpand">True</property>
-            <child>
-              <object class="GtkButton" id="dns_apply_button">
-                <property name="label" translatable="yes">_Lookup</property>
-                <property name="use_underline">True</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
               </object>
             </child>
           </object>

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -19,6 +19,16 @@
             <property name="focusable">True</property>
             <property name="input-purpose">url</property>
             <property name="title" translatable="yes">Domain or URL to get the HTTP headers from</property>
+            <child type="suffix">
+              <object class="GtkButton" id="http_apply_button">
+                <property name="label" translatable="yes">_Fetch</property>
+                <property name="use_underline">True</property>
+                <property name="valign">center</property>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
         <child>
@@ -46,24 +56,6 @@
                 <property name="spinning">False</property>
                 <property name="valign">center</property>
                 <property name="visible">False</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow">
-            <property name="activatable">False</property>
-            <property name="focusable">False</property>
-            <property name="hexpand">True</property>
-            <child>
-              <object class="GtkButton" id="http_apply_button">
-                <property name="label" translatable="yes">_Fetch</property>
-                <property name="use_underline">True</property>
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
               </object>
             </child>
           </object>

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -33,6 +33,16 @@
                 <property name="hexpand-set">true</property>
                 <property name="input-purpose">url</property>
                 <property name="title" translatable="yes">Target (IP/CIDR/Hostname)</property>
+                <child type="suffix">
+                  <object class="GtkButton" id="nmap_apply_button">
+                    <property name="label" translatable="yes">_Scan</property>
+                    <property name="use_underline">True</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
@@ -135,24 +145,6 @@
                     <property name="visible">False</property>
                     <style>
                       <class name="destructive-action"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="AdwActionRow">
-                <property name="activatable">False</property>
-                <property name="focusable">False</property>
-                <property name="hexpand">True</property>
-                <child>
-                  <object class="GtkButton" id="nmap_apply_button">
-                    <property name="label" translatable="yes">_Scan</property>
-                    <property name="use_underline">True</property>
-                    <property name="halign">center</property>
-                    <property name="valign">center</property>
-                    <style>
-                      <class name="suggested-action"/>
                     </style>
                   </object>
                 </child>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -17,6 +17,17 @@
         <child>
           <object class="AdwEntryRow" id="url_entry">
             <property name="title">Target URL</property>
+            <child type="suffix">
+              <object class="GtkButton" id="scan_button">
+                <property name="halign">end</property>
+                <property name="label">Start Scan</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_scan_button_clicked"/>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
         <child>
@@ -175,24 +186,6 @@
                     <property name="visible">False</property>
                   </object>
                 </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwActionRow">
-            <property name="activatable">False</property>
-            <property name="focusable">False</property>
-            <property name="hexpand">True</property>
-            <child>
-              <object class="GtkButton" id="scan_button">
-                <property name="halign">center</property>
-                <property name="label">Start Scan</property>
-                <property name="valign">center</property>
-                <signal name="clicked" handler="on_scan_button_clicked"/>
-                <style>
-                  <class name="suggested-action"/>
-                </style>
               </object>
             </child>
           </object>


### PR DESCRIPTION
This commit reverts the placement of action buttons in the DNS, HTTP, NMAP, and Webscan page UI files (`.ui`). The buttons have been returned to their original positions within their respective entry rows.

This reversion is based on your feedback indicating that the previous change (moving buttons to dedicated AdwActionRows) did not resolve the intended accent color issue.

The docstring and comment improvements from the prior commit (related to general code documentation) are maintained and are not affected by this UI-specific revert.