### PR TITLE
Fix: Correct shortcut activation and update Nikto scan options

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -303,16 +303,39 @@ class WoesApplication(Adw.Application):
             logging.warning(f"{action_description} action: Window or stack not available.")
             return
 
-        page_name = self.win.stack.get_visible_child_name()
-        page_object = self.win.stack.get_visible_child()
+        current_page_name = self.win.stack.get_visible_child_name()
+        visible_stack_page = self.win.stack.get_visible_child() # This is AdwViewStackPage
 
-        if page_name == expected_page_name and page_object:
-            if hasattr(page_object, action_method_name):
-                getattr(page_object, action_method_name)()
+        if current_page_name == expected_page_name and visible_stack_page:
+            # Navigate down the hierarchy:
+            # AdwViewStackPage -> AdwStatusPage -> AdwClampScrollable -> GtkBox -> Actual Page Object
+            status_page = visible_stack_page.get_child()
+            if not status_page:
+                logging.warning(f"{action_description} action: StatusPage not found for {current_page_name}.")
+                return
+
+            clamp_scrollable = status_page.get_child()
+            if not clamp_scrollable:
+                logging.warning(f"{action_description} action: ClampScrollable not found for {current_page_name}.")
+                return
+
+            page_box = clamp_scrollable.get_child()
+            if not page_box:
+                logging.warning(f"{action_description} action: PageBox (GtkBox) not found for {current_page_name}.")
+                return
+
+            actual_page_object = page_box.get_first_child() # Assuming the page instance is the first child of the GtkBox
+
+            if actual_page_object:
+                if hasattr(actual_page_object, action_method_name):
+                    logging.debug(f"Attempting to call {action_method_name} on {type(actual_page_object)} for page {current_page_name}")
+                    getattr(actual_page_object, action_method_name)()
+                else:
+                    logging.warning(f"Actual page object for {current_page_name} (type: {type(actual_page_object)}) does not have method '{action_method_name}'.")
             else:
-                logging.warning(f"{expected_page_name.capitalize()} page object does not have a '{action_method_name}' method.")
-        elif page_name == expected_page_name: # page_object is None
-            logging.warning(f"{expected_page_name.capitalize()} page object is None, cannot trigger {action_method_name}.")
+                logging.warning(f"Could not retrieve actual page object for {current_page_name}.")
+        elif current_page_name == expected_page_name: # visible_stack_page is None
+            logging.warning(f"{action_description} action: AdwViewStackPage for {current_page_name} is None.")
         # No warning if it's not the expected_page_name page, as the action is specific to that page.
 
     def on_page_action_http_fetch(self, _action: Gio.SimpleAction, _param: Optional[GLib.Variant]):

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -444,8 +444,14 @@ class WebScanPage(Adw.PreferencesPage):
             nikto_command.append('-ssl')
         if evasion_active:
             nikto_command.extend(['-evasion', '1'])
+
+        # Add the new -Plugin option if mutate_switch was active:
         if mutate_active:
-            nikto_command.extend(['-mutate', '1'])
+            # Plugin argument based on the deprecation message in user feedback
+            plugin_argument = "@@DEFAULT;tests(,all)"
+            nikto_command.extend(['-Plugin', plugin_argument]) # Using singular -Plugin as per error message
+            logger.info(f"Using -Plugin {plugin_argument} instead of deprecated -mutate.")
+
         if maxtime_str:
             try:
                 maxtime_val = int(maxtime_str)
@@ -588,6 +594,14 @@ class WebScanPage(Adw.PreferencesPage):
             main_report_content = main_report_content.replace('\\n', '\n')
             logger.debug("Applied newline unescaping to main_report_content.")
 
+            rfi_warning = '- ***** RFIURL is not defined in nikto.conf--no RFI tests will run *****'
+            if main_report_content and rfi_warning in main_report_content:
+                main_report_content = main_report_content.replace(rfi_warning, '').strip()
+                # If removing the warning makes the content empty, set to None or empty string based on preference
+                if not main_report_content.strip():
+                    main_report_content = "" # Or None, depending on how empty strings are handled later
+                logger.info("Filtered RFIURL warning from Nikto's main_report_content.")
+
             if aux_output is not None:
                 if not isinstance(aux_output, str):
                     logger.warning(f"aux_output was type {type(aux_output)}, converting to string. Value (first 100 chars): {str(aux_output)[:100]}")
@@ -599,6 +613,12 @@ class WebScanPage(Adw.PreferencesPage):
                 elif aux_output:
                      aux_output = aux_output.replace('\\n', '\n')
                      logger.debug("Applied newline unescaping to aux_output.")
+
+            if aux_output and rfi_warning in aux_output:
+                aux_output = aux_output.replace(rfi_warning, '').strip()
+                if not aux_output.strip():
+                    aux_output = None # aux_output is often None if empty
+                logger.info("Filtered RFIURL warning from Nikto's aux_output.")
 
 
             if process.returncode not in [0, 1]:


### PR DESCRIPTION
This commit addresses issues with keyboard shortcut activation and refines Nikto scan parameters based on your feedback.

Keyboard Shortcuts:
- I modified the `_trigger_page_action` method in `WoesApplication` (`src/main.py`) to correctly retrieve the actual page widget instance from the `AdwViewStack`. Previously, it might have been targeting a wrapper widget (e.g., `AdwStatusPage`), causing `hasattr` checks for page-specific methods like `trigger_scan` to fail. The method now traverses the widget hierarchy (AdwViewStackPage -> AdwStatusPage -> AdwClampScrollable -> GtkBox -> Actual Page Object) to ensure the correct page instance is found and its action method is called. This should restore functionality for keyboard shortcuts like <Alt>F, <Alt>S, etc.

Nikto Scan Options (`src/webscan_page.py`):
- The warning message "- ***** RFIURL is not defined in nikto.conf--no RFI tests will run *****" is now filtered from Nikto's standard error output before being displayed in the results view. This reduces noise for you.
- The deprecated `-mutate 1` Nikto command-line option has been replaced. When the corresponding "Mutation" switch is enabled in the UI, the scan now uses the `-Plugin @@DEFAULT;tests(,all)` argument, as suggested by Nikto's deprecation message.