### PR TITLE
I've updated `src/gtk/window.ui` to ensure all tool pages (HTTP, Nmap…

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -49,19 +49,19 @@
                   <object class="AdwStatusPage" id="http_status_page">
                     <property name="description">This tool is ideal for developers, as well as systems and network administrators, who need to inspect HTTP headers for debugging, troubleshooting, and security analysis.</property>
                     <property name="icon-name" bind-source="http_page" bind-property="icon-name" bind-flags="sync-create"/>
-                    <property name="overflow">hidden</property>
+                    <property name="margin-end">15</property>
+                    <property name="margin-start">15</property>
                     <property name="title" bind-source="http_page" bind-property="title" bind-flags="sync-create"/>
                     <property name="valign">start</property>
                     <child>
-                      <object class="AdwClampScrollable" id="http_clamp_scrollable">
+                      <object class="AdwClampScrollable">
                         <property name="maximum-size">1400</property>
-                        <property name="tightening-threshold">500</property>
                         <property name="unit">px</property>
+                        <property name="vexpand">True</property>
                         <child>
                           <object class="GtkBox" id="HttpPage">
                             <child>
                               <object class="HttpPage">
-                                <property name="overflow">hidden</property>
                               </object>
                             </child>
                           </object>
@@ -82,22 +82,26 @@
                   <object class="AdwStatusPage" id="nmap_status_page">
                     <property name="description">This tool is designed to facilitate network scanning, reconnaissance, and exploit detection using Nmap, a powerful network scanning tool. This interface provides the capability to perform various types of scans, including &lt;b&gt;service detection&lt;/b&gt;, &lt;b&gt;OS fingerprinting&lt;/b&gt;, &lt;b&gt;port scanning&lt;/b&gt;, and &lt;b&gt;vulnerability assessments&lt;/b&gt; using the &lt;i&gt;Nmap Scripting Engine (NSE)&lt;/i&gt;.</property>
                     <property name="icon-name" bind-source="nmap_page" bind-property="icon-name" bind-flags="sync-create"/>
+                    <property name="margin-end">15</property>
+                    <property name="margin-start">15</property>
                     <property name="title" bind-source="nmap_page" bind-property="title" bind-flags="sync-create">Port Scanning</property>
-                    <property name="vexpand">true</property>
-                    <property name="vexpand-set">true</property>
+                    <property name="valign">start</property>
                     <child>
-                      <object class="GtkBox" id="NmapPage">
-                        <property name="height-request">1000</property>
-                        <property name="hexpand">true</property>
-                        <property name="hexpand-set">true</property>
-                        <property name="valign">center</property>
-                        <property name="vexpand">true</property>
-                        <property name="vexpand-set">true</property>
+                      <object class="AdwClampScrollable">
+                        <property name="maximum-size">1400</property>
+                        <property name="unit">px</property>
+                        <property name="vexpand">True</property>
                         <child>
-                          <object class="NmapPage">
+                          <object class="GtkBox" id="NmapPage">
                             <property name="hexpand">true</property>
                             <property name="hexpand-set">true</property>
-                            <property name="vexpand">true</property>
+                            <child>
+                              <object class="NmapPage">
+                                <property name="hexpand">true</property>
+                                <property name="hexpand-set">true</property>
+                                <property name="vexpand">true</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -147,24 +151,30 @@
               <object class="AdwViewStackPage" id="webscan_page">
                 <property name="child">
                   <object class="AdwStatusPage" id="webscan_status_page">
-                    <property name="child">
-                      <object class="GtkBox" id="webscan_box">
-                        <property name="orientation">vertical</property>
-                        <property name="valign">start</property> <!-- Changed to start for better layout with PreferencesPage -->
-                        <property name="vexpand">true</property>
+                    <property name="description" translatable="yes">The Web Scan tool helps identify common web vulnerabilities by using popular scanning tools to analyze the target URL.</property>
+                    <property name="icon-name" bind-source="webscan_page" bind-property="icon-name" bind-flags="sync-create">org.gnome.Loupe-symbolic</property>
+                    <property name="margin-end">15</property>
+                    <property name="margin-start">15</property>
+                    <property name="title" bind-source="webscan_page" bind-property="title" bind-flags="sync-create">Web Scanner</property>
+                    <property name="valign">start</property>
+                    <child>
+                      <object class="AdwClampScrollable">
+                        <property name="maximum-size">1400</property>
+                        <property name="unit">px</property>
+                        <property name="vexpand">True</property>
                         <child>
-                          <object class="WebScanPage">
-                            <property name="hexpand">true</property>
-                            <property name="vexpand">true</property>
+                          <object class="GtkBox" id="webscan_box">
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="WebScanPage">
+                                <property name="hexpand">true</property>
+                                <property name="vexpand">true</property>
+                              </object>
+                            </child>
                           </object>
                         </child>
                       </object>
-                    </property>
-                    <property name="icon-name" bind-source="webscan_page" bind-property="icon-name" bind-flags="sync-create">org.gnome.Loupe-symbolic</property>
-                    <property name="title" bind-source="webscan_page" bind-property="title" bind-flags="sync-create">Web Scanner</property>
-                    <property name="valign">start</property>
-                    <property name="vexpand">true</property>
-                    <property name="vexpand-set">true</property>
+                    </child>
                   </object>
                 </property>
                 <property name="icon-name">face-cool</property>


### PR DESCRIPTION
…, WebScan) consistently use the same embedding structure as the DNS page, which correctly displays accent colors. This involves wrapping the page content within an `AdwStatusPage` -> `AdwClampScrollable` -> `GtkBox` -> PageObject hierarchy.

Here's what I changed:
- I restructured the HTTP, Nmap, and WebScan page sections in `window.ui`.
  - I introduced `AdwClampScrollable` where it was missing (Nmap, WebScan).
  - I aligned properties (margins, vexpand, etc.) of `AdwStatusPage` and `AdwClampScrollable` across all pages to match the DNS page's setup.
  - I removed potentially conflicting properties from child elements (e.g., `overflow="hidden"` from HttpPage object, sizing properties from GtkBoxes now managed by AdwClampScrollable).
- I added a description for you to the `AdwStatusPage` for the WebScan tool, explaining its purpose.

This refactoring aims to resolve inconsistencies in how pages were embedded, which I suspected was the cause of issues with accent colors not appearing correctly on some pages.