### PR TITLE
I've made some progress on your request to fix NameErrors, remove lin…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,11 +69,13 @@ target-version = "py310"
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of pycodestyle (`E`) codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "D"]
+select = ["E4", "E7", "E9", "F", "D", "B", "ARG"]
 ignore = [
     "E402", # Module level import not at top of file (often needed with Gtk gi.require_version)
     "D203", # Conflicts with D211
     "D212", # Conflicts with D213
+    "B001", # Do not use bare `except:` (broad-except)
+    "PLR0914", # too-many-locals
 ]
 
 # Allow fixes for all enabled rules
@@ -105,3 +107,4 @@ docstring-code-line-length = "dynamic"
 [tool.ruff.lint.per-file-ignores]
 "src/dns_page.py" = ["C901"]
 "src/http_page.py" = ["E501"]
+"src/main.py" = ["SLF001"]

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ parsing, and launching the main application window and services.
 import sys
 import os
 import logging
-from typing import Callable, List, Optional, Any # Use list
+from typing import Callable, List, Optional, Any
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -33,7 +33,7 @@ def _load_gresources_early():
     either a development path or an installed path. Exits the application
     if the GResource file cannot be found or loaded.
     """
-    installed_resource_path = os.path.join(PKGDATADIR, "woes.gresource") # type: ignore[name-defined]
+    installed_resource_path = os.path.join(PKGDATADIR, "woes.gresource")
     script_dir = os.path.dirname(os.path.abspath(__file__))
     dev_resource_path = os.path.normpath(os.path.join(script_dir, "..", "build", "src", "woes.gresource"))
 
@@ -66,7 +66,7 @@ def _load_gresources_early():
             )
             sys.exit(1)
 
-        Gio.Resource._register(resource)  # pylint: disable=protected-access
+        Gio.Resource._register(resource)
         logging.info("Successfully loaded and registered GResource: %s", resource_file_path)
 
         available_resources = resource.enumerate_children(
@@ -90,7 +90,7 @@ def _load_gresources_early():
             exc_info=True,
         )
         sys.exit(1)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         logging.critical(
             "An unexpected error occurred during GResource loading: %s. Application will now exit.",
             e,
@@ -112,7 +112,7 @@ class WoesApplication(Adw.Application):
         Manages the application lifecycle, actions, and the main window.
     """
 
-    def __init__(self, version: str = VERSION, **kwargs: Any): # type: ignore[assignment]
+    def __init__(self, version: str = VERSION, **kwargs: Any):
         """
         Initialize the WoesApplication.
 
@@ -127,31 +127,31 @@ class WoesApplication(Adw.Application):
 
         logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 
-        super().__init__(application_id=APP_ID, flags=Gio.ApplicationFlags.DEFAULT_FLAGS, **kwargs) # type: ignore[no-untyped-call]
+        super().__init__(application_id=APP_ID, flags=Gio.ApplicationFlags.DEFAULT_FLAGS, **kwargs)
 
-        self.add_main_option( # type: ignore[no-untyped-call]
+        self.add_main_option(
             "debug",
             ord("d"),
-            GLib.OptionFlags.NONE, # type: ignore[attr-defined]
-            GLib.OptionArg.NONE, # type: ignore[attr-defined]
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.NONE,
             "Enable debug logging",
             None,
         )
 
-        self.create_action("quit", lambda *_: self.quit(), ["<primary>q"]) # type: ignore[no-untyped-call]
-        self.create_action("about", self.on_about_action) # type: ignore[no-untyped-call]
-        self.create_action("preferences", self.on_preferences_action) # type: ignore[no-untyped-call]
-        self.create_action("switch-to-http", self.switch_to_http, ["<primary>1"]) # type: ignore[no-untyped-call]
-        self.create_action("switch-to-nmap", self.switch_to_nmap, ["<primary>2"]) # type: ignore[no-untyped-call]
-        self.create_action("switch-to-dns", self.switch_to_dns, ["<primary>3"]) # type: ignore[no-untyped-call]
-        self.create_action("switch-to-webscan", self.switch_to_webscan, ["<primary>4"]) # type: ignore[no-untyped-call]
+        self.create_action("quit", lambda *_: self.quit(), ["<primary>q"])
+        self.create_action("about", self.on_about_action)
+        self.create_action("preferences", self.on_preferences_action)
+        self.create_action("switch-to-http", self.switch_to_http, ["<primary>1"])
+        self.create_action("switch-to-nmap", self.switch_to_nmap, ["<primary>2"])
+        self.create_action("switch-to-dns", self.switch_to_dns, ["<primary>3"])
+        self.create_action("switch-to-webscan", self.switch_to_webscan, ["<primary>4"])
 
-        self.create_action("page-action-http-fetch", self.on_page_action_http_fetch, ["<Alt>F"]) # type: ignore[no-untyped-call]
-        self.create_action("page-action-nmap-scan", self.on_page_action_nmap_scan, ["<Alt>S"]) # type: ignore[no-untyped-call]
-        self.create_action("page-action-dns-lookup", self.on_page_action_dns_lookup, ["<Alt>L"]) # type: ignore[no-untyped-call]
-        self.create_action("page-action-webscan-scan", self.on_page_action_webscan_scan, ["<Alt>W"]) # type: ignore[no-untyped-call]
+        self.create_action("page-action-http-fetch", self.on_page_action_http_fetch, ["<Alt>F"])
+        self.create_action("page-action-nmap-scan", self.on_page_action_nmap_scan, ["<Alt>S"])
+        self.create_action("page-action-dns-lookup", self.on_page_action_dns_lookup, ["<Alt>L"])
+        self.create_action("page-action-webscan-scan", self.on_page_action_webscan_scan, ["<Alt>W"])
 
-    def do_handle_local_options(self, options: GLib.VariantDict) -> int: # type: ignore[override]
+    def do_handle_local_options(self, options: GLib.VariantDict) -> int:
         """
         Handle local command-line options.
 
@@ -163,7 +163,7 @@ class WoesApplication(Adw.Application):
                  allowing further processing (like :meth:`do_command_line`) to occur.
         :rtype: int
         """
-        if options.contains("debug"): # type: ignore[no-untyped-call]
+        if options.contains("debug"):
             self.debug_enabled = True
             logging.basicConfig(
                 level=logging.DEBUG,
@@ -173,7 +173,7 @@ class WoesApplication(Adw.Application):
             logging.debug("Debug mode enabled via command line.")
         return -1  # Indicates that command line processing is not finished
 
-    def do_command_line(self, command_line: Gio.ApplicationCommandLine) -> int: # type: ignore[override]
+    def do_command_line(self, command_line: Gio.ApplicationCommandLine) -> int:
         """
         Override the :meth:`Gio.Application.do_command_line` virtual method to handle command line arguments.
 
