### PR TITLE
fix: Correct Pango enum usage and ensure CSS font styling for TextViews

### DIFF
--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -81,12 +81,6 @@ class WebScanPage(Adw.PreferencesPage):
         self.settings = Gio.Settings.new(APP_ID)
         self.style_manager = Adw.StyleManager.get_default()
 
-        # Global Font setting
-        self._output_font_gsettings_key = "output-font"
-        output_font_str = self.settings.get_string(self._output_font_gsettings_key)
-        # Defaulting to Monospace 10 for this view as it's typical for raw output
-        self._output_font_desc = Pango.FontDescription.from_string(output_font_str if output_font_str else "Monospace 10")
-
         # Ensure correct style classes are applied
         if self.scan_button:
             self.scan_button.get_style_context().add_class("suggested-action")
@@ -126,33 +120,7 @@ class WebScanPage(Adw.PreferencesPage):
         if self.nikto_output_file_button:
             self.nikto_output_file_button.connect("clicked", self._on_nikto_output_file_button_clicked)
 
-        # Connect GSettings change for global font
-        self.settings.connect(f"changed::{self._output_font_gsettings_key}", self._on_global_output_font_changed)
-
-        self._apply_font_to_textview() # Apply initial font
         self._update_results_actions_sensitivity()
-
-    def _on_global_output_font_changed(self, settings: Gio.Settings, key: str) -> None:
-        logger.debug("WebScanPage: Global output font setting changed for key: %s", key)
-        if key == self._output_font_gsettings_key:
-            output_font_str = settings.get_string(key)
-            # Default to Monospace 10 if global is not set or invalid for this view's typical content
-            self._output_font_desc = Pango.FontDescription.from_string(output_font_str if output_font_str else "Monospace 10")
-            self._apply_font_to_textview() # Call existing method to apply
-
-    def _apply_font_to_textview(self) -> None:
-        """Apply the current font family and size to the source_view."""
-        if not hasattr(self, 'source_view') or not self.source_view:
-            logger.warning("WebScanPage: _apply_font_to_textview called but source_view does not exist.")
-            return
-
-        if self._output_font_desc and self._output_font_desc.get_size() > 0:
-            self.source_view.override_font(self._output_font_desc)
-            logger.debug(f"WebScanPage: Applied font '{self._output_font_desc.to_string()}' to source_view.")
-        else:
-            # Fallback to theme default if the description is somehow invalid or empty
-            self.source_view.override_font(Pango.FontDescription())
-            logger.debug("WebScanPage: Cleared font override on source_view (invalid/default font_desc).")
 
     def __del__(self):
         """Clean up when the WebScanPage is destroyed."""

--- a/src/window.py
+++ b/src/window.py
@@ -133,13 +133,13 @@ class WoesWindow(Adw.ApplicationWindow):
         safe_family = family.replace("'", "\\'") if family else "Sans" # Escape single quotes for CSS
 
         size_pt = font_desc.get_size() / Pango.SCALE
-        weight = font_desc.get_weight().value
-        style_enum_val = font_desc.get_style().value
+        weight = font_desc.get_weight() # Corrected: Direct value
+        style_enum_val = font_desc.get_style() # Corrected: Direct enum member
 
         css_style_map = {
-            Pango.Style.NORMAL.value: "normal",
-            Pango.Style.OBLIQUE.value: "oblique",
-            Pango.Style.ITALIC.value: "italic",
+            Pango.Style.NORMAL: "normal", # Corrected: Use enum member as key
+            Pango.Style.OBLIQUE: "oblique",
+            Pango.Style.ITALIC: "italic",
         }
 
         # Construct CSS string using f-string (which is fine inside Python code)


### PR DESCRIPTION
This commit addresses two main issues:
1. An `AttributeError` in `window.py` related to incorrect usage of `Pango.Weight` and `Pango.Style` enum values when generating CSS.
2. Persistent `AttributeError`s on `Gtk.TextView` in `webscan_page.py` (and potentially `nmap_page.py` if old code paths were hit), ensuring these pages exclusively use the CSS-based styling mechanism for their TextViews.

Corrections:

1.  **Pango Enum Usage in `WoesWindow` (`src/window.py`):**
    *   In the `update_textview_font_style` method, `font_desc.get_weight()`
      and `font_desc.get_style()` are now used directly to get the
      integer enum values for Pango.Weight and Pango.Style respectively.
      The incorrect `.value` attribute access has been removed.
    *   The `css_style_map` for `Pango.Style` now correctly uses the
      `Pango.Style` enum members (e.g., `Pango.Style.NORMAL`) as keys.

2.  **Exclusive CSS Styling for TextViews:**
    *   Verified and ensured that `src/webscan_page.py` and `src/nmap_page.py`
      have all direct font manipulation methods (`_apply_font_to_textview`,
      `override_font`, `modify_font` calls on their TextViews) and
      class-specific GSettings listeners for "output-font" removed.
    *   These pages now solely rely on the global CSS styling applied by
      `WoesWindow` based on the `set_name()` calls
      ("webscan-output-textview", "nmap-raw-output-textview").

These changes should resolve the runtime AttributeErrors and ensure that font preferences (including family, size, weight, and style) are correctly and robustly applied to all designated output areas, particularly the Gtk.TextView widgets in the Nmap and WebScan pages.