### PR TITLE
Fix: Correct SyntaxError in custom_dns_adapter.py

### DIFF
--- a/src/custom_dns_adapter.py
+++ b/src/custom_dns_adapter.py
@@ -1,4 +1,3 @@
-"""
 """Custom HTTPAdapter for 'requests' with custom DNS resolution and SNI handling.
 
 This module provides a custom :class:`requests.adapters.HTTPAdapter` that allows for specifying a DNS server


### PR DESCRIPTION
Removes an extraneous triple-quote from the beginning of the file. This extra quote caused a SyntaxError by making the interpreter misinterpret the module-level docstring and subsequent strings.