@@ -185,14 +185,14 @@ class WoesApplication(Adw.Application):
         :return: The exit status of the command line processing. 0 for success.
         :rtype: int
         """
-        options: GLib.VariantDict = command_line.get_options_dict() # type: ignore[no-untyped-call]
-        if self.handle_local_options(options): # type: ignore[no-untyped-call]
+        options: GLib.VariantDict = command_line.get_options_dict()
+        if self.handle_local_options(options):
             logging.debug("Local options handled.")
 
-        self.activate() # type: ignore[no-untyped-call]
+        self.activate()
         return 0
 
-    def do_activate(self) -> None: # type: ignore[override]
+    def do_activate(self) -> None:
         """
         Create and present the main application window.
 
@@ -200,18 +200,18 @@ class WoesApplication(Adw.Application):
         It ensures the main window (:class:`.window.WoesWindow`) is created and shown.
         If the window cannot be created or presented, the application may exit.
         """
-        win: Optional[WoesWindow] = self.props.active_window # type: ignore[assignment]
+        win: Optional[WoesWindow] = self.props.active_window
         if not win:
             try:
                 win = WoesWindow(application=self)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 logging.exception("WoesApplication.do_activate: Error creating WoesWindow instance")
                 sys.exit(1)
 
         if win:
             try:
                 win.present()
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 logging.exception("WoesApplication.do_activate: Error during win.present()")
             self.win = win
         else:
@@ -226,7 +226,7 @@ class WoesApplication(Adw.Application):
         :type page_name: str
         """
         if self.win and hasattr(self.win, "stack"):
-            self.win.stack.set_visible_child_name(page_name) # type: ignore[no-untyped-call]
+            self.win.stack.set_visible_child_name(page_name)
         else:
             logging.warning(f"Cannot switch to {page_name}_page: window or stack not available.")
 
@@ -289,11 +289,11 @@ class WoesApplication(Adw.Application):
             logging.warning(f"{action_description} action: Window or stack not available.")
             return
 
-        current_page_name: str = self.win.stack.get_visible_child_name() # type: ignore[no-untyped-call]
-        visible_stack_page: Optional[Adw.ViewStackPage] = self.win.stack.get_visible_child() # type: ignore[no-untyped-call, assignment]
+        current_page_name: str = self.win.stack.get_visible_child_name()
+        visible_stack_page: Optional[Adw.ViewStackPage] = self.win.stack.get_visible_child()
 
         if current_page_name == expected_page_name and visible_stack_page:
-            status_page: Optional[Adw.StatusPage] = visible_stack_page.get_child() # type: ignore[no-untyped-call, assignment]
+            status_page: Optional[Adw.StatusPage] = visible_stack_page.get_child()
             if not status_page:
                 logging.warning(f"{action_description} action: StatusPage not found for {current_page_name}.")
                 return
@@ -301,7 +301,7 @@ class WoesApplication(Adw.Application):
             # Child of AdwStatusPage. Based on the previous error, this is likely the GtkBox
             # (e.g., the one with id="HttpPage" in the UI file) that directly contains
             # the actual page class instance (e.g., an instance of your HttpPage class).
-            page_container_widget: Optional[Gtk.Widget] = status_page.get_child() # type: ignore[no-untyped-call]
+            page_container_widget: Optional[Gtk.Widget] = status_page.get_child()
             if not page_container_widget:
                 logging.warning(f"{action_description} action: Page container widget (child of StatusPage) not found for {current_page_name}.")
                 return
@@ -311,7 +311,7 @@ class WoesApplication(Adw.Application):
             if hasattr(page_container_widget, "get_first_child") and callable(getattr(page_container_widget, "get_first_child")):
                 # This assumes the GtkBox (like <object class="GtkBox" id="HttpPage">) is page_container_widget
                 # and its child (<object class="HttpPage">) is the actual page.
-                candidate: Optional[Gtk.Widget] = page_container_widget.get_first_child() # type: ignore[no-untyped-call]
+                candidate: Optional[Gtk.Widget] = page_container_widget.get_first_child()
                 if hasattr(candidate, action_method_name): # Check if this candidate has the method
                     actual_page_object = candidate
                 elif hasattr(page_container_widget, action_method_name): # Check if page_container_widget itself has the method
@@ -436,15 +436,15 @@ class WoesApplication(Adw.Application):
         """
         return Adw.AboutWindow(
             application_name="woes",
-            application_icon=APP_ID, # type: ignore[name-defined]
+            application_icon=APP_ID,
             developer_name="Carey McLelland",
             version=self.version,
             developers=["Carey McLelland"],
             copyright="© 2025 Carey McLelland",
-            website=APP_WEBSITE_URL, # type: ignore[name-defined]
-            license_type=APP_LICENSE_TYPE, # type: ignore[name-defined]
-            comments=APP_DESCRIPTION, # type: ignore[name-defined]
-            issue_url=APP_ISSUES_URL, # type: ignore[name-defined]
+            website=APP_WEBSITE_URL,
+            license_type=APP_LICENSE_TYPE,
+            comments=APP_DESCRIPTION,
+            issue_url=APP_ISSUES_URL,
         )
 
     def on_preferences_action(self, _widget: Gio.SimpleAction, _param: Optional[GLib.Variant]) -> None:
@@ -478,12 +478,12 @@ class WoesApplication(Adw.Application):
         """
         action = Gio.SimpleAction.new(name, None)
         action.connect("activate", callback)
-        self.add_action(action) # type: ignore[no-untyped-call]
+        self.add_action(action)
         if shortcuts:
