### PR TITLE
Fix: Programmatically ensure style classes on page buttons

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -136,6 +136,15 @@ class HttpPage(Adw.PreferencesPage):
         self._connect_signals()
         self._update_user_agent_model()
         self.settings.connect("changed::custom-user-agents", lambda _s, _k: self._update_user_agent_model())
+
+        # Ensure correct style classes are applied
+        if self.http_apply_button:
+            self.http_apply_button.get_style_context().add_class("suggested-action")
+        if self.clear_results_button:
+            self.clear_results_button.get_style_context().add_class("destructive-action")
+        if self.copy_results_button:
+            self.copy_results_button.get_style_context().add_class("flat")
+
         if self.http_host_header_row:
             self._on_host_header_changed(self.http_host_header_row)
         if self.http_user_agent_row:

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -101,6 +101,12 @@ class NmapPage(Adw.PreferencesPage):
         self.scanner = NmapScanner()
         self.settings = Gio.Settings.new(APP_ID)
 
+        # Ensure correct style classes are applied
+        if self.nmap_apply_button:
+            self.nmap_apply_button.get_style_context().add_class("suggested-action")
+        if self.nmap_cancel_scan_button: # This button's visibility is toggled
+            self.nmap_cancel_scan_button.get_style_context().add_class("destructive-action")
+
         self.current_nmap_task: Optional[Gio.Task] = None
         self.current_nmap_cancellable: Optional[Gio.Cancellable] = None
         self._current_nmap_scan_params: Optional[Dict[str, Any]] = None

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -79,6 +79,19 @@ class WebScanPage(Adw.PreferencesPage):
         self._current_webscan_params: Optional[Dict[str, Any]] = None
         self.settings = Gio.Settings.new(APP_ID)
         self.style_manager = Adw.StyleManager.get_default()
+
+        # Ensure correct style classes are applied
+        if self.scan_button:
+            self.scan_button.get_style_context().add_class("suggested-action")
+        if self.webscan_cancel_button: # This button's visibility is toggled; ensure class is present from init
+            self.webscan_cancel_button.get_style_context().add_class("destructive-action")
+        if self.clear_results_button:
+            self.clear_results_button.get_style_context().add_class("destructive-action")
+        if self.copy_results_button:
+            self.copy_results_button.get_style_context().add_class("flat")
+        if self.nikto_output_file_button: # Assuming flat is appropriate for this icon button
+            self.nikto_output_file_button.get_style_context().add_class("flat")
+
         logger.debug("WebScanPage initialized")
 
         self.url_entry.connect("entry-activated", self.on_scan_button_clicked)


### PR DESCRIPTION
Problem:
Follow-up to the previous fix. Your feedback indicated that '.suggested-action' and similar classes were still missing from buttons on HTTP, WebScan, and Nmap pages, with only 'text-button' being present. This prevented the CSS overrides for '.suggested-action.text-button' from working correctly on those pages. The DNS page buttons were reportedly working as expected.

Hypothesis:
The issue might stem from how AdwEntryRow (used in HTTP, WebScan, Nmap for input rows with action buttons) handles its suffix GtkButton children, possibly by not applying or by stripping style classes defined in the .ui files. AdwActionRow (used in DNS page) might not exhibit this behavior.

Solution:
This change programmatically adds the intended style classes (e.g., 'suggested-action', 'destructive-action', 'flat') to the relevant Gtk.Template.Child buttons within the __init__ method of their respective page classes (HttpPage, WebScanPage, NmapPage).

This ensures that the buttons have the necessary base classes applied. The existing CSS overrides in style.css and style-dark.css (from the previous commit) should then correctly resolve any styling conflicts if Adwaita also applies the 'text-button' class.