### PR TITLE
Hi there! Here's a summary of the recent changes:

### DIFF
--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -71,5 +71,10 @@
       <summary>Font for tool output areas</summary>
       <description>Sets the font family and size for text in HTTP, DNS, Nmap, and WebScan result views. Format is "FamilyName [Style] Size", e.g., "Ubuntu Mono 11".</description>
     </key>
+  <key name="default-user-agent-title" type="s">
+    <default>""</default>
+    <summary>Default User-Agent Title</summary>
+    <description>The title of the User-Agent to be used by default on the HTTP page. Empty means system default or no override.</description>
+  </key>
   </schema>
 </schemalist>

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -184,6 +184,19 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwPreferencesGroup" id="default_ua_settings_group">
+            <property name="title" translatable="yes">Default User-Agent</property>
+            <property name="description" translatable="yes">Choose the User-Agent to be active when the application starts.</property>
+            <child>
+              <object class="AdwComboRow" id="default_ua_combo_row">
+                <property name="title" translatable="yes">Startup User-Agent</property>
+                <property name="subtitle" translatable="yes">This User-Agent will be selected by default on the HTTP page.</property>
+                <!-- The model will be populated from code -->
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -771,6 +771,51 @@ class HttpPage(Adw.PreferencesPage):
         self._on_user_agent_changed(self.http_user_agent_row, None)  # Update visual cue
         logging.info("User-Agent dropdown model updated with %d titles.", len(display_titles))
 
+        # Apply default User-Agent from preferences
+        default_ua_title_pref = self.settings.get_string("default-user-agent-title")
+        model = self.http_user_agent_row.get_model() # type: ignore
+
+        if isinstance(model, Gtk.StringList):
+            target_selection_idx = -1
+            if default_ua_title_pref and default_ua_title_pref != "[System Default]":
+                # Try to find the preferred default title
+                for i in range(model.get_n_items()):
+                    if model.get_string(i) == default_ua_title_pref:
+                        target_selection_idx = i
+                        logging.info(f"HTTP Page: Setting User-Agent to preferred default: '{default_ua_title_pref}' at index {i}.")
+                        break
+                if target_selection_idx == -1:
+                    logging.warning(f"HTTP Page: Preferred default User-Agent title '{default_ua_title_pref}' not found in combo box. Falling back to 'None'.")
+                    # Fallback to "None" if preferred default is not found
+                    for i in range(model.get_n_items()):
+                        if model.get_string(i) == "None": # "None" is explicitly added in _update_user_agent_model
+                            target_selection_idx = i
+                            logging.info(f"HTTP Page: Selected 'None' User-Agent as fallback at index {i}.")
+                            break
+            else:
+                # Default title is empty or "[System Default]", so select the "None" option.
+                for i in range(model.get_n_items()):
+                    if model.get_string(i) == "None": # "None" is explicitly added in _update_user_agent_model
+                        target_selection_idx = i
+                        logging.info(f"HTTP Page: User-Agent set to system default ('None') at index {i}.")
+                        break
+
+            if target_selection_idx != -1:
+                self.http_user_agent_row.set_selected(target_selection_idx) # type: ignore
+            elif model.get_n_items() > 0:
+                # Absolute fallback: if "None" wasn't found for some reason, select the first item.
+                self.http_user_agent_row.set_selected(0) # type: ignore
+                logging.warning("HTTP Page: Could not find 'None' or preferred User-Agent. Defaulting to first item (index 0).")
+            else:
+                logging.warning("HTTP Page: User-Agent ComboBox is empty, cannot set default.")
+
+        else:
+            logging.warning("HTTP Page: User-Agent ComboBox model is not Gtk.StringList, cannot set default.")
+
+        # Ensure visual cue is updated after setting the default, again.
+        # The previous call to _on_user_agent_changed was before this default logic.
+        self._on_user_agent_changed(self.http_user_agent_row, None) # type: ignore
+
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:
         """
         Create a Gtk.SignalListItemFactory for Gtk.ColumnView columns.

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -16,7 +16,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, Gio, Gtk, GLib, GObject, Gdk
 
 # Local application imports
-from .constants import APP_ID, RESOURCE_PREFIX
+from .constants import APP_ID, RESOURCE_PREFIX, USER_AGENTS
 
 # Conditional import for dnspython
 try:
@@ -71,6 +71,9 @@ class Preferences(Adw.PreferencesWindow):
 
     # Global Font Preference UI Element
     global_output_font_button = Gtk.Template.Child("global_output_font_button")
+
+    # Default User Agent UI
+    default_ua_combo_row = Gtk.Template.Child("default_ua_combo_row")
 
 
     def __init__(self, main_window: Optional[Gtk.Window] = None):
@@ -157,6 +160,27 @@ class Preferences(Adw.PreferencesWindow):
         if self.global_output_font_button:
             self.global_output_font_button.connect("font-set", self.on_global_font_setting_changed)
 
+        # Default User Agent Signal
+        if self.default_ua_combo_row: # Check if it exists
+            self.default_ua_combo_row.connect("notify::selected-item", self._on_default_ua_selection_changed)
+        else:
+            logging.warning("default_ua_combo_row is None in load_ui, cannot connect signal.")
+
+
+    def _on_default_ua_selection_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
+        selected_item_obj = combo_row.get_selected_item()
+        if isinstance(selected_item_obj, Gtk.StringObject):
+            selected_title = selected_item_obj.get_string()
+            if selected_title == "[System Default]":
+                self.settings.set_string("default-user-agent-title", "")
+                logging.debug("Default User-Agent set to System Default (empty string in GSettings).")
+            else:
+                self.settings.set_string("default-user-agent-title", selected_title)
+                logging.debug(f"Default User-Agent title set to: {selected_title}")
+        elif selected_item_obj is None:
+            # This might happen if the model is cleared or selection is removed
+            self.settings.set_string("default-user-agent-title", "")
+            logging.debug("Default User-Agent selection cleared, set to System Default.")
 
     def on_global_font_setting_changed(self, font_button: Gtk.FontButton):
         """