-            self.set_accels_for_action(f"app.{name}", shortcuts) # type: ignore[no-untyped-call]
+            self.set_accels_for_action(f"app.{name}", shortcuts)
 
 
-def main(version: str = VERSION) -> int: # type: ignore[assignment]
+def main(version: str = VERSION) -> int:
     """
     Run the Woes application.
 
@@ -524,6 +524,6 @@ def main(version: str = VERSION) -> int: # type: ignore[assignment]
 
     # Original application run lines (commented out for this test run)
     # app = WoesApplication(version=version)
-    # exit_status: int = app.run(sys.argv) # type: ignore[no-untyped-call]
+    # exit_status: int = app.run(sys.argv)
     # logging.info("Application exited with status %s.", exit_status)
     # return exit_status

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -49,24 +49,24 @@ class NmapItem(GObject.Object):
         self.value = value
 
 
-class NmapTargetRow(Gtk.ListBoxRow):
-    """A :class:`Gtk.ListBoxRow` customized to display an NmapItem's key."""
-
-    nmap_item = GObject.Property(type=NmapItem)
-
-    def __init__(self, nmap_item: NmapItem, **kwargs: Any):
-        """
-        Initialize an NmapTargetRow.
-
-        :param nmap_item: The :class:`.NmapItem` to display.
-        :type nmap_item: NmapItem
-        :param kwargs: Additional keyword arguments for :class:`Gtk.ListBoxRow`.
-        :type kwargs: Any
-        """
-        super().__init__(**kwargs)
-        self.nmap_item = nmap_item
-        label = Gtk.Label(label=nmap_item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
-        self.set_child(label)
+# class NmapTargetRow(Gtk.ListBoxRow):
+#     """A :class:`Gtk.ListBoxRow` customized to display an NmapItem's key."""
+#
+#     nmap_item = GObject.Property(type=NmapItem)
+#
+#     def __init__(self, nmap_item: NmapItem, **kwargs: Any):
+#         """
+#         Initialize an NmapTargetRow.
+#
+#         :param nmap_item: The :class:`.NmapItem` to display.
+#         :type nmap_item: NmapItem
+#         :param kwargs: Additional keyword arguments for :class:`Gtk.ListBoxRow`.
+#         :type kwargs: Any
+#         """
+#         super().__init__(**kwargs)
+#         self.nmap_item = nmap_item
+#         label = Gtk.Label(label=nmap_item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
+#         self.set_child(label)
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
@@ -75,21 +75,21 @@ class NmapPage(Adw.PreferencesPage):
 
     __gtype_name__ = "NmapPage"
 
-    nmap_target_entryrow = Gtk.Template.Child("nmap_target_entryrow") # type: Adw.EntryRow
-    nmap_apply_button = Gtk.Template.Child("nmap_apply_button") # type: Gtk.Button
-    nmap_fingerprint_switchrow = Gtk.Template.Child("nmap_fingerprint_switchrow") # type: Adw.SwitchRow
-    nmap_all_ports_switchrow = Gtk.Template.Child("nmap_all_ports_switchrow") # type: Adw.SwitchRow
-    nmap_scripts_dropdown = Gtk.Template.Child("nmap_scripts_dropdown") # type: Gtk.DropDown
-    nmap_service_version_switchrow = Gtk.Template.Child("nmap_service_version_switchrow") # type: Adw.SwitchRow
-    nmap_no_ping_switchrow = Gtk.Template.Child("nmap_no_ping_switchrow") # type: Adw.SwitchRow
-    nmap_timing_template_comborow = Gtk.Template.Child("nmap_timing_template_comborow") # type: Adw.ComboRow
-    status_row = Gtk.Template.Child("status_row") # type: Adw.ActionRow
-    scan_spinner = Gtk.Template.Child("scan_spinner") # type: Gtk.Spinner
-    nmap_cancel_scan_button = Gtk.Template.Child() # type: Gtk.Button
+    nmap_target_entryrow = Gtk.Template.Child("nmap_target_entryrow")
+    nmap_apply_button = Gtk.Template.Child("nmap_apply_button")
+    nmap_fingerprint_switchrow = Gtk.Template.Child("nmap_fingerprint_switchrow")
+    nmap_all_ports_switchrow = Gtk.Template.Child("nmap_all_ports_switchrow")
+    nmap_scripts_dropdown = Gtk.Template.Child("nmap_scripts_dropdown")
+    nmap_service_version_switchrow = Gtk.Template.Child("nmap_service_version_switchrow")
+    nmap_no_ping_switchrow = Gtk.Template.Child("nmap_no_ping_switchrow")
+    nmap_timing_template_comborow = Gtk.Template.Child("nmap_timing_template_comborow")
+    status_row = Gtk.Template.Child("status_row")
+    scan_spinner = Gtk.Template.Child("scan_spinner")
+    nmap_cancel_scan_button = Gtk.Template.Child()
 
-    nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox") # type: Gtk.ListBox
-    nmap_detail_box = Gtk.Template.Child("nmap_detail_box") # type: Gtk.Box
-    nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder") # type: Adw.StatusPage
+    nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")
+    nmap_detail_box = Gtk.Template.Child("nmap_detail_box")
+    nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
 
     def __init__(self, **kwargs: Any):
         """
@@ -110,7 +110,7 @@ class NmapPage(Adw.PreferencesPage):
 
         if self.nmap_apply_button:
             self.nmap_apply_button.get_style_context().add_class("suggested-action")
-        if self.nmap_cancel_scan_button: # type: ignore[truthy-bool]
+        if self.nmap_cancel_scan_button:
             self.nmap_cancel_scan_button.get_style_context().add_class("destructive-action")
 
         self.current_nmap_task: Optional[Gio.Task] = None
@@ -166,20 +166,20 @@ class NmapPage(Adw.PreferencesPage):
         """
         logger.info("Cancel scan button clicked.")
         if self.current_nmap_cancellable and not self.current_nmap_cancellable.is_cancelled():
-            self.current_nmap_cancellable.cancel() # type: ignore[union-attr]
+            self.current_nmap_cancellable.cancel()
             logger.info("Scan cancellation requested.")
         else:
             logger.warning("No active scan or cancellable to cancel.")
 
-    def _on_target_activate(self, _widget: Adw.EntryRow) -> None: # pylint: disable=unused-argument # Standard GTK signal handler signature
-        target = self.nmap_target_entryrow.get_text().strip() # type: ignore[attr-defined]
+    def _on_target_activate(self, _widget: Adw.EntryRow) -> None:
+        target = self.nmap_target_entryrow.get_text().strip()
         self._clear_error()
 
         if not self.scanner.validate_target_input(target):
             message = "Invalid target format. Please enter a valid IP, CIDR, or hostname."
-            show_global_toast(self, message) # type: ignore[arg-type]
+            show_global_toast(self, message)
             return
-        self.nmap_target_entryrow.remove_css_class("error") # type: ignore[attr-defined]
+        self.nmap_target_entryrow.remove_css_class("error")
 
         if not target:
             self._clear_results()
@@ -201,18 +201,18 @@ class NmapPage(Adw.PreferencesPage):
 
         scan_params: dict[str, Any] = {
             "target": target,
-            "os_fingerprinting": self.nmap_fingerprint_switchrow.get_active(), # type: ignore[attr-defined]
-            "scan_all_ports": self.nmap_all_ports_switchrow.get_active(), # type: ignore[attr-defined]
+            "os_fingerprinting": self.nmap_fingerprint_switchrow.get_active(),
+            "scan_all_ports": self.nmap_all_ports_switchrow.get_active(),
             "selected_script": (
-                item.get_string() # type: ignore[union-attr]
-                if isinstance(item := self.nmap_scripts_dropdown.get_selected_item(), Gtk.StringObject) and item.get_string() != "None" # type: ignore[attr-defined]
+                item.get_string()
+                if isinstance(item := self.nmap_scripts_dropdown.get_selected_item(), Gtk.StringObject) and item.get_string() != "None"
                 else None
             ),
-            "service_version": self.nmap_service_version_switchrow.get_active(), # type: ignore[attr-defined]
-            "no_ping": self.nmap_no_ping_switchrow.get_active(), # type: ignore[attr-defined]
+            "service_version": self.nmap_service_version_switchrow.get_active(),
+            "no_ping": self.nmap_no_ping_switchrow.get_active(),
             "timing_template": (
                 f"T{m.group(1)}"
-                if (m := re.search(r"\(T([0-5])\)", self.nmap_timing_template_comborow.get_selected_item().get_string())) # type: ignore[attr-defined]
+                if (m := re.search(r"\(T([0-5])\)", self.nmap_timing_template_comborow.get_selected_item().get_string()))
                 else "T3"
             ),
             "custom_dns_server": self.settings.get_string("custom-dns-server")
@@ -223,14 +223,14 @@ class NmapPage(Adw.PreferencesPage):
             self, self.current_nmap_cancellable, self._nmap_scan_task_done_cb, None
         )
         self._current_nmap_scan_params = scan_params
-        self.current_nmap_task.run_in_thread(self._run_nmap_scan_thread_func) # type: ignore[arg-type]
+        self.current_nmap_task.run_in_thread(self._run_nmap_scan_thread_func)
 
 
     def _run_nmap_scan_thread_func(
         self,
         task: Gio.Task,
         _source_object: GObject.Object,
-        _task_data: Optional[dict[str, Any]], # pylint: disable=unused-argument # This arg from run_in_thread is not used
+        _task_data: Optional[dict[str, Any]],
         cancellable: Optional[Gio.Cancellable]
     ) -> None:
         """
@@ -245,40 +245,40 @@ class NmapPage(Adw.PreferencesPage):
         :param cancellable: A :class:`Gio.Cancellable` object to monitor for cancellation.
         :type cancellable: Optional[Gio.Cancellable]
         """
-        page_instance: NmapPage = _source_object # type: ignore[assignment]
+        page_instance: NmapPage = _source_object
         params = page_instance._current_nmap_scan_params
 
         if not params:
             logger.error("NmapPage: _run_nmap_scan_thread_func: _current_nmap_scan_params is None. This indicates a programming error.")
-            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, "Internal error: Scan parameters not found.") # type: ignore[union-attr]
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, "Internal error: Scan parameters not found.")
             return
 
         target = params["target"]
 
         if cancellable and cancellable.is_cancelled():
