### PR TITLE
Fix: Ensure accent colors on suggested/destructive action buttons

### DIFF
--- a/src/gtk/style-dark.css
+++ b/src/gtk/style-dark.css
@@ -12,3 +12,20 @@
     background-color: rgba(74, 144, 226, 0.1); /* Lighter blueish background for dark theme */
     border-left: 3px solid rgba(74, 144, 226, 0.7); /* Lighter blueish border for dark theme */
 }
+
+/* Ensure accent colors on buttons are not overridden by text-button styling */
+button.suggested-action,
+button.suggested-action.text-button {
+    background-image: none;
+    background-color: var(--accent-bg-color);
+    color: var(--accent-fg-color);
+    border-color: var(--accent-bg-color); /* Or var(--accent-color) for more contrast */
+}
+
+button.destructive-action,
+button.destructive-action.text-button {
+    background-image: none;
+    background-color: var(--destructive-bg-color);
+    color: var(--destructive-fg-color);
+    border-color: var(--destructive-bg-color); /* Or var(--destructive-color) for more contrast */
+}

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -20,3 +20,20 @@
     background-color: rgba(0, 120, 212, 0.08); /* Light blueish background */
     border-left: 3px solid rgba(0, 120, 212, 0.7); /* Blueish border */
 }
+
+/* Ensure accent colors on buttons are not overridden by text-button styling */
+button.suggested-action,
+button.suggested-action.text-button {
+    background-image: none;
+    background-color: var(--accent-bg-color);
+    color: var(--accent-fg-color);
+    border-color: var(--accent-bg-color); /* Or var(--accent-color) for more contrast */
+}
+
+button.destructive-action,
+button.destructive-action.text-button {
+    background-image: none;
+    background-color: var(--destructive-bg-color);
+    color: var(--destructive-fg-color);
+    border-color: var(--destructive-bg-color); /* Or var(--destructive-color) for more contrast */
+}


### PR DESCRIPTION
Problem:
The 'text-button' CSS class, applied by GTK/Adwaita to GtkButtons (especially text-only ones), was overriding the background color intended for '.suggested-action' and '.destructive-action' buttons. This caused them to lose their accent colors.

Solution:
I added CSS rules to style.css and style-dark.css to explicitly set the 'background-color', 'color', and 'border-color' for 'button.suggested-action' and 'button.destructive-action' using Adwaita's standard CSS variables (e.g., var(--accent-bg-color)). These rules also apply when the 'text-button' class is present, ensuring the accent styles take precedence and are correctly displayed. The 'background-image: none;' property is also included to prevent potential interference from other styles.

This change ensures that action buttons consistently display their intended accent colors as per Adwaita design language.