@@ -520,3 +544,42 @@ class Preferences(Adw.PreferencesWindow):
                 self.global_output_font_button.set_font(default_font)
                 self.settings.set_string("output-font", default_font)
                 logging.warning(f"GSettings 'output-font' was empty, set to default: {default_font}")
+
+        # Default User Agent
+        if self.default_ua_combo_row: # Check if it exists
+            self._populate_default_ua_combo_row() # Populate before trying to set selection
+            default_ua_title_pref = self.settings.get_string("default-user-agent-title")
+            if not self._select_combo_row_item(self.default_ua_combo_row, default_ua_title_pref if default_ua_title_pref else "[System Default]"):
+                logging.warning(f"Could not select default UA '{default_ua_title_pref}' in preferences ComboRow.")
+                self.default_ua_combo_row.set_selected(0) # Default to "[System Default]"
+        else:
+            logging.warning("default_ua_combo_row is None in load_preferences.")
+
+    def _populate_default_ua_combo_row(self):
+        if not self.default_ua_combo_row:
+            logging.warning("Default User-Agent ComboRow not found in Preferences UI.")
+            return
+
+        ua_titles = ["[System Default]"] # Special first item
+
+        # Add predefined User-Agents
+        for ua_dict in USER_AGENTS: # USER_AGENTS is a list of dicts
+            title = ua_dict.get("title")
+            if title:
+                ua_titles.append(title)
+
+        # Add custom User-Agents
+        variant = self.settings.get_value("custom-user-agents")
+        custom_ua_pairs = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else [])
+        for title, _ in custom_ua_pairs:
+            if title not in ua_titles: # Avoid duplicates
+                ua_titles.append(title)
+
+        # For now, keep the order: System Default, Predefined, Custom (as appended)
+        # If sorting is desired later, it can be implemented here. Example:
+        # predefined_and_custom_titles = sorted(list(set(ua_titles) - {"[System Default]"}), key=str.lower)
+        # final_ua_titles = ["[System Default]"] + predefined_and_custom_titles
+
+        string_list = Gtk.StringList.new(ua_titles)
+        self.default_ua_combo_row.set_model(string_list)
+        logging.debug("Populated default User-Agent ComboRow with %d items.", len(ua_titles))


### PR DESCRIPTION
**Feat: Allow setting a default User-Agent in preferences**

This update introduces functionality allowing you to select a default User-Agent string in the application preferences. This selected User-Agent will be automatically applied when the HTTP page is loaded.

Key changes:

1.  **GSettings Schema (`data/com.github.mclellac.woes.gschema.xml`):**
    *   I added a new string key `default-user-agent-title`. This key stores the title of the User-Agent chosen as the default. An empty string signifies that the system default (no override) should be used.

2.  **Preferences UI (`src/gtk/preferences.ui`):**
    *   I added a new `Adw.PreferencesGroup` for "Default User-Agent" settings.
    *   I included an `Adw.ComboRow` (`default_ua_combo_row`) allowing you to select your preferred default User-Agent.

3.  **Preferences Logic (`src/preferences.py`):**
    *   The `default_ua_combo_row` is now populated with:
        *   A "[System Default]" option.
        *   All predefined User-Agents.
        *   All user-added custom User-Agents.
    *   Your selection is saved to the `default-user-agent-title` GSettings key.
    *   The saved preference is loaded and applied to the combo row when the Preferences window is opened.

4.  **HTTP Page Logic (`src/http_page.py`):**
    *   When the HTTP page's User-Agent selection combo box (`http_user_agent_row`) is populated, it now reads the `default-user-agent-title` from GSettings.
    *   If a default title is set, the corresponding User-Agent is automatically selected in the `http_user_agent_row`.
    *   If the setting is empty, "[System Default]", or the saved title is not found, the "None" option (no override) is selected.
    *   The UI cues (e.g., CSS for active override) are updated accordingly.

This feature enhances your experience by allowing you to persist a commonly used User-Agent, reducing the need for manual selection on each use of the HTTP page.