-            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, "Scan cancelled before start.") # type: ignore[union-attr]
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, "Scan cancelled before start.")
             return
 
         try:
             nm = self.scanner.run_nmap_scan(params, cancellable=cancellable)
 
             if cancellable and cancellable.is_cancelled():
-                task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, "Scan cancelled during operation.") # type: ignore[union-attr]
+                task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, "Scan cancelled during operation.")
             else:
-                task.return_value(nm) # type: ignore[union-attr]
+                task.return_value(nm)
         except ScanCancelledError as e:
             logger.info("Nmap scan for %s was cancelled: %s", target, e)
-            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, str(e)) # type: ignore[union-attr]
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, str(e))
         except nmap.PortScannerError as e:
             logger.exception("Nmap PortScannerError for %s:", target)
-            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.SCAN_FAILED.value, f"Nmap scan error: {e}") # type: ignore[union-attr]
-        except Exception as e: # pylint: disable=broad-except
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.SCAN_FAILED.value, f"Nmap scan error: {e}")
+        except Exception as e:
             logger.exception("Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__)
-            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, f"Scan failed unexpectedly: {e}") # type: ignore[union-attr]
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, f"Scan failed unexpectedly: {e}")
         finally:
             logger.info("Nmap scan thread finished for %s.", target)
 
-    def _nmap_scan_task_done_cb(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Optional[Any]) -> None: # pylint: disable=unused-argument
+    def _nmap_scan_task_done_cb(self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Optional[Any]) -> None:
         """
         Handle completion of the Nmap scan :class:`Gio.Task`.
 
@@ -289,7 +289,7 @@ class NmapPage(Adw.PreferencesPage):
         :param _user_data: User data passed with the callback (unused).
         :type _user_data: Optional[Any]
         """
-        original_target = self._current_nmap_scan_params["target"] if self._current_nmap_scan_params else "unknown target" # type: ignore[index]
+        original_target = self._current_nmap_scan_params["target"] if self._current_nmap_scan_params else "unknown target"
 
         logger.info(f"Nmap scan task done for {original_target}.")
 
@@ -299,11 +299,11 @@ class NmapPage(Adw.PreferencesPage):
 
             if isinstance(propagated_value, nmap.PortScanner):
                 nm_results_final = propagated_value
-            elif hasattr(propagated_value, 'value') and isinstance(getattr(propagated_value, 'value'), nmap.PortScanner): # type: ignore[attr-defined]
+            elif hasattr(propagated_value, 'value') and isinstance(getattr(propagated_value, 'value'), nmap.PortScanner):
                 logger.debug(f"NmapPage: Received wrapped object {type(propagated_value)} with .value attribute containing nmap.PortScanner. Unwrapping.")
-                nm_results_final = getattr(propagated_value, 'value') # type: ignore[attr-defined]
-            elif hasattr(propagated_value, 'value'): # type: ignore[attr-defined]
-                logger.error(f"NmapPage: Received wrapped object {type(propagated_value)} with .value of type {type(getattr(propagated_value, 'value'))}. Expected nmap.PortScanner.") # type: ignore[attr-defined]
+                nm_results_final = getattr(propagated_value, 'value')
+            elif hasattr(propagated_value, 'value'):
+                logger.error(f"NmapPage: Received wrapped object {type(propagated_value)} with .value of type {type(getattr(propagated_value, 'value'))}. Expected nmap.PortScanner.")
                 self._handle_scan_error(original_target, "Scan returned unexpectedly wrapped data of the wrong type.")
             else:
                 logger.error(f"Nmap scan for {original_target} returned unexpected result type: {type(propagated_value)}")
@@ -321,17 +321,17 @@ class NmapPage(Adw.PreferencesPage):
                 self._handle_scan_error(original_target, e.message)
             else: # UNEXPECTED or other GLib.Error
                 self._handle_scan_error(original_target, f"Scan error: {e.message}")
-        except Exception as e: # pylint: disable=broad-except
+        except Exception as e:
             logger.exception(f"NmapPage: Unexpected Python error in _nmap_scan_task_done_cb for {original_target}:")
             self._handle_scan_error(original_target, f"Unexpected error processing scan results: {e}")
         finally:
             self.current_nmap_task = None
             self.current_nmap_cancellable = None
             self._set_scan_status(ScanStatus.IDLE, "Idle") # Default status after task completion
-            self.nmap_target_entryrow.set_sensitive(True) # type: ignore[attr-defined]
+            self.nmap_target_entryrow.set_sensitive(True)
             if self.nmap_apply_button:
                 self.nmap_apply_button.set_sensitive(True)
