### PR TITLE
Fix NameError for Tuple in style_utils

### DIFF
--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -8,7 +8,7 @@ system and application-specific style configurations.
 import logging
 import re
 import platform
-from typing import Optional # Use lowercase tuple
+from typing import Optional, Tuple
 import collections.abc # For Sequence if needed
 
 import gi


### PR DESCRIPTION
I resolved a NameError in `src/style_utils.py` where `Tuple` was used as a type hint without being imported from the `typing` module.

The import statement `from typing import Optional` was changed to `from typing import Optional, Tuple` to correctly include `Tuple`. The misleading comment `# Use lowercase tuple` was also removed during this change.