### PR TITLE
Fix: Import Any in custom_dns_adapter.py

### DIFF
--- a/src/custom_dns_adapter.py
+++ b/src/custom_dns_adapter.py
@@ -7,7 +7,7 @@ for hostname resolution and handles Server Name Indication (SNI) for HTTPS conne
 import logging
 import socket
 import ssl
-from typing import Optional, Tuple, List, Dict # Use list, dict
+from typing import Optional, Tuple, List, Dict, Any # Use list, dict
 
 import requests
 import requests.utils # For urlparse, urlunparse


### PR DESCRIPTION
Adds `Any` to the `typing` import to resolve a NameError. The type hint `Any` was used without being imported, causing a NameError at runtime. This change ensures `Any` is correctly imported from the `typing` module.