-            if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button: # type: ignore[truthy-bool]
+            if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
                  self.nmap_cancel_scan_button.set_sensitive(False)
                  self.nmap_cancel_scan_button.set_visible(False)
 
@@ -353,11 +353,11 @@ class NmapPage(Adw.PreferencesPage):
                 f"Scan complete for {original_target}. No hosts found or responsive.",
             )
             self._clear_dynamic_details()
-            self.nmap_detail_placeholder.set_title("No Responsive Hosts") # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_description( # type: ignore[attr-defined]
+            self.nmap_detail_placeholder.set_title("No Responsive Hosts")
+            self.nmap_detail_placeholder.set_description(
                 (f"The Nmap scan for '{original_target}' did not find any responsive hosts.")
             )
-            self.nmap_detail_placeholder.set_visible(True) # type: ignore[attr-defined]
+            self.nmap_detail_placeholder.set_visible(True)
             return
 
         results_yaml_map: dict[str, str] = self.scanner.convert_results_to_yaml(nm)
@@ -380,7 +380,7 @@ class NmapPage(Adw.PreferencesPage):
         :param error_message: The error message to display.
         :type error_message: str
         """
-        show_global_error(self, f"Error scanning {target}: {error_message}") # type: ignore[arg-type]
+        show_global_error(self, f"Error scanning {target}: {error_message}")
         self._set_scan_status(ScanStatus.FAILED, f"Scan failed for {target}")
 
     def _on_target_selected(self, _listbox: Gtk.ListBox, row: Optional[Gtk.ListBoxRow]) -> None:
@@ -397,18 +397,18 @@ class NmapPage(Adw.PreferencesPage):
         self._current_selected_host_data_dict = None
 
         if row is None:
-            self.nmap_detail_placeholder.set_title("No Host Selected") # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_description("Select a host from the list to view details.") # type: ignore[attr-defined]
-            if not self.nmap_detail_placeholder.get_parent(): # type: ignore[attr-defined]
-                self.nmap_detail_box.append(self.nmap_detail_placeholder) # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_visible(True) # type: ignore[attr-defined]
+            self.nmap_detail_placeholder.set_title("No Host Selected")
+            self.nmap_detail_placeholder.set_description("Select a host from the list to view details.")
+            if not self.nmap_detail_placeholder.get_parent():
+                self.nmap_detail_box.append(self.nmap_detail_placeholder)
+            self.nmap_detail_placeholder.set_visible(True)
             return
-        self.nmap_detail_placeholder.set_visible(False) # type: ignore[attr-defined]
-        item_obj = row.nmap_item if isinstance(row, NmapTargetRow) else None # type: ignore[attr-defined]
+        self.nmap_detail_placeholder.set_visible(False)
+        item_obj = row.nmap_item if isinstance(row, NmapTargetRow) else None
         if item_obj and isinstance(item_obj, NmapItem):
             selected_target_key = item_obj.key
             try:
-                host_data_dict: dict[str, Any] = yaml.safe_load(item_obj.value) # type: ignore[assignment]
+                host_data_dict: dict[str, Any] = yaml.safe_load(item_obj.value)
                 if not isinstance(host_data_dict, dict):
                     logger.warning(
                         "Parsed YAML for host %s is not a dictionary. Value: %s",
@@ -425,7 +425,7 @@ class NmapPage(Adw.PreferencesPage):
                 error_label = Gtk.Label(label=f"Error: Could not parse scan results for {selected_target_key}.\n{e}")
                 error_label.set_wrap(True)
                 error_label.set_halign(Gtk.Align.START)
-                self.nmap_detail_box.append(error_label) # type: ignore[attr-defined]
+                self.nmap_detail_box.append(error_label)
                 self._current_selected_host_key = None
                 self._current_selected_host_data_dict = None
                 return
@@ -436,18 +436,18 @@ class NmapPage(Adw.PreferencesPage):
             self._add_raw_output_expander(host_data_dict, selected_target_key)
         elif item_obj is None and row is not None:
             logger.warning("Selected row is not a valid NmapTargetRow or has no NmapItem.")
-            self.nmap_detail_placeholder.set_title("Selection Error") # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_description("Could not process selected item.") # type: ignore[attr-defined]
-            if not self.nmap_detail_placeholder.get_parent(): # type: ignore[attr-defined]
-                self.nmap_detail_box.append(self.nmap_detail_placeholder) # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_visible(True) # type: ignore[attr-defined]
+            self.nmap_detail_placeholder.set_title("Selection Error")
+            self.nmap_detail_placeholder.set_description("Could not process selected item.")
+            if not self.nmap_detail_placeholder.get_parent():
+                self.nmap_detail_box.append(self.nmap_detail_placeholder)
+            self.nmap_detail_placeholder.set_visible(True)
         else:
             logger.warning("Could not retrieve NmapItem from selected row or item_obj is None.")
-            self.nmap_detail_placeholder.set_title("Error") # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_description("Could not load details for the selected host.") # type: ignore[attr-defined]
-            if not self.nmap_detail_placeholder.get_parent(): # type: ignore[attr-defined]
-                self.nmap_detail_box.append(self.nmap_detail_placeholder) # type: ignore[attr-defined]
-            self.nmap_detail_placeholder.set_visible(True) # type: ignore[attr-defined]
+            self.nmap_detail_placeholder.set_title("Error")
+            self.nmap_detail_placeholder.set_description("Could not load details for the selected host.")
+            if not self.nmap_detail_placeholder.get_parent():
+                self.nmap_detail_box.append(self.nmap_detail_placeholder)
+            self.nmap_detail_placeholder.set_visible(True)
 
     def _add_raw_output_expander(self, host_data_dict: Dict[str, Any], host_key: str):
         """
@@ -496,24 +496,24 @@ class NmapPage(Adw.PreferencesPage):
         :param summary_text: The summary text to copy to the clipboard.
         """
         if not summary_text:
-            show_global_toast(self, "No summary text available to copy.") # type: ignore
+            show_global_toast(self, "No summary text available to copy.")
             return
 
         try:
-            clipboard = self.get_clipboard() # type: ignore
+            clipboard = self.get_clipboard()
             if clipboard:
-                clipboard.set(summary_text) # type: ignore
-                show_global_toast(self, "Host summary copied to clipboard.") # type: ignore
+                clipboard.set(summary_text)
+                show_global_toast(self, "Host summary copied to clipboard.")
                 logger.info("Copied Nmap host summary to clipboard.")
             else:
                 logger.warning("Could not get clipboard for NmapPage.")
-                show_global_toast(self, "Failed to access clipboard.") # type: ignore
-        except Exception as e: # pylint: disable=broad-except
+                show_global_toast(self, "Failed to access clipboard.")
+        except Exception as e:
             logger.exception("Error copying Nmap host summary to clipboard:")
-            show_global_toast(self, f"Error copying: {e}") # type: ignore
+            show_global_toast(self, f"Error copying: {e}")
 
 
-    def _add_host_details_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
+    def _add_host_details_expander(self, host_data: Dict[str, Any], host_key: str):
         """
         Add an Adw.ExpanderRow to display general host information.
 
