### PR TITLE
Fix: Refine CSS generation to mitigate Gtk-WARNING

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -146,8 +146,8 @@ class WoesWindow(Adw.ApplicationWindow):
         css_string = (
             f"#nmap-raw-output-textview text, #webscan-output-textview text {{"
             f"font-family: '{safe_family}'; "
-            f"font-size: {size_pt}pt; "
-            f"font-weight: {weight}; "
+            f"font-size: {str(size_pt).replace(',', '.')}pt; "
+            f"font-weight: {int(weight)}; "
             f"font-style: {css_style_map.get(style_enum_val, 'normal')};"
             f"}}"
         )


### PR DESCRIPTION
Explicitly formats font-weight as an integer and ensures font-size uses a period for the decimal point in the CSS applied to Nmap and Webscan TextViews.

This is an attempt to address a Gtk-WARNING "Theme parser error: Expected a number" that could occur when certain fonts were selected. While the previous CSS formatting was technically correct, this more explicit approach may satisfy a stricter parsing path in GTK's CSS loader.