### PR TITLE
Feat(http): Improve display of long HTTP header values

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -487,9 +487,22 @@ class HttpPage(Adw.PreferencesPage):
                         headers_for_this_response = response_data_dict.get("headers", {})
                         if isinstance(headers_for_this_response, dict):
                             for key, value in headers_for_this_response.items():
-                                processed_headers_for_store.append(
-                                    HeaderItem(key=str(key), value=str(value), is_special_row=False)
-                                )
+                                original_value_str = str(value)
+                                parts = original_value_str.split(';')
+
+                                first_part = True
+                                for i, part_content in enumerate(parts):
+                                    trimmed_part = part_content.strip()
+                                    if first_part:
+                                        processed_headers_for_store.append(
+                                            HeaderItem(key=str(key), value=trimmed_part, is_special_row=False)
+                                        )
+                                        first_part = False
+                                    else:
+                                        # For subsequent parts, the key is empty, value is the part.
+                                        processed_headers_for_store.append(
+                                            HeaderItem(key="", value=trimmed_part, is_special_row=False)
+                                        )
                         else:
                             logger.warning(
                                 "HttpPage: Headers data for response stage %d is not a dict: %s", i, headers_for_this_response


### PR DESCRIPTION
This commit enhances the readability of HTTP headers in the HTTP Page by splitting long header values at semicolons and displaying each part on a new line.

Previously, headers like Content-Security-Policy or Akamai headers with multiple semicolon-separated directives would appear as a single, long line, making them difficult for you to read.

The `_fetch_headers_task_done_cb` method in `src/http_page.py` has been modified to:
- When processing each header's value, split the value string by the semicolon character (`;`).
- For the first part of the split value, a `HeaderItem` is created with the original header key.
- For all subsequent parts, new `HeaderItem` instances are created with an empty string as the key and the respective part as the value. Each part has leading/trailing whitespace trimmed.

This results in a display where continuation lines for a header value appear indented under the original header key in the `Gtk.ColumnView`, significantly improving your experience when inspecting complex headers. The existing cell renderer's text wrapping capabilities will handle any individual parts that are still long.