@@ -543,7 +543,7 @@ class NmapPage(Adw.PreferencesPage):
             expander.add_row(Adw.ActionRow(title="Hostnames", subtitle="No hostnames reported"))
         self.nmap_detail_box.append(expander)
 
-    def _add_ports_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
+    def _add_ports_expander(self, host_data: Dict[str, Any], host_key: str):
         """
         Add an Adw.ExpanderRow to display detected network ports and their details.
 
@@ -572,7 +572,7 @@ class NmapPage(Adw.PreferencesPage):
             expander.add_row(Adw.ActionRow(title="Ports", subtitle="No open ports reported or port data available."))
         self.nmap_detail_box.append(expander)
 
-    def _add_os_expander(self, host_data: Dict[str, Any], host_key: str):  # pylint: disable=too-many-locals # UI construction method with many data points
+    def _add_os_expander(self, host_data: Dict[str, Any], host_key: str):
         """
         Add an Adw.ExpanderRow to display OS detection results.
 
@@ -670,33 +670,33 @@ class NmapPage(Adw.PreferencesPage):
             style_context.remove_class(css_class)
         if status_type == ScanStatus.IN_PROGRESS:
             self.scan_spinner.set_visible(True)
-            self.scan_spinner.start() # type: ignore
-            self.status_row.set_title("Scanning...") # type: ignore
+            self.scan_spinner.start()
+            self.status_row.set_title("Scanning...")
             style_context.add_class("accent-color")
             if self.nmap_apply_button:
-                self.nmap_apply_button.set_sensitive(False) # type: ignore
+                self.nmap_apply_button.set_sensitive(False)
             if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
                 self.nmap_cancel_scan_button.set_visible(True)
                 self.nmap_cancel_scan_button.set_sensitive(True)
         else:
-            self.scan_spinner.stop() # type: ignore
-            self.scan_spinner.set_visible(False) # type: ignore
+            self.scan_spinner.stop()
+            self.scan_spinner.set_visible(False)
             if self.nmap_apply_button:
-                self.nmap_apply_button.set_sensitive(True) # type: ignore
+                self.nmap_apply_button.set_sensitive(True)
             if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
                 self.nmap_cancel_scan_button.set_visible(False)
                 self.nmap_cancel_scan_button.set_sensitive(False)
 
             if status_type == ScanStatus.COMPLETE:
-                self.status_row.set_title("Scan Complete") # type: ignore
+                self.status_row.set_title("Scan Complete")
                 style_context.add_class("success-color")
             elif status_type == ScanStatus.FAILED:
-                self.status_row.set_title("Scan Failed") # type: ignore
+                self.status_row.set_title("Scan Failed")
                 style_context.add_class("error-color")
             elif status_type == ScanStatus.IDLE:
-                self.status_row.set_title("Idle") # type: ignore
+                self.status_row.set_title("Idle")
             else:
-                self.status_row.set_title("Scan Status") # type: ignore
+                self.status_row.set_title("Scan Status")
 
     def _clear_results(self):
         """Clear all Nmap scan results from the UI."""
@@ -710,10 +710,10 @@ class NmapPage(Adw.PreferencesPage):
         if not self.nmap_detail_placeholder.get_parent():
             self.nmap_detail_box.append(self.nmap_detail_placeholder)
         self.nmap_detail_placeholder.set_visible(True)
-        self.nmap_target_entryrow.remove_css_class("error") # type: ignore
-        self.nmap_target_entryrow.set_sensitive(True) # type: ignore
+        self.nmap_target_entryrow.remove_css_class("error")
+        self.nmap_target_entryrow.set_sensitive(True)
         if self.nmap_apply_button:
-            self.nmap_apply_button.set_sensitive(True) # type: ignore
+            self.nmap_apply_button.set_sensitive(True)
         if hasattr(self, 'nmap_cancel_scan_button') and self.nmap_cancel_scan_button:
             self.nmap_cancel_scan_button.set_sensitive(False)
             self.nmap_cancel_scan_button.set_visible(False)
