### PR TITLE
Fix(ui): Apply font preferences correctly to Nmap/Webscan TextViews

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -144,7 +144,7 @@ class WoesWindow(Adw.ApplicationWindow):
 
         # Construct CSS string using f-string (which is fine inside Python code)
         css_string = (
-            f"#nmap-raw-output-textview text, #webscan-output-textview text {{"
+            f"#nmap-raw-output-textview, #webscan-output-textview {{"
             f"font-family: '{safe_family}'; "
             f"font-size: {str(size_pt).replace(',', '.')}pt; "
             f"font-weight: {int(weight)}; "


### PR DESCRIPTION
Your font preferences, set via the Gtk.FontButton in the preferences dialog and stored in the "output-font" GSetting, were not being correctly applied to the Gtk.TextView widgets on the Nmap and Webscan pages.

The `WoesWindow.update_textview_font_style` method was generating CSS that targeted the `text` sub-node of the TextViews (e.g., `#nmap-raw-output-textview text`).

This commit changes the CSS selector to target the Gtk.TextView widgets directly (e.g., `#nmap-raw-output-textview`). Font properties set on the widget itself are typically inherited by its `text` sub-node. This change ensures the custom font is applied as intended.

The specific TextViews are:
- Nmap page: `#nmap-raw-output-textview`
- Webscan page: `#webscan-output-textview`

This maintains UI consistency by using the established mechanism for styling these specific output areas.