@@ -750,18 +750,18 @@ class NmapPage(Adw.PreferencesPage):
         """
         summary_lines = []
         status_info = host_data_dict.get("status", {})
-        state = status_info.get("state", "N/A") # type: ignore[attr-defined]
-        reason = status_info.get("reason", "N/A") # type: ignore[attr-defined]
-        summary_lines.append(f"Host is {state} (reason: {reason}).") # type: ignore[attr-defined]
-        addresses_info = host_data_dict.get("addresses", {}) # type: ignore[attr-defined]
-        if ipv4 := addresses_info.get("ipv4"): # type: ignore[attr-defined]
+        state = status_info.get("state", "N/A")
+        reason = status_info.get("reason", "N/A")
+        summary_lines.append(f"Host is {state} (reason: {reason}).")
+        addresses_info = host_data_dict.get("addresses", {})
+        if ipv4 := addresses_info.get("ipv4"):
             summary_lines.append(f"IPv4 Address: {ipv4}")
-        if ipv6 := addresses_info.get("ipv6"): # type: ignore[attr-defined]
+        if ipv6 := addresses_info.get("ipv6"):
             summary_lines.append(f"IPv6 Address: {ipv6}")
-        if mac := addresses_info.get("mac"): # type: ignore[attr-defined]
+        if mac := addresses_info.get("mac"):
             summary_lines.append(f"MAC Address: {mac}")
 
-        prescan_results = host_data_dict.get("prescript_results") # type: ignore[attr-defined]
+        prescan_results = host_data_dict.get("prescript_results")
         if prescan_results and isinstance(prescan_results, list):
             summary_lines.append("\nPre-scan script results:")
             for script_item in prescan_results:
@@ -770,46 +770,46 @@ class NmapPage(Adw.PreferencesPage):
                     if script_output and isinstance(script_output, str):
                         formatted_output = "\n".join(
                             [
-                                f"|_ {script_id}: {line.strip()}" if i == 0 else f"|  {line.strip()}" # type: ignore[str-bytes-safe]
+                                f"|_ {script_id}: {line.strip()}" if i == 0 else f"|  {line.strip()}"
                                 for i, line in enumerate(script_output.strip().split("\n"))
                             ]
                         )
                         summary_lines.append(formatted_output)
                     else:
-                        summary_lines.append(f"|_ {script_id}: (no output)") # type: ignore[str-bytes-safe]
+                        summary_lines.append(f"|_ {script_id}: (no output)")
 
-        hostnames_list = host_data_dict.get("hostnames", []) # type: ignore[attr-defined]
+        hostnames_list = host_data_dict.get("hostnames", [])
         if hostnames_list:
             summary_lines.append("\nHostnames:")
             for hn_entry in hostnames_list:
-                summary_lines.append(f"  {hn_entry.get('name', 'N/A')} ({hn_entry.get('type', 'N/A')})") # type: ignore[str-bytes-safe]
+                summary_lines.append(f"  {hn_entry.get('name', 'N/A')} ({hn_entry.get('type', 'N/A')})")
 
-        host_scripts = host_data_dict.get("hostscript") # type: ignore[attr-defined]
+        host_scripts = host_data_dict.get("hostscript")
         if host_scripts and isinstance(host_scripts, list):
             summary_lines.append("\nHost script output:")
             for script_item in host_scripts:
                 if isinstance(script_item, dict):
                     script_id, script_output = script_item.get("id", "N/A"), script_item.get("output", "N/A")
-                    formatted_output = "\n".join([f"    {line.strip()}" for line in script_output.strip().split("\n")]) # type: ignore[union-attr, str-bytes-safe]
-                    summary_lines.append(f"  Script: {script_id}\n{formatted_output}") # type: ignore[str-bytes-safe]
+                    formatted_output = "\n".join([f"    {line.strip()}" for line in script_output.strip().split("\n")])
+                    summary_lines.append(f"  Script: {script_id}\n{formatted_output}")
 
         ports_data = []
         for proto in ["tcp", "udp", "sctp", "ip"]:
-            if proto_data := host_data_dict.get(proto): # type: ignore[attr-defined]
+            if proto_data := host_data_dict.get(proto):
                 if isinstance(proto_data, dict):
                     for port_id, port_info in proto_data.items():
                         p_state = port_info.get("state", "N/A")
-                        if p_state not in ["closed", "filtered out"]: # type: ignore[comparison-overlap]
+                        if p_state not in ["closed", "filtered out"]:
                             p_name, p_product, p_version, p_reason = (
                                 port_info.get(k, "") for k in ["name", "product", "version", "reason"]
                             )
-                            port_str = f"{port_id}/{proto.upper():<4} {p_state:<10} {p_name}" # type: ignore[str-bytes-safe]
+                            port_str = f"{port_id}/{proto.upper():<4} {p_state:<10} {p_name}"
                             if p_product:
-                                port_str += f" {p_product}" # type: ignore[str-bytes-safe]
+                                port_str += f" {p_product}"
                             if p_version:
-                                port_str += f" {p_version}" # type: ignore[str-bytes-safe]
+                                port_str += f" {p_version}"
                             if p_reason:
-                                port_str += f" (reason: {p_reason})" # type: ignore[str-bytes-safe]
+                                port_str += f" (reason: {p_reason})"
                             ports_data.append(port_str)
                         if port_scripts := port_info.get("script"):
                             if isinstance(port_scripts, dict):
@@ -817,7 +817,7 @@ class NmapPage(Adw.PreferencesPage):
                                     if script_output and isinstance(script_output, str):
                                         formatted_script_output = "\n".join(
                                             [
-                                                f"  |_{script_id}: {line.strip()}" if i == 0 else f"  | {line.strip()}" # type: ignore[str-bytes-safe]
+                                                f"  |_{script_id}: {line.strip()}" if i == 0 else f"  | {line.strip()}"
                                                 for i, line in enumerate(script_output.strip().split("\n"))
                                             ]
                                         )
@@ -828,18 +828,18 @@ class NmapPage(Adw.PreferencesPage):
         else:
             summary_lines.append("No open ports reported or port data available.")
 
-        osmatch_data = host_data_dict.get("osmatch", []) # type: ignore[attr-defined]
+        osmatch_data = host_data_dict.get("osmatch", [])
         if osmatch_data:
             summary_lines.append("\nOS details:")
             for match in osmatch_data:
-                summary_lines.append(f"  Name: {match.get('name', 'N/A')}") # type: ignore[str-bytes-safe]
-                summary_lines.append(f"  Accuracy: {match.get('accuracy', 'N/A')}%") # type: ignore[str-bytes-safe]
-                if "osclass" in match: # type: ignore[operator]
-                    osclasses = match["osclass"] if isinstance(match["osclass"], list) else [match["osclass"]] # type: ignore[index]
+                summary_lines.append(f"  Name: {match.get('name', 'N/A')}")
+                summary_lines.append(f"  Accuracy: {match.get('accuracy', 'N/A')}%")
+                if "osclass" in match:
+                    osclasses = match["osclass"] if isinstance(match["osclass"], list) else [match["osclass"]]
                     for os_class in osclasses:
                         if isinstance(os_class, dict):
                             summary_lines.append("  OS Class:")
-                            summary_lines.append( # type: ignore[str-bytes-safe]
+                            summary_lines.append(
                                 f"    Type: {os_class.get('type', 'N/A')}, Vendor: {os_class.get('vendor', 'N/A')}, Family: {os_class.get('osfamily', 'N/A')}, Gen: {os_class.get('osgen', 'N/A')}"
                             )
         else:
@@ -851,7 +851,7 @@ class NmapPage(Adw.PreferencesPage):
         if self.nmap_apply_button and self.nmap_apply_button.get_sensitive():
             self.nmap_apply_button.clicked()
         elif self.current_nmap_task and not self.current_nmap_task.is_done():
-             show_global_toast(self, "A scan is already in progress. Cancel it or wait.") # type: ignore[arg-type]
+             show_global_toast(self, "A scan is already in progress. Cancel it or wait.")
         else:
             logger.warning("Nmap scan button not available or not sensitive, cannot trigger scan.")
 

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -8,7 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 import re
 import ast
-from typing import Optional, Dict, Any # Use dict
+from typing import Optional, Dict, Any
 import time
 from enum import Enum
 
@@ -28,27 +28,27 @@ class WebScanPage(Adw.PreferencesPage):
 
     __gtype_name__ = "WebScanPage"
 
-    url_entry: Adw.EntryRow = Gtk.Template.Child() # type: ignore
-    scan_button: Gtk.Button = Gtk.Template.Child() # type: ignore
-    results_scrolled_window: Gtk.ScrolledWindow = Gtk.Template.Child() # type: ignore
-    force_ssl_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
-    cgi_vulns_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
-    interesting_content_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
-    evasion_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
-    mutate_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
-    maxtime_entry_row: Adw.EntryRow = Gtk.Template.Child() # type: ignore
-    clear_results_button: Gtk.Button = Gtk.Template.Child() # type: ignore
-    copy_results_button: Gtk.Button = Gtk.Template.Child() # type: ignore
-    webscan_status_action_row: Adw.ActionRow = Gtk.Template.Child() # type: ignore
-    webscan_status_spinner: Gtk.Spinner = Gtk.Template.Child("webscan_status_spinner") # type: ignore
-    webscan_cancel_button: Gtk.Button = Gtk.Template.Child() # type: ignore
+    url_entry: Adw.EntryRow = Gtk.Template.Child()
+    scan_button: Gtk.Button = Gtk.Template.Child()
+    results_scrolled_window: Gtk.ScrolledWindow = Gtk.Template.Child()
+    force_ssl_switch: Adw.SwitchRow = Gtk.Template.Child()
+    cgi_vulns_switch: Adw.SwitchRow = Gtk.Template.Child()
+    interesting_content_switch: Adw.SwitchRow = Gtk.Template.Child()
+    evasion_switch: Adw.SwitchRow = Gtk.Template.Child()
+    mutate_switch: Adw.SwitchRow = Gtk.Template.Child()
+    maxtime_entry_row: Adw.EntryRow = Gtk.Template.Child()
+    clear_results_button: Gtk.Button = Gtk.Template.Child()
+    copy_results_button: Gtk.Button = Gtk.Template.Child()
+    webscan_status_action_row: Adw.ActionRow = Gtk.Template.Child()
+    webscan_status_spinner: Gtk.Spinner = Gtk.Template.Child("webscan_status_spinner")
+    webscan_cancel_button: Gtk.Button = Gtk.Template.Child()
 
     # New UI elements for Nikto options
-    nikto_format_combo_row: Adw.ComboRow = Gtk.Template.Child() # type: ignore
-    nikto_output_file_row: Adw.EntryRow = Gtk.Template.Child() # type: ignore
-    nikto_output_file_button: Gtk.Button = Gtk.Template.Child() # type: ignore
-    no404_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
-    auth_bypass_switch: Adw.SwitchRow = Gtk.Template.Child() # type: ignore
+    nikto_format_combo_row: Adw.ComboRow = Gtk.Template.Child()
+    nikto_output_file_row: Adw.EntryRow = Gtk.Template.Child()
+    nikto_output_file_button: Gtk.Button = Gtk.Template.Child()
+    no404_switch: Adw.SwitchRow = Gtk.Template.Child()
+    auth_bypass_switch: Adw.SwitchRow = Gtk.Template.Child()
 
     def __init__(self, **kwargs: Any):
         """
@@ -63,14 +63,14 @@ class WebScanPage(Adw.PreferencesPage):
         source_buffer = Gtk.TextBuffer()
         self.source_view.set_buffer(source_buffer)
 
-        self.source_view.set_hexpand(True) # type: ignore[no-untyped-call]
-        self.source_view.set_vexpand(True) # type: ignore[no-untyped-call]
-        self.source_view.set_monospace(True) # type: ignore[no-untyped-call]
-        self.source_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR) # type: ignore[no-untyped-call]
-        self.source_view.set_editable(False) # type: ignore[no-untyped-call]
+        self.source_view.set_hexpand(True)
+        self.source_view.set_vexpand(True)
+        self.source_view.set_monospace(True)
+        self.source_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self.source_view.set_editable(False)
 
         if self.results_scrolled_window:
-            self.results_scrolled_window.set_child(self.source_view) # type: ignore[union-attr]
+            self.results_scrolled_window.set_child(self.source_view)
         else:
             logger.error("results_scrolled_window is None in __init__, cannot add Gtk.TextView.")
 
@@ -188,7 +188,7 @@ class WebScanPage(Adw.PreferencesPage):
 
         def on_dialog_response(_source_object, response_id, _user_data):
             if response_id == Gtk.ResponseType.ACCEPT:
-                file_path = dialog.get_file().get_path() # type: ignore
+                file_path = dialog.get_file().get_path()
                 if self.nikto_output_file_row:
                     self.nikto_output_file_row.set_text(file_path if file_path else "")
                     logger.info(f"Nikto output file set to: {file_path}")
@@ -260,7 +260,7 @@ class WebScanPage(Adw.PreferencesPage):
                         logger.info("Webscan results copied to clipboard successfully.")
                     else:
                         logger.warning("Failed to get default clipboard for copying webscan results.")
-                except Exception as e: # pylint: disable=broad-except # Clipboard operations can be unreliable
+                except Exception as e: # Clipboard operations can be unreliable
                     logger.error(f"Error copying webscan results to clipboard: {e}", exc_info=True)
             else:
                 logger.info("No webscan results to copy.")
@@ -356,7 +356,7 @@ class WebScanPage(Adw.PreferencesPage):
         :param cancellable: A :class:`Gio.Cancellable` object to monitor for cancellation.
         :type cancellable: Gio.Cancellable
         """
-        page_instance: WebScanPage = _source_object # type: ignore[assignment]
+        page_instance: WebScanPage = _source_object
         scan_params = page_instance._current_webscan_params
 
         if not scan_params:
@@ -835,7 +835,7 @@ class WebScanPage(Adw.PreferencesPage):
         if self.scan_button and self.scan_button.get_sensitive():
             self.scan_button.clicked()
         elif self.current_web_scan_task and not self.current_web_scan_task.is_done():
-            show_global_toast(self, "A scan is already in progress. Cancel it or wait.") # type: ignore[arg-type]
+            show_global_toast(self, "A scan is already in progress. Cancel it or wait.")
         else:
             logger.warning("Webscan scan button not available or not sensitive, cannot trigger scan.")
 


### PR DESCRIPTION
…ter comments, and update the Ruff config.

Here's what I've done:
1.  I corrected a `NameError` for `Tuple` in `src/style_utils.py` by fixing the import.
2.  I also corrected a `NameError` for `List` in `src/utils.py` by fixing its import.
3.  I removed some incorrect or misleading comments from import lines in `src/style_utils.py`, `src/utils.py`, `src/main.py`, `src/nmap_page.py`, and `src/webscan_page.py`.
4.  I removed all `# noqa`, `# type: ignore`, and `# pylint: disable` comments from `src/style_utils.py`, `src/utils.py`, `src/window.py`, `src/nmap_page.py`, `src/main.py`, and `src/webscan_page.py`. This helps ensure we're following the policy of central linter configuration.
5.  I updated the `pyproject.toml` file (`[tool.ruff.lint]`) to:
    - Add `"B"` (flake8-bugbear) and `"ARG"` (flake8-unused-arguments) to the `select` list.
    - Add `"B001"` (broad-except) and `"PLR0914"` (too-many-locals) to the global `ignore` list.
    - Add a per-file ignore for `"SLF001"` (private member access) for `src/main.py`.

However, I'm still encountering a persistent `SyntaxError` in `src/nmap_page.py`.
- You've reported a `SyntaxError: unterminated string literal` at or before line 53 in `src/nmap_page.py`, which seems related to the `NmapTargetRow` class docstring.
- I tried to fix this by rewriting the docstring, but it seemed like the file content was already correct.
- As a diagnostic step, I've commented out the entire `NmapTargetRow` class definition in `src/nmap_page.py`. This should help us figure out if the error is coming from within this block. Please note that the application will need this class to be restored and the syntax error properly fixed for full functionality.