### PR TITLE
Fix: Correct premature exit, lint codebase, and address minor issues

### DIFF
--- a/build-flatpak.py
+++ b/build-flatpak.py
@@ -1,4 +1,5 @@
 """Builds the flatpak package."""
+
 import os
 import subprocess
 
@@ -67,18 +68,24 @@ print(f"Generated Flatpak module file: {FLATPAK_MODULE_FILE}")
 if not os.path.exists(os.path.join(OUTPUT_DIR, REPO_NAME)):
     print(f"Initializing Flatpak repository: {REPO_NAME}")
     subprocess.run(
-        ["flatpak", "build-init", os.path.join(OUTPUT_DIR, REPO_NAME), APP_ID, SDK, RUNTIME, RUNTIME_VERSION, f"--branch={BRANCH}"],
-        check=True
+        [
+            "flatpak",
+            "build-init",
+            os.path.join(OUTPUT_DIR, REPO_NAME),
+            APP_ID,
+            SDK,
+            RUNTIME,
+            RUNTIME_VERSION,
+            f"--branch={BRANCH}",
+        ],
+        check=True,
     )
 else:
     print(f"Flatpak repository {REPO_NAME} already exists.")
 
 # 3. Build the application
 print(f"Building {APP_ID}...")
-subprocess.run(
-    ["flatpak", "build", os.path.join(OUTPUT_DIR, REPO_NAME), FLATPAK_MODULE_FILE],
-    check=True
-)
+subprocess.run(["flatpak", "build", os.path.join(OUTPUT_DIR, REPO_NAME), FLATPAK_MODULE_FILE], check=True)
 
 # 4. Finish the build (optional, for creating a runnable Flatpak)
 # This step creates a bundle or installs to a local repository.
@@ -87,10 +94,7 @@ subprocess.run(
 
 # Example: Install to the local repository (for testing)
 print(f"Installing {APP_ID} to local repository {REPO_NAME}...")
-subprocess.run(
-    ["flatpak", "build-finish", os.path.join(OUTPUT_DIR, REPO_NAME)],
-    check=True
-)
+subprocess.run(["flatpak", "build-finish", os.path.join(OUTPUT_DIR, REPO_NAME)], check=True)
 # To run after installing to local repo:
 # flatpak run --user --command=sh -c 'flatpak install --user --reinstall {REPO_NAME} {APP_ID} && flatpak run {APP_ID}'
 
@@ -98,8 +102,15 @@ subprocess.run(
 bundle_path = os.path.join(OUTPUT_DIR, f"{APP_ID}.flatpak")
 print(f"Creating Flatpak bundle: {bundle_path}")
 subprocess.run(
-    ["flatpak", "build-bundle", os.path.join(OUTPUT_DIR, REPO_NAME), bundle_path, APP_ID, "--runtime-repo=https://dl.flathub.org/repo/flathub.flatpakrepo"],
-    check=True
+    [
+        "flatpak",
+        "build-bundle",
+        os.path.join(OUTPUT_DIR, REPO_NAME),
+        bundle_path,
+        APP_ID,
+        "--runtime-repo=https://dl.flathub.org/repo/flathub.flatpakrepo",
+    ],
+    check=True,
 )
 
 print("\nFlatpak build process completed.")

--- a/modify_ui.py
+++ b/modify_ui.py
@@ -1,11 +1,13 @@
 """Modifies the UI files to fix GtkTemplate issues."""
+
 import re
 
 # Path to your .ui file
-UI_FILE_PATH = "src/woes_gui/window.ui" # Replace with your actual UI file path
+UI_FILE_PATH = "src/woes_gui/window.ui"  # Replace with your actual UI file path
 # UI_FILE_PATH_HTTP = "src/woes_gui/http_page.ui"
 # UI_FILE_PATH_DNS = "src/woes_gui/dns_page.ui"
 # UI_FILE_PATH_NMAP = "src/woes_gui/nmap_page.ui"
+
 
 def modify_template_child_tags(file_path):
     """
@@ -22,28 +24,28 @@ def modify_template_child_tags(file_path):
 
     """
     try:
-        with open(file_path, 'r', encoding='utf-8') as file:
+        with open(file_path, "r", encoding="utf-8") as file:
             content = file.read()
 
         # Regex to find <template ...> tags
         # It captures the part before 'class=', the class attribute itself, and the part after.
         template_regex = r'(<template\s+)([^>]*\bclass\s*=\s*"[^"]*"\s*)([^>]*>)'
+
         # Replacement function for <template>
         def replace_template(match):
             before_class = match.group(1)
-            class_attr_part = match.group(2) # The whole class="XYZ" part
+            class_attr_part = match.group(2)  # The whole class="XYZ" part
             after_class = match.group(3)
 
             # Remove the class attribute by finding its start and end
             # This is safer than just removing based on group 2 if other attributes are mixed
-            modified_attrs = re.sub(r'\bclass\s*=\s*"[^"]*"\s*', '', class_attr_part, count=1)
+            modified_attrs = re.sub(r'\bclass\s*=\s*"[^"]*"\s*', "", class_attr_part, count=1)
 
             # Reconstruct the template tag
             # Ensure there's a space if both parts have content, or just one if the other is empty
             if modified_attrs.strip() and after_class.strip():
                 return f"{before_class}{modified_attrs.strip()} {after_class.strip()}"
             return f"{before_class}{modified_attrs.strip()}{after_class.strip()}"
-
 
         modified_content = re.sub(template_regex, replace_template, content)
         print(f"Processed <template> tags in {file_path}.")
@@ -61,7 +63,7 @@ def modify_template_child_tags(file_path):
         # The main purpose is to clean the <template> tag itself.
 
         if modified_content != content:
-            with open(file_path, 'w', encoding='utf-8') as file:
+            with open(file_path, "w", encoding="utf-8") as file:
                 file.write(modified_content)
             print(f"Successfully modified UI file: {file_path}")
         else:
@@ -69,8 +71,9 @@ def modify_template_child_tags(file_path):
 
     except FileNotFoundError:
         print(f"Error: UI file not found at {file_path}")
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         print(f"An error occurred: {e}")
+
 
 if __name__ == "__main__":
     modify_template_child_tags(UI_FILE_PATH)

--- a/modify_webscan_py.py
+++ b/modify_webscan_py.py
@@ -1,10 +1,11 @@
 """Modifies the webscan_page.py file to adapt SourceView usage."""
+
 import re
 
 webscan_py_path = "src/webscan_page.py"
 
 try:
-    with open(webscan_py_path, 'r', encoding='utf-8') as file:
+    with open(webscan_py_path, "r", encoding="utf-8") as file:
         content = file.read()
 
     # Replace Gtk.SourceView with Gtk.TextView
@@ -15,13 +16,14 @@ try:
     # If language highlighting isn't essential, you can remove lines related to it.
     # For now, let's comment out lines that might cause issues if SourceLanguageManager is not available.
     # This is a heuristic. A more robust solution would be to understand how language setting is used.
-    modified_content = re.sub(r'.*Gtk\.SourceLanguageManager.*', r'# \g<0> # Commented out by script', modified_content)
+    modified_content = re.sub(r".*Gtk\.SourceLanguageManager.*", r"# \g<0> # Commented out by script", modified_content)
     # Comment out .set_language
-    modified_content = re.sub(r'(\s*)self\.source_buffer\.set_language\(.*\)', r'\1# \g<0> # Commented out by script', modified_content)
-
+    modified_content = re.sub(
+        r"(\s*)self\.source_buffer\.set_language\(.*\)", r"\1# \g<0> # Commented out by script", modified_content
+    )
 
     if modified_content != content:
-        with open(webscan_py_path, 'w', encoding='utf-8') as file:
+        with open(webscan_py_path, "w", encoding="utf-8") as file:
             file.write(modified_content)
         print(f"Successfully modified {webscan_py_path} for Gtk.TextView compatibility.")
     else:
@@ -29,5 +31,5 @@ try:
 
 except FileNotFoundError:
     print(f"Error: File not found at {webscan_py_path}")
-except Exception as e: # pylint: disable=broad-except
+except Exception as e:  # pylint: disable=broad-except
     print(f"An error occurred: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ ignore = [
     "E402", # Module level import not at top of file (often needed with Gtk gi.require_version)
     "D203", # Conflicts with D211
     "D212", # Conflicts with D213
-    "B001", # Do not use bare `except:` (broad-except)
+    "E722", # Do not use bare `except:` (broad-except) (formerly B001)
     "PLR0914", # too-many-locals
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ def detect_os_and_distro():
                     distro_info[key] = value.strip('"')
                 distro = distro_info.get("ID", "unknown")
         except Exception as e:
-            raise RuntimeError(f"Could not determine Linux distribution: {str(e)}")
+            raise RuntimeError(f"Could not determine Linux distribution: {str(e)}") from e
     elif os_type == "Darwin":
         distro = "darwin"
     else:
@@ -213,9 +213,7 @@ def main():
     """Parse command-line arguments and run the setup process."""
     parser = argparse.ArgumentParser(description="Dependency installer and application builder")
     parser.add_argument("-i", "--install-deps", action="store_true", help="Install dependencies")
-    parser.add_argument(
-        "-b", "--build", action="store_true", help="Build and install the application"
-    )
+    parser.add_argument("-b", "--build", action="store_true", help="Build and install the application")
     args = parser.parse_args()
 
     if not any(vars(args).values()):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,1 @@
 """Initializes the woes package."""
-

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,6 +5,7 @@ This module defines various global constants used throughout the Woes applicatio
 including application identifiers, resource paths, theme names, version information,
 URLs, and predefined User-Agent strings.
 """
+
 import os
 
 from gi.repository import Gtk
@@ -30,136 +31,113 @@ TEXT_SCALING_FACTOR_KEY = "text-scaling-factor"
 USER_AGENTS = [
     {
         "title": "Chrome (Windows)",
-        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
     },
     {
         "title": "Firefox (Windows)",
-        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
+        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
     },
     {
         "title": "Safari (macOS)",
-        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
     },
     {
         "title": "Edge (Windows)",
-        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
+        "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
     },
     {
         "title": "OpenAI GPTBot",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.1; +https://openai.com/gptbot"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.1; +https://openai.com/gptbot",
     },
     {
         "title": "OpenAI SearchBot",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot",
     },
     {
         "title": "OpenAI ChatGPT-User (Legacy)",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot",
     },
     {
         "title": "OpenAI ChatGPT-User",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/2.0; +https://openai.com/bot"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/2.0; +https://openai.com/bot",
     },
     {
         "title": "Google-Extended",
-        "value": "Mozilla/5.0 (compatible; Google-Extended/1.0; +http://www.google.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; Google-Extended/1.0; +http://www.google.com/bot.html)",
     },
     {
         "title": "Googlebot (Smartphone)",
-        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        "value": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
     },
     {
         "title": "Anthropic ClaudeBot (Chat)",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ClaudeBot/1.0; +claudebot@anthropic.com"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ClaudeBot/1.0; +claudebot@anthropic.com",
     },
     {
         "title": "Anthropic AI (Generic)",
-        "value": "Mozilla/5.0 (compatible; anthropic-ai/1.0; +http://www.anthropic.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; anthropic-ai/1.0; +http://www.anthropic.com/bot.html)",
     },
     {
         "title": "Anthropic Claude-Web",
-        "value": "Mozilla/5.0 (compatible; claude-web/1.0; +http://www.anthropic.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; claude-web/1.0; +http://www.anthropic.com/bot.html)",
     },
-    {
-        "title": "Microsoft Bingbot",
-        "value": "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)"
-    },
+    {"title": "Microsoft Bingbot", "value": "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)"},
     {
         "title": "AppleBot (Specific)",
-        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15 (AppleBot/0.1)"
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15 (AppleBot/0.1)",
     },
-    {
-        "title": "AppleBot (Generic)",
-        "value": "Mozilla/5.0 (compatible; Applebot/1.0; +http://www.apple.com/bot.html)"
-    },
+    {"title": "AppleBot (Generic)", "value": "Mozilla/5.0 (compatible; Applebot/1.0; +http://www.apple.com/bot.html)"},
     {
         "title": "Applebot-Extended",
-        "value": "Mozilla/5.0 (compatible; Applebot-Extended/1.0; +http://www.apple.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; Applebot-Extended/1.0; +http://www.apple.com/bot.html)",
     },
     {
         "title": "PerplexityAI Bot",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot",
     },
     {
         "title": "PerplexityAI User",
-        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; Perplexity-User/1.0; +https://www.perplexity.ai/useragent"
+        "value": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; Perplexity-User/1.0; +https://www.perplexity.ai/useragent",
     },
     {
         "title": "Amazonbot",
-        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)"
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)",
     },
     {
         "title": "Meta FacebookBot",
-        "value": "Mozilla/5.0 (compatible; FacebookBot/1.0; +http://www.facebook.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; FacebookBot/1.0; +http://www.facebook.com/bot.html)",
     },
     {
         "title": "Meta External Agent",
-        "value": "Mozilla/5.0 (compatible; meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler))"
+        "value": "Mozilla/5.0 (compatible; meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler))",
     },
     {
         "title": "LinkedInBot",
-        "value": "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)"
+        "value": "LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)",
     },
     {
         "title": "ByteDance Bytespider",
-        "value": "Mozilla/5.0 (compatible; Bytespider/1.0; +http://www.bytedance.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; Bytespider/1.0; +http://www.bytedance.com/bot.html)",
     },
     {
         "title": "DuckDuckGo DuckAssistBot",
-        "value": "Mozilla/5.0 (compatible; DuckAssistBot/1.0; +http://www.duckduckgo.com/bot.html)"
+        "value": "Mozilla/5.0 (compatible; DuckAssistBot/1.0; +http://www.duckduckgo.com/bot.html)",
     },
-    {
-        "title": "Cohere AI Bot",
-        "value": "Mozilla/5.0 (compatible; cohere-ai/1.0; +http://www.cohere.ai/bot.html)"
-    },
+    {"title": "Cohere AI Bot", "value": "Mozilla/5.0 (compatible; cohere-ai/1.0; +http://www.cohere.ai/bot.html)"},
     {
         "title": "Allen Institute AI2Bot",
-        "value": "Mozilla/5.0 (compatible; AI2Bot/1.0; +http://www.allenai.org/crawler)"
+        "value": "Mozilla/5.0 (compatible; AI2Bot/1.0; +http://www.allenai.org/crawler)",
     },
     {
         "title": "Common Crawl CCBot",
-        "value": "Mozilla/5.0 (compatible; CCBot/1.0; +http://www.commoncrawl.org/bot.html)"
+        "value": "Mozilla/5.0 (compatible; CCBot/1.0; +http://www.commoncrawl.org/bot.html)",
     },
     {
         "title": "Diffbot",
-        "value": "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729; Diffbot/0.1; +http://www.diffbot.com)"
+        "value": "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729; Diffbot/0.1; +http://www.diffbot.com)",
     },
-    {
-        "title": "Omgili Bot",
-        "value": "Mozilla/5.0 (compatible; omgili/1.0; +http://www.omgili.com/bot.html)"
-    },
-    {
-        "title": "TimpiBot",
-        "value": "Timpibot/0.8 (+http://www.timpi.io)"
-    },
-    {
-        "title": "You.com YouBot",
-        "value": "Mozilla/5.0 (compatible; YouBot (+http://www.you.com))"
-    },
-    {
-        "title": "MistralAI User",
-        "value": "Mozilla/5.0 (compatible; MistralAI-User/1.0; +https://mistral.ai/bot)"
-    }
+    {"title": "Omgili Bot", "value": "Mozilla/5.0 (compatible; omgili/1.0; +http://www.omgili.com/bot.html)"},
+    {"title": "TimpiBot", "value": "Timpibot/0.8 (+http://www.timpi.io)"},
+    {"title": "You.com YouBot", "value": "Mozilla/5.0 (compatible; YouBot (+http://www.you.com))"},
+    {"title": "MistralAI User", "value": "Mozilla/5.0 (compatible; MistralAI-User/1.0; +https://mistral.ai/bot)"},
 ]
-
-

--- a/src/custom_dns_adapter.py
+++ b/src/custom_dns_adapter.py
@@ -1,4 +1,5 @@
-"""Custom HTTPAdapter for 'requests' with custom DNS resolution and SNI handling.
+"""
+Custom HTTPAdapter for 'requests' with custom DNS resolution and SNI handling.
 
 This module provides a custom :class:`requests.adapters.HTTPAdapter` that allows for specifying a DNS server
 for hostname resolution and handles Server Name Indication (SNI) for HTTPS connections.
@@ -7,10 +8,10 @@ for hostname resolution and handles Server Name Indication (SNI) for HTTPS conne
 import logging
 import socket
 import ssl
-from typing import Optional, Tuple, List, Dict, Any # Use list, dict
+from typing import Optional, Tuple, Any  # Use list, dict
 
 import requests
-import requests.utils # For urlparse, urlunparse
+import requests.utils  # For urlparse, urlunparse
 from requests.adapters import HTTPAdapter
 
 try:
@@ -18,7 +19,9 @@ try:
     import dns.exception
 except ImportError:
     dns = None
-    logging.getLogger(__name__).warning("dnspython library not found. Custom DNS functionality will be disabled in CustomDNSAdapter.")
+    logging.getLogger(__name__).warning(
+        "dnspython library not found. Custom DNS functionality will be disabled in CustomDNSAdapter."
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +44,9 @@ class CustomDNSAdapter(HTTPAdapter):
     If custom DNS is not used or resolution fails, it behaves like a standard :class:`requests.adapters.HTTPAdapter`.
     """
 
-    def __init__(self, *args: Any, custom_dns_server: Optional[str] = None, default_sni: Optional[str] = None, **kwargs: Any):
+    def __init__(
+        self, *args: Any, custom_dns_server: Optional[str] = None, default_sni: Optional[str] = None, **kwargs: Any
+    ):
         """
         Initialize the CustomDNSAdapter.
 
@@ -76,11 +81,17 @@ class CustomDNSAdapter(HTTPAdapter):
         :rtype: Optional[str]
         """
         if not self.custom_dns_server or not dns:
-            logger.debug("CustomDNSAdapter: Skipping custom DNS (server: %s, dnspython available: %s) for %s.",
-                         self.custom_dns_server, bool(dns), hostname)
+            logger.debug(
+                "CustomDNSAdapter: Skipping custom DNS (server: %s, dnspython available: %s) for %s.",
+                self.custom_dns_server,
+                bool(dns),
+                hostname,
+            )
             return None
 
-        logger.info("CustomDNSAdapter: Attempting to resolve '%s' using DNS server %s", hostname, self.custom_dns_server)
+        logger.info(
+            "CustomDNSAdapter: Attempting to resolve '%s' using DNS server %s", hostname, self.custom_dns_server
+        )
         resolver = dns.resolver.Resolver()
         resolver.nameservers = [self.custom_dns_server]
         resolver.timeout = 2.0
@@ -96,21 +107,42 @@ class CustomDNSAdapter(HTTPAdapter):
                     if ips:
                         break
                 except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-                    logger.debug("CustomDNSAdapter: No %s records found for %s via %s.", rdtype, hostname, self.custom_dns_server)
+                    logger.debug(
+                        "CustomDNSAdapter: No %s records found for %s via %s.", rdtype, hostname, self.custom_dns_server
+                    )
                 except dns.exception.DNSException as e:
-                    logger.warning("CustomDNSAdapter: DNS %s query for %s via %s failed: %s",
-                                   rdtype, hostname, self.custom_dns_server, e)
+                    logger.warning(
+                        "CustomDNSAdapter: DNS %s query for %s via %s failed: %s",
+                        rdtype,
+                        hostname,
+                        self.custom_dns_server,
+                        e,
+                    )
 
             if ips:
                 selected_ip = ips[0]
-                logger.info("CustomDNSAdapter: Resolved '%s' to %s (using %s).", hostname, selected_ip, self.custom_dns_server)
+                logger.info(
+                    "CustomDNSAdapter: Resolved '%s' to %s (using %s).", hostname, selected_ip, self.custom_dns_server
+                )
                 return selected_ip
-            logger.warning("CustomDNSAdapter: No AAAA or A records found for %s via %s.", hostname, self.custom_dns_server)
+            logger.warning(
+                "CustomDNSAdapter: No AAAA or A records found for %s via %s.", hostname, self.custom_dns_server
+            )
         except Exception as e:
-            logger.error("CustomDNSAdapter: Unexpected error during custom DNS resolution for %s: %s", hostname, e, exc_info=True)
+            logger.error(
+                "CustomDNSAdapter: Unexpected error during custom DNS resolution for %s: %s", hostname, e, exc_info=True
+            )
         return None
 
-    def send(self, request: requests.models.PreparedRequest, stream: bool = False, timeout: Optional[float | Tuple[float, float]] = None, verify: bool = True, cert: Optional[Tuple[str, str] | str] = None, proxies: Optional[dict[str,str]]=None) -> requests.Response: # type: ignore[override]
+    def send(
+        self,
+        request: requests.models.PreparedRequest,
+        stream: bool = False,
+        timeout: Optional[float | Tuple[float, float]] = None,
+        verify: bool = True,
+        cert: Optional[Tuple[str, str] | str] = None,
+        proxies: Optional[dict[str, str]] = None,
+    ) -> requests.Response:  # type: ignore[override]
         """
         Send a prepared request.
 
@@ -139,7 +171,7 @@ class CustomDNSAdapter(HTTPAdapter):
         :return: The :class:`requests.Response` object.
         :rtype: requests.Response
         """
-        parsed_url = requests.utils.urlparse(request.url) # type: ignore[attr-defined]
+        parsed_url = requests.utils.urlparse(request.url)  # type: ignore[attr-defined]
         original_hostname = parsed_url.hostname
         self._resolved_sni = None
 
@@ -160,12 +192,16 @@ class CustomDNSAdapter(HTTPAdapter):
             if resolved_ip:
                 self._resolved_sni = original_hostname
                 self.resolved_ip_cache[original_hostname] = resolved_ip
-                logger.info("CustomDNSAdapter.send: Original request URL %s will be used. Connection will target resolved IP %s (SNI will be: %s)", # type: ignore[str-format]
-                             request.url, resolved_ip, self._resolved_sni)
+                logger.info(
+                    "CustomDNSAdapter.send: Original request URL %s will be used. Connection will target resolved IP %s (SNI will be: %s)",  # type: ignore[str-format]
+                    request.url,
+                    resolved_ip,
+                    self._resolved_sni,
+                )
 
-        return super().send(request, stream, timeout, verify, cert, proxies) # type: ignore[return-value]
+        return super().send(request, stream, timeout, verify, cert, proxies)  # type: ignore[return-value]
 
-    def get_connection(self, url: str, proxies: Optional[dict[str, str]] = None) -> Any: # type: ignore[override]
+    def get_connection(self, url: str, proxies: Optional[dict[str, str]] = None) -> Any:  # type: ignore[override]
         """
         Override :meth:`requests.adapters.HTTPAdapter.get_connection` for custom IP resolution.
 
@@ -176,7 +212,7 @@ class CustomDNSAdapter(HTTPAdapter):
         :return: The connection object from `urllib3`.
         :rtype: urllib3.connectionpool.HTTPConnectionPool or urllib3.connectionpool.HTTPSConnectionPool
         """
-        parsed_url = requests.utils.urlparse(url) # type: ignore[attr-defined]
+        parsed_url = requests.utils.urlparse(url)  # type: ignore[attr-defined]
         original_hostname = parsed_url.hostname
 
         resolved_ip_for_connection: Optional[str] = None
@@ -184,10 +220,14 @@ class CustomDNSAdapter(HTTPAdapter):
             resolved_ip_for_connection = self.resolved_ip_cache[original_hostname]
 
         if resolved_ip_for_connection:
-            logger.info("CustomDNSAdapter.get_connection: Using resolved IP %s for connection to original host %s (URL: %s)", # type: ignore[str-format]
-                         resolved_ip_for_connection, original_hostname, url)
+            logger.info(
+                "CustomDNSAdapter.get_connection: Using resolved IP %s for connection to original host %s (URL: %s)",  # type: ignore[str-format]
+                resolved_ip_for_connection,
+                original_hostname,
+                url,
+            )
 
-            conn_url_parts = list(parsed_url[:]) # Make a mutable copy
+            conn_url_parts = list(parsed_url[:])  # Make a mutable copy
             new_netloc = resolved_ip_for_connection
             if parsed_url.port:
                 new_netloc += f":{parsed_url.port}"
@@ -196,16 +236,22 @@ class CustomDNSAdapter(HTTPAdapter):
             if not conn_url_parts[0]:
                 conn_url_parts[0] = "https" if parsed_url.scheme == "https" else "http"
 
-            connection_target_url = requests.utils.urlunparse(conn_url_parts) # type: ignore[attr-defined]
+            connection_target_url = requests.utils.urlunparse(conn_url_parts)  # type: ignore[attr-defined]
 
-            logger.debug("CustomDNSAdapter.get_connection: PoolManager will connect to IP-based URL: %s (SNI via _resolved_sni: %s)", # type: ignore[str-format]
-                         connection_target_url, self._resolved_sni)
-            return self.poolmanager.connection_from_url(connection_target_url) # type: ignore[no-any-return]
+            logger.debug(
+                "CustomDNSAdapter.get_connection: PoolManager will connect to IP-based URL: %s (SNI via _resolved_sni: %s)",  # type: ignore[str-format]
+                connection_target_url,
+                self._resolved_sni,
+            )
+            return self.poolmanager.connection_from_url(connection_target_url)  # type: ignore[no-any-return]
         else:
-            logger.debug("CustomDNSAdapter.get_connection: Proceeding with default connection for URL: %s. Cache miss or custom DNS not used for this host.", url)
-            return super().get_connection(url, proxies=proxies) # type: ignore[no-any-return]
+            logger.debug(
+                "CustomDNSAdapter.get_connection: Proceeding with default connection for URL: %s. Cache miss or custom DNS not used for this host.",
+                url,
+            )
+            return super().get_connection(url, proxies=proxies)  # type: ignore[no-any-return]
 
-    def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any) -> None: # type: ignore[override]
+    def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any) -> None:  # type: ignore[override]
         """
         Initialize the `urllib3.PoolManager` with SNI and certificate validation settings.
 
@@ -221,7 +267,10 @@ class CustomDNSAdapter(HTTPAdapter):
         sni_hostname_for_pool: Optional[str] = None
         if self._resolved_sni:
             sni_hostname_for_pool = self._resolved_sni
-            logger.info("CustomDNSAdapter.init_poolmanager: Using SNI/assert_hostname from resolved hostname: %s", sni_hostname_for_pool)
+            logger.info(
+                "CustomDNSAdapter.init_poolmanager: Using SNI/assert_hostname from resolved hostname: %s",
+                sni_hostname_for_pool,
+            )
         elif self.default_sni_for_ip_url:
             sni_hostname_for_pool = self.default_sni_for_ip_url
             logger.info("CustomDNSAdapter.init_poolmanager: Using default SNI for IP URL: %s", sni_hostname_for_pool)
@@ -230,8 +279,12 @@ class CustomDNSAdapter(HTTPAdapter):
             pool_kwargs["assert_hostname"] = sni_hostname_for_pool
             pool_kwargs["server_hostname"] = sni_hostname_for_pool
             pool_kwargs["cert_reqs"] = ssl.CERT_REQUIRED
-            logger.debug("CustomDNSAdapter.init_poolmanager: Pool configured with SNI/assert_hostname: %s", sni_hostname_for_pool)
+            logger.debug(
+                "CustomDNSAdapter.init_poolmanager: Pool configured with SNI/assert_hostname: %s", sni_hostname_for_pool
+            )
         else:
-            logger.debug("CustomDNSAdapter.init_poolmanager: No specific SNI/assert_hostname configuration for this pool.")
+            logger.debug(
+                "CustomDNSAdapter.init_poolmanager: No specific SNI/assert_hostname configuration for this pool."
+            )
 
         super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)

--- a/src/dns_client.py
+++ b/src/dns_client.py
@@ -1,6 +1,7 @@
 """Module for performing DNS lookups."""
+
 import logging
-from typing import Optional, List, Dict, Any # Use list, dict
+from typing import Optional, List, Dict, Any  # Use list, dict
 import ipaddress
 
 import dns.resolver
@@ -17,20 +18,24 @@ class DnsClientError(Exception):
 
     pass
 
+
 class DnsResolutionTimeoutError(DnsClientError):
     """Exception for DNS resolution timeouts."""
 
     pass
+
 
 class DnsNxDomainError(DnsClientError):
     """Exception for NXDOMAIN errors (non-existent domain)."""
 
     pass
 
+
 class DnsNoAnswerError(DnsClientError):
     """Exception for NoAnswer errors (query name exists, but not for specified type)."""
 
     pass
+
 
 class DnsGenericError(DnsClientError):
     """Exception for other DNS resolution errors."""
@@ -72,40 +77,40 @@ class DnsResolverClient:
         :rtype: list[dict[str, Any]]
         """
         try:
-            answer: dns.resolver.Answer = self.resolver.resolve(query_name_str, record_type_str) # type: ignore[no-untyped-call]
+            answer: dns.resolver.Answer = self.resolver.resolve(query_name_str, record_type_str)  # type: ignore[no-untyped-call]
             parsed_records: list[dict[str, Any]] = []
             for rdata in answer:
                 record: dict[str, Any] = {
-                    'name': answer.qname.to_text(), # type: ignore[attr-defined]
-                    'ttl': rdata.ttl if hasattr(rdata, 'ttl') else answer.response.answer[0].ttl, # type: ignore[union-attr]
-                    'class': dns.rdataclass.to_text(rdata.rdclass), # type: ignore[no-untyped-call]
-                    'type': dns.rdatatype.to_text(rdata.rdtype) # type: ignore[no-untyped-call]
+                    "name": answer.qname.to_text(),  # type: ignore[attr-defined]
+                    "ttl": rdata.ttl if hasattr(rdata, "ttl") else answer.response.answer[0].ttl,  # type: ignore[union-attr]
+                    "class": dns.rdataclass.to_text(rdata.rdclass),  # type: ignore[no-untyped-call]
+                    "type": dns.rdatatype.to_text(rdata.rdtype),  # type: ignore[no-untyped-call]
                 }
                 if rdata.rdtype == dns.rdatatype.A:
-                    record['address'] = rdata.address
+                    record["address"] = rdata.address
                 elif rdata.rdtype == dns.rdatatype.AAAA:
-                    record['address'] = rdata.address
+                    record["address"] = rdata.address
                 elif rdata.rdtype == dns.rdatatype.CNAME:
-                    record['target'] = rdata.target.to_text()
+                    record["target"] = rdata.target.to_text()
                 elif rdata.rdtype == dns.rdatatype.MX:
-                    record['preference'] = rdata.preference
-                    record['exchange'] = rdata.exchange.to_text()
-                elif rdata.rdtype == dns.rdatatype.TXT: # type: ignore[attr-defined]
-                    record['texts'] = [s.decode('utf-8', 'replace') for s in rdata.strings] # type: ignore[attr-defined]
-                elif rdata.rdtype == dns.rdatatype.NS: # type: ignore[attr-defined]
-                    record['target'] = rdata.target.to_text() # type: ignore[attr-defined]
-                elif rdata.rdtype == dns.rdatatype.PTR: # type: ignore[attr-defined]
-                    record['target'] = rdata.target.to_text() # type: ignore[attr-defined]
-                elif rdata.rdtype == dns.rdatatype.SOA: # type: ignore[attr-defined]
-                    record['mname'] = rdata.mname.to_text() # type: ignore[attr-defined]
-                    record['rname'] = rdata.rname.to_text() # type: ignore[attr-defined]
-                    record['serial'] = rdata.serial # type: ignore[attr-defined]
-                    record['refresh'] = rdata.refresh # type: ignore[attr-defined]
-                    record['retry'] = rdata.retry # type: ignore[attr-defined]
-                    record['expire'] = rdata.expire # type: ignore[attr-defined]
-                    record['minimum'] = rdata.minimum # type: ignore[attr-defined]
+                    record["preference"] = rdata.preference
+                    record["exchange"] = rdata.exchange.to_text()
+                elif rdata.rdtype == dns.rdatatype.TXT:  # type: ignore[attr-defined]
+                    record["texts"] = [s.decode("utf-8", "replace") for s in rdata.strings]  # type: ignore[attr-defined]
+                elif rdata.rdtype == dns.rdatatype.NS:  # type: ignore[attr-defined]
+                    record["target"] = rdata.target.to_text()  # type: ignore[attr-defined]
+                elif rdata.rdtype == dns.rdatatype.PTR:  # type: ignore[attr-defined]
+                    record["target"] = rdata.target.to_text()  # type: ignore[attr-defined]
+                elif rdata.rdtype == dns.rdatatype.SOA:  # type: ignore[attr-defined]
+                    record["mname"] = rdata.mname.to_text()  # type: ignore[attr-defined]
+                    record["rname"] = rdata.rname.to_text()  # type: ignore[attr-defined]
+                    record["serial"] = rdata.serial  # type: ignore[attr-defined]
+                    record["refresh"] = rdata.refresh  # type: ignore[attr-defined]
+                    record["retry"] = rdata.retry  # type: ignore[attr-defined]
+                    record["expire"] = rdata.expire  # type: ignore[attr-defined]
+                    record["minimum"] = rdata.minimum  # type: ignore[attr-defined]
                 else:
-                    record['data'] = rdata.to_text() # type: ignore[no-untyped-call]
+                    record["data"] = rdata.to_text()  # type: ignore[no-untyped-call]
                 parsed_records.append(record)
             return parsed_records
         except dns.resolver.NXDOMAIN as e:
@@ -113,7 +118,9 @@ class DnsResolverClient:
             raise DnsNxDomainError(f"Domain not found: {query_name_str}") from e
         except dns.resolver.NoAnswer as e:
             logger.info("DnsResolverClient: NoAnswer for %s (%s): %s", query_name_str, record_type_str, e)
-            raise DnsNoAnswerError(f"No {record_type_str} records found for {query_name_str}, though the name exists.") from e
+            raise DnsNoAnswerError(
+                f"No {record_type_str} records found for {query_name_str}, though the name exists."
+            ) from e
         except dns.resolver.Timeout as e:
             logger.warning("DnsResolverClient: Timeout for %s (%s): %s", query_name_str, record_type_str, e)
             raise DnsResolutionTimeoutError(f"DNS query timed out for {query_name_str}") from e
@@ -145,24 +152,44 @@ class DnsResolverClient:
             try:
                 is_ip = False
                 try:
-                    ipaddress.ip_address(domain_or_ip) # Use a proper IP validation library
+                    ipaddress.ip_address(domain_or_ip)  # Use a proper IP validation library
                     is_ip = True
                 except ValueError:
                     is_ip = False
 
                 if is_ip:
                     query_target = dns.reversename.from_address(domain_or_ip)
-                    logger.debug("DnsResolverClient: Converted IP %s to reverse name %s for PTR lookup", domain_or_ip, query_target)
+                    logger.debug(
+                        "DnsResolverClient: Converted IP %s to reverse name %s for PTR lookup",
+                        domain_or_ip,
+                        query_target,
+                    )
                 # If it's not an IP, and PTR is requested, it will likely fail or return empty,
                 # which is the correct behavior for a non-IP PTR query.
             except dns.exception.SyntaxError as e:
-                 logger.warning("DnsResolverClient: Syntax error converting '%s' for PTR query: %s. Proceeding with original target.", domain_or_ip, e)
-                 # Proceed with domain_or_ip as query_target, which might be intentional for non-IP PTRs
+                logger.warning(
+                    "DnsResolverClient: Syntax error converting '%s' for PTR query: %s. Proceeding with original target.",
+                    domain_or_ip,
+                    e,
+                )
+                # Proceed with domain_or_ip as query_target, which might be intentional for non-IP PTRs
             except TypeError as e_type:
-                 logger.error("DnsResolverClient: Type error during IP to reverse name conversion for PTR query on '%s': %s. Proceeding with original target.", domain_or_ip, e_type)
+                logger.error(
+                    "DnsResolverClient: Type error during IP to reverse name conversion for PTR query on '%s': %s. Proceeding with original target.",
+                    domain_or_ip,
+                    e_type,
+                )
             except ValueError as e_value:
-                 logger.error("DnsResolverClient: Value error during IP to reverse name conversion for PTR query on '%s': %s. Proceeding with original target.", domain_or_ip, e_value)
+                logger.error(
+                    "DnsResolverClient: Value error during IP to reverse name conversion for PTR query on '%s': %s. Proceeding with original target.",
+                    domain_or_ip,
+                    e_value,
+                )
             except Exception as e:
-                 logger.error("DnsResolverClient: Unexpected error converting '%s' for PTR query: %s. Proceeding with original target.", domain_or_ip, e)
+                logger.error(
+                    "DnsResolverClient: Unexpected error converting '%s' for PTR query: %s. Proceeding with original target.",
+                    domain_or_ip,
+                    e,
+                )
 
         return self._lookup_record_internal(query_target, record_type.upper())

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -68,9 +68,7 @@ class DNSPage(Adw.PreferencesPage):
         # Global Font setting
         self._output_font_gsettings_key = "output-font"
         output_font_str = self.settings.get_string(self._output_font_gsettings_key)
-        self._output_font_desc = Pango.FontDescription.from_string(
-            output_font_str if output_font_str else "Sans 10"
-        )
+        self._output_font_desc = Pango.FontDescription.from_string(output_font_str if output_font_str else "Sans 10")
 
         # Stored results for refresh
         self._current_result_records: Optional[List[Dict[str, Any]]] = None
@@ -94,9 +92,7 @@ class DNSPage(Adw.PreferencesPage):
             self.dns_copy_all_results_button.connect("clicked", self._on_copy_all_results_clicked)
 
         # Connect GSettings change for global font
-        self.settings.connect(
-            f"changed::{self._output_font_gsettings_key}", self._on_global_output_font_changed
-        )
+        self.settings.connect(f"changed::{self._output_font_gsettings_key}", self._on_global_output_font_changed)
 
     def _on_global_output_font_changed(self, settings: Gio.Settings, key: str) -> None:
         logger.debug("DNSPage: Global output font setting changed for key: %s", key)
@@ -239,9 +235,7 @@ class DNSPage(Adw.PreferencesPage):
         logger.debug(f"_on_entry_activated called by widget: {_widget}")
         self._perform_lookup()
 
-    def _on_record_type_changed(
-        self, _dropdown: Gtk.DropDown, _param_spec: GObject.ParamSpec
-    ) -> None:
+    def _on_record_type_changed(self, _dropdown: Gtk.DropDown, _param_spec: GObject.ParamSpec) -> None:
         """
         Handle changes in the selected DNS record type.
 
@@ -256,9 +250,7 @@ class DNSPage(Adw.PreferencesPage):
 
     # --- Helper methods for building record rows ---
 
-    def _create_copy_button(
-        self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget
-    ) -> Gtk.Button:
+    def _create_copy_button(self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget) -> Gtk.Button:
         """
         Create a :class:`Gtk.Button` for copying text.
 
@@ -276,9 +268,7 @@ class DNSPage(Adw.PreferencesPage):
         button.set_tooltip_text(tooltip_text)
         button.connect(
             "clicked",
-            lambda _btn, text=text_to_copy, w=widget_for_clipboard: DNSPage._copy_to_clipboard(
-                text, w
-            ),
+            lambda _btn, text=text_to_copy, w=widget_for_clipboard: DNSPage._copy_to_clipboard(text, w),
         )
         return button
 
@@ -337,9 +327,7 @@ class DNSPage(Adw.PreferencesPage):
         # suffix_box removed
         row.add_suffix(value_label)  # type: ignore
         row.add_suffix(
-            self._create_copy_button(
-                main_value_text, f"{main_value_tooltip_prefix}: {main_value_text}", row
-            )
+            self._create_copy_button(main_value_text, f"{main_value_tooltip_prefix}: {main_value_text}", row)
         )  # type: ignore
         row.add_suffix(self._create_copy_button(full_summary_text, "Copy Full Record Summary", row))  # type: ignore
 
@@ -364,9 +352,7 @@ class DNSPage(Adw.PreferencesPage):
         if icon_name:
             row.add_prefix(Gtk.Image(icon_name=icon_name))  # type: ignore
 
-        copy_full_button = self._create_copy_button(
-            full_summary_text, "Copy Full Record Summary", row
-        )
+        copy_full_button = self._create_copy_button(full_summary_text, "Copy Full Record Summary", row)
         row.add_suffix(copy_full_button)  # type: ignore
         return row
 
@@ -405,14 +391,10 @@ class DNSPage(Adw.PreferencesPage):
             ellipsize=Pango.EllipsizeMode.END,
         )
         value_label.override_font(self._output_font_desc)
-        copy_button = self._create_copy_button(
-            value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row
-        )
+        copy_button = self._create_copy_button(value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row)
 
         # content_box removed
-        if (
-            is_value_primary_content
-        ):  # For TXT segments where the value is the main content of the row
+        if is_value_primary_content:  # For TXT segments where the value is the main content of the row
             detail_row.add_prefix(value_label)  # type: ignore
             detail_row.add_prefix(copy_button)  # type: ignore
         else:  # For SOA fields where title is present and value is a suffix
@@ -442,13 +424,9 @@ class DNSPage(Adw.PreferencesPage):
             current_subtitle = self.dns_status_row.get_subtitle()  # type: ignore
             if message:
                 self.dns_status_row.set_subtitle(message)  # type: ignore
-            elif (
-                active and current_subtitle != "Looking up..."
-            ):  # Default message when starting an operation
+            elif active and current_subtitle != "Looking up...":  # Default message when starting an operation
                 self.dns_status_row.set_subtitle("Looking up...")  # type: ignore
-            elif (
-                not active and not message
-            ):  # Default message when stopping (idle) and no specific message given
+            elif not active and not message:  # Default message when stopping (idle) and no specific message given
                 self.dns_status_row.set_subtitle("Idle")  # type: ignore
             # If not active and a message is present (e.g. error or success), it will be set by the caller.
 
@@ -533,9 +511,7 @@ class DNSPage(Adw.PreferencesPage):
         # This logic is mainly for updating the dropdown if it wasn't already PTR for an IP.
         actual_record_type_displayed = requested_record_type
         if is_valid_ip(user_input) and requested_record_type.upper() == "PTR":
-            actual_record_type_displayed = self._update_ptr_dropdown(
-                user_input, requested_record_type
-            )
+            actual_record_type_displayed = self._update_ptr_dropdown(user_input, requested_record_type)
 
         nameservers_used = dns_client.resolver.nameservers
 
@@ -545,9 +521,7 @@ class DNSPage(Adw.PreferencesPage):
         self._current_requested_record_type = actual_record_type_displayed
         self._current_dns_servers = nameservers_used
 
-        self._display_result(
-            result_data, user_input, actual_record_type_displayed, nameservers_used
-        )
+        self._display_result(result_data, user_input, actual_record_type_displayed, nameservers_used)
 
         status_message = (
             f"{len(result_data)} {actual_record_type_displayed} record(s) found."
@@ -579,9 +553,7 @@ class DNSPage(Adw.PreferencesPage):
         :type dns_client: .dns_client.DnsResolverClient
         """
         error_message = str(error)  # Original full error message
-        status_subtitle = (
-            f"Error: {error_message.splitlines()[0]}"  # Default status: first line of error
-        )
+        status_subtitle = f"Error: {error_message.splitlines()[0]}"  # Default status: first line of error
 
         if isinstance(error, DnsNxDomainError):
             show_global_error(self, error_message)  # type: ignore
@@ -599,9 +571,7 @@ class DNSPage(Adw.PreferencesPage):
                 [], user_input, requested_record_type, nameservers_used
             )  # Shows "No records found" in results area
             # Override the "No records found" status from _display_result with the actual error for clarity in status row
-            status_subtitle = (
-                f"No {requested_record_type} records found for {user_input} (No Answer)."
-            )
+            status_subtitle = f"No {requested_record_type} records found for {user_input} (No Answer)."
         elif isinstance(error, DnsResolutionTimeoutError):
             show_global_error(self, error_message)  # type: ignore
             status_subtitle = f"Timeout: Could not resolve {user_input}."
@@ -646,14 +616,10 @@ class DNSPage(Adw.PreferencesPage):
         self._set_loading_state(True, "Looking up...")
         user_input = self.domain_entry.get_text().strip()  # type: ignore
         requested_record_type = self._get_selected_record_type()
-        logger.debug(
-            f"DNSPage: Performing DNS lookup for: {user_input}, type: {requested_record_type}"
-        )
+        logger.debug(f"DNSPage: Performing DNS lookup for: {user_input}, type: {requested_record_type}")
 
         if not self._validate_dns_input(user_input):
-            self._set_loading_state(
-                False, "Idle - Invalid input."
-            )  # Reset status to Idle with specific message
+            self._set_loading_state(False, "Idle - Invalid input.")  # Reset status to Idle with specific message
             return
 
         self._clear_error()
@@ -663,9 +629,7 @@ class DNSPage(Adw.PreferencesPage):
 
         try:
             result_data = dns_client.resolve(user_input, requested_record_type)
-            self._handle_dns_lookup_success(
-                result_data, user_input, requested_record_type, dns_client
-            )
+            self._handle_dns_lookup_success(result_data, user_input, requested_record_type, dns_client)
             # Status is set by _handle_dns_lookup_success
         except Exception as e:  # Catch all exceptions here and delegate to the handler
             self._handle_dns_lookup_exception(e, user_input, requested_record_type, dns_client)
@@ -741,9 +705,7 @@ class DNSPage(Adw.PreferencesPage):
         while child := self.dns_results_box_container.get_first_child():  # type: ignore
             self.dns_results_box_container.remove(child)  # type: ignore
 
-        query_info_row = Adw.ActionRow(
-            title=f"Query: {domain_or_ip}", subtitle=f"Record type queried: {record_type}"
-        )
+        query_info_row = Adw.ActionRow(title=f"Query: {domain_or_ip}", subtitle=f"Record type queried: {record_type}")
         query_info_row.set_selectable(False)
         self.dns_results_box_container.append(query_info_row)  # type: ignore
 
@@ -782,9 +744,7 @@ class DNSPage(Adw.PreferencesPage):
 
     # --- Helper methods for building record rows ---
 
-    def _create_copy_button(
-        self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget
-    ) -> Gtk.Button:
+    def _create_copy_button(self, text_to_copy: str, tooltip_text: str, widget_for_clipboard: Gtk.Widget) -> Gtk.Button:
         """
         Create a :class:`Gtk.Button` for copying text.
 
@@ -802,9 +762,7 @@ class DNSPage(Adw.PreferencesPage):
         button.set_tooltip_text(tooltip_text)
         button.connect(
             "clicked",
-            lambda _btn, text=text_to_copy, w=widget_for_clipboard: DNSPage._copy_to_clipboard(
-                text, w
-            ),
+            lambda _btn, text=text_to_copy, w=widget_for_clipboard: DNSPage._copy_to_clipboard(text, w),
         )
         return button
 
@@ -862,9 +820,7 @@ class DNSPage(Adw.PreferencesPage):
         copy_value_button = self._create_copy_button(
             main_value_text, f"{main_value_tooltip_prefix}: {main_value_text}", row
         )
-        copy_full_summary_button = self._create_copy_button(
-            full_summary_text, "Copy Full Record Summary", row
-        )
+        copy_full_summary_button = self._create_copy_button(full_summary_text, "Copy Full Record Summary", row)
 
         row.add_suffix(value_label)  # type: ignore
         row.add_suffix(copy_value_button)  # type: ignore
@@ -891,9 +847,7 @@ class DNSPage(Adw.PreferencesPage):
         if icon_name:
             row.add_prefix(Gtk.Image(icon_name=icon_name))  # type: ignore
 
-        copy_full_button = self._create_copy_button(
-            full_summary_text, "Copy Full Record Summary", row
-        )
+        copy_full_button = self._create_copy_button(full_summary_text, "Copy Full Record Summary", row)
         row.add_suffix(copy_full_button)  # type: ignore
         # row.set_expanded(True) # Decided by caller, as TXT/SOA might be empty initially
         return row
@@ -930,14 +884,10 @@ class DNSPage(Adw.PreferencesPage):
             wrap=True,
             wrap_mode=Pango.WrapMode.WORD_CHAR,
         )
-        copy_button = self._create_copy_button(
-            value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row
-        )
+        copy_button = self._create_copy_button(value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row)
 
         # content_box is removed. Widgets will be added directly to the detail_row.
-        if (
-            is_value_primary_content
-        ):  # For TXT segments where the value is the main content of the row
+        if is_value_primary_content:  # For TXT segments where the value is the main content of the row
             detail_row.add_prefix(value_label)  # type: ignore
             detail_row.add_prefix(copy_button)  # type: ignore
         else:  # For SOA fields where title is present and value is a suffix
@@ -966,11 +916,11 @@ class DNSPage(Adw.PreferencesPage):
         :return: An :class:`Adw.ActionRow` for the record.
         :rtype: Adw.ActionRow
         """
-        row = self._create_base_action_row(
-            name, record_type, base_subtitle, "network-wired-symbolic"
-        )
+        row = self._create_base_action_row(name, record_type, base_subtitle, "network-wired-symbolic")
         address_value = str(record_data.get("address", "N/A"))
-        summary_text = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {address_value}"
+        summary_text = (
+            f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {address_value}"
+        )
         self._add_standard_suffix_box_to_row(row, address_value, "Copy Address", summary_text)
         return row
 
@@ -999,7 +949,9 @@ class DNSPage(Adw.PreferencesPage):
 
         row = self._create_base_action_row(name, record_type, base_subtitle, icon_name)
         target_value = str(record_data.get("target", "N/A"))
-        summary_text = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {target_value}"
+        summary_text = (
+            f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {target_value}"
+        )
         self._add_standard_suffix_box_to_row(row, target_value, "Copy Target", summary_text)
         return row
 
@@ -1020,16 +972,14 @@ class DNSPage(Adw.PreferencesPage):
         :return: An :class:`Adw.ActionRow` for the record.
         :rtype: Adw.ActionRow
         """
-        row = self._create_base_action_row(
-            name, record_type, base_subtitle, "help-question-symbolic"
-        )
+        row = self._create_base_action_row(name, record_type, base_subtitle, "help-question-symbolic")
         data_value = str(record_data.get("data", "N/A"))
         summary_text = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} {record_type} {data_value}"
         self._add_standard_suffix_box_to_row(row, data_value, "Copy Data", summary_text)
         return row
 
     def _build_mx_record_row(
-        self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str
+        self, record_data: Dict[str, Any], name: str, base_subtitle: str
     ) -> Adw.ExpanderRow:  # record_type is "MX"
         """
         Build a UI row for an MX DNS record.
@@ -1047,7 +997,9 @@ class DNSPage(Adw.PreferencesPage):
         """
         exchange_value = str(record_data.get("exchange", "N/A"))
         preference_value = str(record_data.get("preference", "N/A"))
-        summary_mx = f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} MX {preference_value} {exchange_value}"
+        summary_mx = (
+            f"{name} {record_data.get('ttl', '')} {record_data.get('class', '')} MX {preference_value} {exchange_value}"
+        )
 
         row = self._create_base_expander_row(
             name, f"MX Record ({base_subtitle})", "mail-send-receive-symbolic", summary_mx
@@ -1063,9 +1015,7 @@ class DNSPage(Adw.PreferencesPage):
             lines=1,
             ellipsize=Pango.EllipsizeMode.END,
         )
-        copy_button_exchange = self._create_copy_button(
-            exchange_value, f"Copy Exchange: {exchange_value}", row
-        )
+        copy_button_exchange = self._create_copy_button(exchange_value, f"Copy Exchange: {exchange_value}", row)
         # mx_detail_row_title_box removed
 
         mx_detail_row = Adw.ActionRow(subtitle=f"Preference: {preference_value}")  # type: ignore
@@ -1079,7 +1029,7 @@ class DNSPage(Adw.PreferencesPage):
         return row
 
     def _build_txt_record_row(
-        self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str
+        self, record_data: Dict[str, Any], name: str, base_subtitle: str
     ) -> Adw.ExpanderRow:  # record_type is "TXT"
         """
         Build a UI row for a TXT DNS record.
@@ -1115,7 +1065,7 @@ class DNSPage(Adw.PreferencesPage):
         return row
 
     def _build_soa_record_row(
-        self, record_data: Dict[str, Any], name: str, base_subtitle: str, record_type: str
+        self, record_data: Dict[str, Any], name: str, base_subtitle: str
     ) -> Adw.ExpanderRow:  # record_type is "SOA"
         """
         Build a UI row for an SOA DNS record.
@@ -1154,9 +1104,7 @@ class DNSPage(Adw.PreferencesPage):
             ("Minimum TTL", minimum_val),
         ]
         for field_name_str, field_value in soa_fields:
-            self._add_expander_detail_row(
-                row, field_name_str, field_value, f"Copy {field_name_str}"
-            )
+            self._add_expander_detail_row(row, field_name_str, field_value, f"Copy {field_name_str}")
         row.set_expanded(True)
         return row
 
@@ -1181,19 +1129,15 @@ class DNSPage(Adw.PreferencesPage):
         if record_type in ("A", "AAAA"):
             return self._build_address_record_row(record_data, name, base_subtitle, record_type)
         elif record_type in ("CNAME", "NS", "PTR"):
-            return self._build_cname_ns_ptr_record_row(
-                record_data, name, base_subtitle, record_type
-            )
+            return self._build_cname_ns_ptr_record_row(record_data, name, base_subtitle, record_type)
         elif record_type == "MX":
-            return self._build_mx_record_row(record_data, name, base_subtitle, record_type)
+            return self._build_mx_record_row(record_data, name, base_subtitle)
         elif record_type == "TXT":
-            return self._build_txt_record_row(record_data, name, base_subtitle, record_type)
+            return self._build_txt_record_row(record_data, name, base_subtitle)
         elif record_type == "SOA":
-            return self._build_soa_record_row(record_data, name, base_subtitle, record_type)
+            return self._build_soa_record_row(record_data, name, base_subtitle)
         elif record_data.get("data"):
-            return self._build_generic_data_record_row(
-                record_data, name, base_subtitle, record_type
-            )  # Renamed
+            return self._build_generic_data_record_row(record_data, name, base_subtitle, record_type)  # Renamed
         else:
             logger.warning(
                 "Could not create row for unknown record_data type or missing data field: %s (Type: %s)",
@@ -1213,6 +1157,4 @@ class DNSPage(Adw.PreferencesPage):
         if self.dns_apply_button and self.dns_apply_button.get_sensitive():  # type: ignore
             self.dns_apply_button.clicked()  # type: ignore
         else:
-            logger.warning(
-                "DNS lookup button not available or not sensitive, cannot trigger lookup."
-            )
+            logger.warning("DNS lookup button not available or not sensitive, cannot trigger lookup.")

--- a/src/helper.py
+++ b/src/helper.py
@@ -1,5 +1,6 @@
 """Provides a Helper class for :class:`Gtk.ColumnView` context menus and keyboard shortcuts."""
-from typing import Optional, List
+
+from typing import Optional
 from gi.repository import Gdk, Gtk, GObject
 import gi
 
@@ -16,7 +17,8 @@ class Helper:
     """
 
     def __init__(self, widget: Gtk.Widget, parent_window: Gtk.Window):
-        """Initialize the Helper class.
+        """
+        Initialize the Helper class.
 
         :param widget: The widget to which the helper is attached. This is
                        expected to be a :class:`Gtk.ColumnView` for full
@@ -30,14 +32,14 @@ class Helper:
         self.last_right_click_coords: Optional[tuple[float, float]] = None
         self.popover: Optional[Gtk.Popover] = None
 
-
         if isinstance(self.widget, Gtk.ColumnView):
-            self.widget.set_sensitive(True) # Ensure widget can receive events
+            self.widget.set_sensitive(True)  # Ensure widget can receive events
             self.setup_keyboard_shortcut()
             self.setup_context_menu()
 
     def setup_keyboard_shortcut(self) -> None:
-        """Set up a keyboard shortcut (``Ctrl+C``) for copying.
+        """
+        Set up a keyboard shortcut (``Ctrl+C``) for copying.
 
         This allows copying selected content from the :class:`Gtk.ColumnView`
         to the clipboard using the ``Ctrl+C`` combination.
@@ -45,31 +47,33 @@ class Helper:
         :return: None
         """
         key_controller = Gtk.EventControllerKey.new()
-        key_controller.connect("key-pressed", self.on_key_pressed) # type: ignore[no-untyped-call]
-        self.widget.add_controller(key_controller) # type: ignore[no-untyped-call]
+        key_controller.connect("key-pressed", self.on_key_pressed)  # type: ignore[no-untyped-call]
+        self.widget.add_controller(key_controller)  # type: ignore[no-untyped-call]
 
     def setup_context_menu(self) -> None:
-        """Set up a context menu (right-click) with a 'Copy' option.
+        """
+        Set up a context menu (right-click) with a 'Copy' option.
 
         :return: None
         """
         self.popover = Gtk.Popover.new()
         if isinstance(self.widget, Gtk.Widget):
-            self.popover.set_parent(self.widget) # type: ignore[no-untyped-call]
+            self.popover.set_parent(self.widget)  # type: ignore[no-untyped-call]
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         copy_button = Gtk.Button(label="Copy")
-        copy_button.connect("clicked", self.on_copy_menu_item_activated) # type: ignore[no-untyped-call]
-        vbox.append(copy_button) # type: ignore[no-untyped-call]
-        self.popover.set_child(vbox) # type: ignore[no-untyped-call]
+        copy_button.connect("clicked", self.on_copy_menu_item_activated)  # type: ignore[no-untyped-call]
+        vbox.append(copy_button)  # type: ignore[no-untyped-call]
+        self.popover.set_child(vbox)  # type: ignore[no-untyped-call]
 
         gesture = Gtk.GestureClick.new()
         gesture.set_button(3)  # Right-click # type: ignore[no-untyped-call]
-        gesture.connect("pressed", self.on_right_click) # type: ignore[no-untyped-call]
-        self.widget.add_controller(gesture) # type: ignore[no-untyped-call]
+        gesture.connect("pressed", self.on_right_click)  # type: ignore[no-untyped-call]
+        self.widget.add_controller(gesture)  # type: ignore[no-untyped-call]
 
     def on_right_click(self, _gesture: Gtk.GestureClick, n_press: int, x: float, y: float) -> None:
-        """Display the context menu popover at the location of the mouse click.
+        """
+        Display the context menu popover at the location of the mouse click.
 
         Called when the right-click gesture is detected on the widget.
 
@@ -90,12 +94,13 @@ class Helper:
                 rect.y = int(y)
                 rect.width = 1
                 rect.height = 1
-                self.popover.set_pointing_to(rect) # type: ignore[no-untyped-call]
-                self.popover.set_has_arrow(False) # type: ignore[no-untyped-call]
-                self.popover.popup() # type: ignore[no-untyped-call]
+                self.popover.set_pointing_to(rect)  # type: ignore[no-untyped-call]
+                self.popover.set_has_arrow(False)  # type: ignore[no-untyped-call]
+                self.popover.popup()  # type: ignore[no-untyped-call]
 
     def copy_context_item_to_clipboard(self) -> None:
-        """Copy the content of the right-clicked item to the clipboard.
+        """
+        Copy the content of the right-clicked item to the clipboard.
 
         This method uses the coordinates stored from the last right-click event
         to identify the specific :class:`Gtk.ListItem` and its underlying data item
@@ -105,14 +110,16 @@ class Helper:
 
         :return: None
         """
-        if not isinstance(self.widget, Gtk.ColumnView) or \
-           not hasattr(self, 'last_right_click_coords') or \
-           self.last_right_click_coords is None:
+        if (
+            not isinstance(self.widget, Gtk.ColumnView)
+            or not hasattr(self, "last_right_click_coords")
+            or self.last_right_click_coords is None
+        ):
             return
 
         x_coord, y_coord = self.last_right_click_coords
 
-        picked_widget = self.widget.pick(x_coord, y_coord, Gtk.PickFlags.DEFAULT) # type: ignore[no-untyped-call]
+        picked_widget = self.widget.pick(x_coord, y_coord, Gtk.PickFlags.DEFAULT)  # type: ignore[no-untyped-call]
 
         if picked_widget is None:
             return
@@ -124,7 +131,7 @@ class Helper:
             if isinstance(current_widget, Gtk.ListItem):
                 target_list_item_widget = current_widget
                 break
-            if current_widget == self.widget: # Stop if we've reached the ColumnView itself
+            if current_widget == self.widget:  # Stop if we've reached the ColumnView itself
                 break
             current_widget = current_widget.get_parent()
 
@@ -139,24 +146,24 @@ class Helper:
         text_to_copy: str = ""
         try:
             # Assuming item_obj is HeaderItem-like (has 'key', 'value', 'is_special_row')
-            key_attr = getattr(item_obj, 'key', None)
-            value_attr = getattr(item_obj, 'value', None)
-            is_special_attr = getattr(item_obj, 'is_special_row', False)
+            key_attr = getattr(item_obj, "key", None)
+            value_attr = getattr(item_obj, "value", None)
+            is_special_attr = getattr(item_obj, "is_special_row", False)
 
             if is_special_attr:
-                text_to_copy = str(key_attr if key_attr is not None else '')
-                val_str = str(value_attr if value_attr is not None else '')
+                text_to_copy = str(key_attr if key_attr is not None else "")
+                val_str = str(value_attr if value_attr is not None else "")
                 if val_str.strip() and val_str != "N/A":
                     text_to_copy += f" {val_str}"
-            elif key_attr == "": # Continuation line for a multi-part header
-                text_to_copy = str(value_attr if value_attr is not None else '')
-            else: # Standard header (key: value)
+            elif key_attr == "":  # Continuation line for a multi-part header
+                text_to_copy = str(value_attr if value_attr is not None else "")
+            else:  # Standard header (key: value)
                 text_to_copy = f"{str(key_attr if key_attr is not None else '')}: {str(value_attr if value_attr is not None else '')}"
 
-            clipboard: Gdk.Clipboard = self.widget.get_clipboard() # type: ignore[assignment]
+            clipboard: Gdk.Clipboard = self.widget.get_clipboard()  # type: ignore[assignment]
             if clipboard:
                 content_provider = Gdk.ContentProvider.new_for_value(text_to_copy)
-                clipboard.set_content(content_provider) # type: ignore[no-untyped-call]
+                clipboard.set_content(content_provider)  # type: ignore[no-untyped-call]
 
         except AttributeError:
             # This might happen if item_obj is not a HeaderItem-like object.
@@ -164,7 +171,8 @@ class Helper:
             pass
 
     def on_copy_menu_item_activated(self, _button: Gtk.Button) -> None:
-        """Handle activation of the 'Copy' menu item.
+        """
+        Handle activation of the 'Copy' menu item.
 
         Copies the right-clicked item's content to the clipboard and hides the popover.
 
@@ -174,14 +182,10 @@ class Helper:
         """
         self.copy_context_item_to_clipboard()
         if self.popover:
-            self.popover.popdown() # type: ignore[no-untyped-call]
+            self.popover.popdown()  # type: ignore[no-untyped-call]
 
     def on_key_pressed(
-        self,
-        _controller: Gtk.EventControllerKey,
-        keyval: int,
-        _keycode: int,
-        state: Gdk.ModifierType
+        self, _controller: Gtk.EventControllerKey, keyval: int, _keycode: int, state: Gdk.ModifierType
     ) -> bool:
         """
         Handle the ``Ctrl+C`` keyboard shortcut to copy selected content.
@@ -203,7 +207,8 @@ class Helper:
         return False
 
     def copy_to_clipboard(self) -> None:
-        """Copy selected content from the :class:`Gtk.ColumnView` to the clipboard.
+        """
+        Copy selected content from the :class:`Gtk.ColumnView` to the clipboard.
 
         Assumes the items in the :class:`Gtk.ColumnView` model have 'key' and
         'value' attributes to construct the string. This method formats the copied text
@@ -219,41 +224,41 @@ class Helper:
         selection_model: Optional[GObject.Object] = self.widget.get_model()
         selected_texts: list[str] = []
 
-        items_to_copy: list[GObject.Object] = [] # type: ignore[misc]
+        items_to_copy: list[GObject.Object] = []  # type: ignore[misc]
         if isinstance(selection_model, Gtk.MultiSelection):
-            selection_bitset: Gtk.Bitset = selection_model.get_selection() # type: ignore[assignment]
+            selection_bitset: Gtk.Bitset = selection_model.get_selection()  # type: ignore[assignment]
             current_pos = selection_bitset.get_minimum()
-            while current_pos != Gtk.INVALID_LIST_POSITION: # type: ignore[comparison-overlap]
-                item = selection_model.get_item(current_pos) # type: ignore[call-overload]
+            while current_pos != Gtk.INVALID_LIST_POSITION:  # type: ignore[comparison-overlap]
+                item = selection_model.get_item(current_pos)  # type: ignore[call-overload]
                 if item:
                     items_to_copy.append(item)
                 current_pos = selection_bitset.get_next(current_pos)
         elif isinstance(selection_model, Gtk.SingleSelection):
-            item = selection_model.get_selected_item() # type: ignore[call-overload]
+            item = selection_model.get_selected_item()  # type: ignore[call-overload]
             if item:
                 items_to_copy.append(item)
 
         for item_obj in items_to_copy:
-            if item_obj and hasattr(item_obj, 'key') and hasattr(item_obj, 'value'):
-                key_attr = getattr(item_obj, 'key', None)
-                value_attr = getattr(item_obj, 'value', None)
-                is_special_attr = getattr(item_obj, 'is_special_row', False)
+            if item_obj and hasattr(item_obj, "key") and hasattr(item_obj, "value"):
+                key_attr = getattr(item_obj, "key", None)
+                value_attr = getattr(item_obj, "value", None)
+                is_special_attr = getattr(item_obj, "is_special_row", False)
 
                 line_to_copy: str = ""
                 if is_special_attr:
-                    line_to_copy = str(key_attr if key_attr is not None else '')
-                    val_str = str(value_attr if value_attr is not None else '')
+                    line_to_copy = str(key_attr if key_attr is not None else "")
+                    val_str = str(value_attr if value_attr is not None else "")
                     if val_str.strip() and val_str != "N/A":
                         line_to_copy += f" {val_str}"
-                elif key_attr == "": # Continuation line
-                    line_to_copy = str(value_attr if value_attr is not None else '')
-                else: # Standard header
+                elif key_attr == "":  # Continuation line
+                    line_to_copy = str(value_attr if value_attr is not None else "")
+                else:  # Standard header
                     line_to_copy = f"{str(key_attr if key_attr is not None else '')}: {str(value_attr if value_attr is not None else '')}"
                 selected_texts.append(line_to_copy)
 
         if selected_texts:
             clipboard_text = "\n".join(selected_texts)
-            clipboard: Gdk.Clipboard = self.widget.get_clipboard() # type: ignore[assignment]
+            clipboard: Gdk.Clipboard = self.widget.get_clipboard()  # type: ignore[assignment]
             if clipboard:
                 content_provider = Gdk.ContentProvider.new_for_value(clipboard_text)
-                clipboard.set_content(content_provider) # type: ignore[no-untyped-call]
+                clipboard.set_content(content_provider)  # type: ignore[no-untyped-call]

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -1,9 +1,11 @@
 """Module for fetching HTTP headers and processing responses."""
+
 import logging
-from typing import Optional, Tuple, Dict, List, Any # Use dict, list
+from typing import Optional, Dict, List, Any  # Use dict, list
 
 import requests
-import requests.utils # For urlparse, urlunparse
+import requests.utils  # For urlparse, urlunparse
+
 try:
     import dns.resolver
     import dns.exception
@@ -14,8 +16,10 @@ except ImportError:
 try:
     import urllib3.exceptions as urllib3_exceptions
 except ImportError:
+
     class _DummyUrllib3Exception(Exception):
         pass
+
     urllib3_exceptions = type(
         "urllib3_exceptions",
         (),
@@ -38,15 +42,18 @@ class HttpClientError(Exception):
 
     pass
 
+
 class HttpRequestTimeoutError(HttpClientError):
     """Exception for request timeouts."""
 
     pass
 
+
 class HttpConnectionError(HttpClientError):
     """Exception for connection errors."""
 
     pass
+
 
 class HttpProcessingError(HttpClientError):
     """
@@ -73,21 +80,25 @@ class HttpProcessingError(HttpClientError):
         self.status_code: Optional[int] = status_code
         self.url = url
 
+
 class HttpGenericRequestError(HttpClientError):
     """Exception for other requests-related errors."""
 
     pass
 
+
 class HttpFetcher:
     """Encapsulates logic for making HTTP requests and processing responses."""
 
-    def __init__(self,
-                 url: str,
-                 use_akamai_pragma: bool = False,
-                 host_header: Optional[str] = None,
-                 user_agent: Optional[str] = None,
-                 custom_dns_server: Optional[str] = None,
-                 cancellable: Optional[Gio.Cancellable] = None):
+    def __init__(
+        self,
+        url: str,
+        use_akamai_pragma: bool = False,
+        host_header: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        custom_dns_server: Optional[str] = None,
+        cancellable: Optional[Gio.Cancellable] = None,
+    ):
         """
         Initialize HttpFetcher.
 
@@ -138,10 +149,15 @@ class HttpFetcher:
 
         if self.use_akamai_pragma:
             directives = [
-                "akamai-x-get-request-id", "akamai-x-get-cache-key", "akamai-x-cache-on",
-                "akamai-x-cache-remote-on", "akamai-x-get-true-cache-key",
-                "akamai-x-check-cacheable", "akamai-x-get-extracted-values",
-                "akamai-x-feo-trace", "x-akamai-logging-mode: verbose",
+                "akamai-x-get-request-id",
+                "akamai-x-get-cache-key",
+                "akamai-x-cache-on",
+                "akamai-x-cache-remote-on",
+                "akamai-x-get-true-cache-key",
+                "akamai-x-check-cacheable",
+                "akamai-x-get-extracted-values",
+                "akamai-x-feo-trace",
+                "x-akamai-logging-mode: verbose",
             ]
             session_headers["Pragma"] = ", ".join(directives)
             logger.info("HttpFetcher: Akamai Pragma headers included.")
@@ -188,7 +204,6 @@ class HttpFetcher:
             logger.warning("HttpFetcher: RequestException for '%s': %s", self.url, e)
             raise HttpGenericRequestError(f"Request failed for {self.url}: {e}") from e
 
-
     def _process_http_response(self, response: requests.Response) -> List[Dict[str, Any]]:
         """
         Process the HTTP response, including redirects.
@@ -203,7 +218,7 @@ class HttpFetcher:
         :rtype: list[dict[str, Any]]
         """
         all_responses_data: list[dict[str, Any]] = []
-        for hist_resp in response.history: # type: ignore[attr-defined]
+        for hist_resp in response.history:  # type: ignore[attr-defined]
             hist_data: dict[str, Any] = {
                 "type": "redirect",
                 "url": str(hist_resp.url),
@@ -212,19 +227,21 @@ class HttpFetcher:
             }
             all_responses_data.append(hist_data)
         try:
-            response.raise_for_status() # type: ignore[attr-defined]
+            response.raise_for_status()  # type: ignore[attr-defined]
             final_data_type = "final"
         except requests.exceptions.HTTPError as http_err:
             error_url = str(http_err.request.url) if http_err.request else self.url
             logger.warning("HttpFetcher: HTTPError for URL '%s' (final URL: '%s'): %s", self.url, error_url, http_err)
             error_message = self._format_http_error(http_err)
-            raise HttpProcessingError(error_message, status_code=http_err.response.status_code, url=error_url) from http_err # type: ignore[union-attr]
+            raise HttpProcessingError(
+                error_message, status_code=http_err.response.status_code, url=error_url
+            ) from http_err  # type: ignore[union-attr]
 
         final_data: dict[str, Any] = {
             "type": final_data_type,
-            "url": str(response.url), # type: ignore[attr-defined]
-            "status_code": response.status_code, # type: ignore[attr-defined]
-            "headers": {str(k): str(v) for k, v in dict(response.headers).items()}, # type: ignore[attr-defined]
+            "url": str(response.url),  # type: ignore[attr-defined]
+            "status_code": response.status_code,  # type: ignore[attr-defined]
+            "headers": {str(k): str(v) for k, v in dict(response.headers).items()},  # type: ignore[attr-defined]
         }
         all_responses_data.append(final_data)
         return all_responses_data
@@ -258,36 +275,47 @@ class HttpFetcher:
                     found_connection_refused = True
                     break
                 if hasattr(current_exc, "original_error"):
-                    original_error = getattr(current_exc, "original_error")
-                    if isinstance(original_error, ConnectionRefusedError) or \
-                       (hasattr(original_error, "errno") and getattr(original_error, "errno") == 111):
+                    original_error = current_exc.original_error
+                    if isinstance(original_error, ConnectionRefusedError) or (
+                        hasattr(original_error, "errno") and original_error.errno == 111
+                    ):
                         found_connection_refused = True
                         break
             if isinstance(current_exc, urllib3_exceptions.MaxRetryError):
-                if hasattr(current_exc, "reason") and isinstance(current_exc.reason, urllib3_exceptions.NewConnectionError):
+                if hasattr(current_exc, "reason") and isinstance(
+                    current_exc.reason, urllib3_exceptions.NewConnectionError
+                ):
                     reason_exc_str = str(current_exc.reason).lower()
                     if "connection refused" in reason_exc_str or "errno 111" in reason_exc_str:
                         found_connection_refused = True
                         break
                     if hasattr(current_exc.reason, "original_error"):
-                        original_error = getattr(current_exc.reason, "original_error")
-                        if isinstance(original_error, ConnectionRefusedError) or \
-                           (hasattr(original_error, "errno") and getattr(original_error, "errno") == 111):
+                        original_error = current_exc.reason.original_error
+                        if isinstance(original_error, ConnectionRefusedError) or (
+                            hasattr(original_error, "errno") and original_error.errno == 111
+                        ):
                             found_connection_refused = True
                             break
-            if any("connection refused" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str)) or \
-               "connection refused" in exc_str:
+            if (
+                any("connection refused" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str))
+                or "connection refused" in exc_str
+            ):
                 found_connection_refused = True
-            if any("errno 111" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str)) or \
-               "errno 111" in exc_str:
+            if (
+                any("errno 111" in str(arg).lower() for arg in current_exc.args if isinstance(arg, str))
+                or "errno 111" in exc_str
+            ):
                 found_connection_refused = True
             if found_connection_refused:
                 break
             next_exc: Optional[BaseException] = None
             if hasattr(current_exc, "__cause__") and current_exc.__cause__ is not None:
                 next_exc = current_exc.__cause__
-            elif hasattr(current_exc, "__context__") and current_exc.__context__ is not None and \
-                 not getattr(current_exc, "__suppress_context__", False):
+            elif (
+                hasattr(current_exc, "__context__")
+                and current_exc.__context__ is not None
+                and not getattr(current_exc, "__suppress_context__", False)
+            ):
                 next_exc = current_exc.__context__
             if current_exc is next_exc:
                 break
@@ -313,9 +341,9 @@ class HttpFetcher:
         :return: A user-friendly error message string.
         :rtype: str
         """
-        status_code = e.response.status_code # type: ignore[union-attr]
-        reason = e.response.reason if e.response.reason else "Unknown Error" # type: ignore[union-attr]
-        url = e.request.url if e.request else "N/A" # type: ignore[union-attr]
+        status_code = e.response.status_code  # type: ignore[union-attr]
+        reason = e.response.reason if e.response.reason else "Unknown Error"  # type: ignore[union-attr]
+        url = e.request.url if e.request else "N/A"  # type: ignore[union-attr]
         if status_code == 403:
             return f"403 Forbidden: Access to {url} denied."
         if status_code == 404:
@@ -341,8 +369,7 @@ class HttpFetcher:
 
         adapter_sni_hint: Optional[str] = None
         if self.host_header:
-            requests.utils.urlparse(self.url) # type: ignore[attr-defined]
-
+            requests.utils.urlparse(self.url)  # type: ignore[attr-defined]
 
         effective_custom_dns_server: Optional[str] = self.custom_dns_server if dns else None
         if self.custom_dns_server and not dns:

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -1,4 +1,5 @@
-"""Defines the HTTP Headers page for the Woes application.
+"""
+Defines the HTTP Headers page for the Woes application.
 
 This module provides the :class:`.HttpPage` class, which allows users to fetch and
 inspect HTTP headers for a given URL. It includes options for custom Host
@@ -9,8 +10,7 @@ and uses a background thread for network operations to keep the UI responsive.
 
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional # Use lowercase for built-in types, e.g. list, dict
-import collections.abc # For Sequence
+from typing import Any, Dict, List, Optional  # Use lowercase for built-in types, e.g. list, dict
 
 import gi
 
@@ -64,7 +64,8 @@ class HeaderItem(GObject.Object):
     is_special_row: bool
 
     def __init__(self, key: str, value: str, is_special_row: bool = False):
-        """Initialize a HeaderItem.
+        """
+        Initialize a HeaderItem.
 
         :param key: The header key or special row title.
         :type key: str
@@ -128,7 +129,8 @@ class HttpPage(Adw.PreferencesPage):
     http_status_spinner: Gtk.Spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: Any):
-        """Initialize the HttpPage.
+        """
+        Initialize the HttpPage.
 
         Initializes UI elements, GSettings, the header list store for the
         column view, and connects signals.
@@ -190,7 +192,8 @@ class HttpPage(Adw.PreferencesPage):
         self.column_view_helper = Helper(widget=self.http_column_view, parent_window=self.get_native())
 
     def _connect_signals(self) -> None:
-        """Connect signals for UI elements to their respective handlers.
+        """
+        Connect signals for UI elements to their respective handlers.
 
         :return: None
         """
@@ -209,7 +212,8 @@ class HttpPage(Adw.PreferencesPage):
             self.http_user_agent_row.connect("notify::selected-item", self._save_selected_user_agent_preference)
 
     def _on_host_header_changed(self, entry_row: Adw.EntryRow) -> None:
-        """Handle changes in the Host header entry row.
+        """
+        Handle changes in the Host header entry row.
 
         Adds or removes a CSS class to indicate if an override is active.
 
@@ -226,7 +230,8 @@ class HttpPage(Adw.PreferencesPage):
             entry_row.remove_css_class("active-override")
 
     def _on_user_agent_changed(self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]) -> None:
-        """Handle changes in the User-Agent combo row selection.
+        """
+        Handle changes in the User-Agent combo row selection.
 
         Adds or removes a CSS class to indicate if a non-default User-Agent is active.
 
@@ -249,8 +254,11 @@ class HttpPage(Adw.PreferencesPage):
         elif selected_item_obj is None and not self._ua_title_to_value_map:  # Model might be empty
             combo_row.remove_css_class("active-override")
 
-    def _on_user_agent_changed_visual_feedback(self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]) -> None:
-        """Handle visual feedback for User-Agent combo row selection changes.
+    def _on_user_agent_changed_visual_feedback(
+        self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]
+    ) -> None:
+        """
+        Handle visual feedback for User-Agent combo row selection changes.
 
         This method is responsible for adding/removing the 'active-override' CSS class.
         It is separated from the logic that saves the preference to GSettings.
@@ -261,10 +269,13 @@ class HttpPage(Adw.PreferencesPage):
         :type _gparam: Optional[GObject.ParamSpec]
         :return: None
         """
-        self._on_user_agent_changed(combo_row, _gparam) # Call the original method for CSS
+        self._on_user_agent_changed(combo_row, _gparam)  # Call the original method for CSS
 
-    def _save_selected_user_agent_preference(self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]) -> None:
-        """Save the selected User-Agent title to GSettings.
+    def _save_selected_user_agent_preference(
+        self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]
+    ) -> None:
+        """
+        Save the selected User-Agent title to GSettings.
 
         This method is connected to the 'notify::selected-item' signal of the User-Agent ComboRow.
         It persists the user's choice.
@@ -281,22 +292,22 @@ class HttpPage(Adw.PreferencesPage):
         selected_item_obj = combo_row.get_selected_item()
         if isinstance(selected_item_obj, Gtk.StringObject):
             selected_title = selected_item_obj.get_string()
-            if selected_title == "None": # "None" is the display title for system default
+            if selected_title == "None":  # "None" is the display title for system default
                 self.settings.set_string("default-user-agent-title", "")
                 logger.info("User-Agent preference saved: System Default (empty string).")
             else:
                 self.settings.set_string("default-user-agent-title", selected_title)
                 logger.info(f"User-Agent preference saved: '{selected_title}'.")
         elif selected_item_obj is None:
-             # This case might occur if the model is empty or selection is cleared programmatically
-             # in a way that doesn't involve selecting the "None" Gtk.StringObject.
-             # Setting to empty string to signify no specific UA default.
+            # This case might occur if the model is empty or selection is cleared programmatically
+            # in a way that doesn't involve selecting the "None" Gtk.StringObject.
+            # Setting to empty string to signify no specific UA default.
             self.settings.set_string("default-user-agent-title", "")
             logger.info("User-Agent preference saved: No selection (empty string).")
 
-
     def _on_copy_results_clicked(self, _button: Gtk.Button) -> None:
-        """Handle the click event for the 'Copy Results' button.
+        """
+        Handle the click event for the 'Copy Results' button.
 
         Constructs a string representation of the displayed headers and copies
         it to the clipboard.
@@ -308,8 +319,8 @@ class HttpPage(Adw.PreferencesPage):
         logger.info("Copying all headers to clipboard.")
         lines: list[str] = []
         if self.header_list_store:
-            for i in range(self.header_list_store.get_n_items()): # type: ignore[attr-defined]
-                item = self.header_list_store.get_item(i) # type: ignore[attr-defined]
+            for i in range(self.header_list_store.get_n_items()):  # type: ignore[attr-defined]
+                item = self.header_list_store.get_item(i)  # type: ignore[attr-defined]
                 if isinstance(item, HeaderItem):
                     if item.is_special_row:
                         if item.value and item.value.strip():
@@ -333,7 +344,8 @@ class HttpPage(Adw.PreferencesPage):
             logger.info("No headers to copy from the results view.")
 
     def _on_entry_row_activated(self, _widget: Gtk.Widget) -> None:
-        """Handle activation of the URL entry row or click of the 'Fetch' button.
+        """
+        Handle activation of the URL entry row or click of the 'Fetch' button.
 
         Validates the URL, gathers request parameters, and starts the
         background task to fetch HTTP headers.
@@ -388,7 +400,8 @@ class HttpPage(Adw.PreferencesPage):
         _task_data_arg: Dict[str, Any],
         cancellable: Optional[Gio.Cancellable],
     ) -> None:
-        """Background thread function for fetching HTTP headers.
+        """
+        Background thread function for fetching HTTP headers.
 
         This function is executed by :meth:`Gio.Task.run_in_thread`.
         It instantiates :class:`.http_client.HttpFetcher` and calls its
@@ -474,9 +487,10 @@ class HttpPage(Adw.PreferencesPage):
             )
 
     def _fetch_headers_task_done_cb(
-        self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Optional[Any] = None
+        self, _source_object: GObject.Object, _result: Gio.AsyncResult, _user_data: Optional[Any] = None
     ) -> None:
-        """Handle completion of the HTTP headers fetch task.
+        """
+        Handle completion of the HTTP headers fetch task.
 
         Processes the result from the background thread, updates the UI with headers
         or an error message, and re-enables UI elements.
@@ -503,15 +517,15 @@ class HttpPage(Adw.PreferencesPage):
         logger.info("Processing task completion in _fetch_headers_task_done_cb.")
 
         try:
-            propagate_result = task_being_processed.propagate_value() # type: ignore[union-attr]
+            propagate_result = task_being_processed.propagate_value()  # type: ignore[union-attr]
             actual_list_of_responses: Optional[list[dict[str, Any]]] = None
 
             if isinstance(propagate_result, list):
                 actual_list_of_responses = propagate_result
-            elif hasattr(propagate_result, "value") and isinstance(propagate_result.value, list): # type: ignore[attr-defined]
+            elif hasattr(propagate_result, "value") and isinstance(propagate_result.value, list):  # type: ignore[attr-defined]
                 # Handles cases where the result might be wrapped, e.g. by older PyGObject versions or specific task types
                 logger.debug("HttpPage: Accessing .value from propagated result of type %s", type(propagate_result))
-                actual_list_of_responses = propagate_result.value # type: ignore[attr-defined]
+                actual_list_of_responses = propagate_result.value  # type: ignore[attr-defined]
             else:
                 logger.error("HttpPage: Unexpected type from propagate_value: %s", type(propagate_result))
                 show_global_error(self, "Unexpected result type from background task.")  # type: ignore[arg-type]
@@ -540,7 +554,7 @@ class HttpPage(Adw.PreferencesPage):
                             continue
                         response_data_dict: dict[str, Any] = response_data_dict_item
                         url_display = f"URL: {response_data_dict.get('url', 'N/A')}"
-                        status_code = response_data_dict.get("status_code", "N/A") # type: ignore
+                        status_code = response_data_dict.get("status_code", "N/A")  # type: ignore
                         response_type = response_data_dict.get("type", "unknown")
                         status_display = f"Status: {status_code} ({str(response_type).capitalize()})"
                         processed_headers_for_store.append(
@@ -628,7 +642,8 @@ class HttpPage(Adw.PreferencesPage):
                     self._set_loading_state(False, "Idle - operation ended.")
 
     def _set_loading_state(self, active: bool, message: str = "Idle") -> None:
-        """Set the UI loading state.
+        """
+        Set the UI loading state.
 
         Manages the visibility of the spinner, updates the status message,
         and adjusts the sensitivity of input controls.
@@ -663,7 +678,8 @@ class HttpPage(Adw.PreferencesPage):
 
     @staticmethod
     def _ensure_scheme(url: str) -> str:
-        """Ensure the URL has a scheme, defaulting to 'https://'.
+        """
+        Ensure the URL has a scheme, defaulting to 'https://'.
 
         This provides a basic check before passing to :class:`.http_client.HttpFetcher`,
         which will perform more robust URL parsing.
@@ -679,7 +695,8 @@ class HttpPage(Adw.PreferencesPage):
         return url
 
     def _on_pragma_toggled(self, _widget: Gtk.Switch, _gparam: GObject.ParamSpec) -> None:
-        """Handle toggling of the Akamai Pragma switch.
+        """
+        Handle toggling of the Akamai Pragma switch.
 
         If a URL is present in the entry row, it re-triggers the fetch.
 
@@ -694,7 +711,8 @@ class HttpPage(Adw.PreferencesPage):
             self._on_entry_row_activated(self.http_entry_row)
 
     def _update_column_view_model(self, header_items: Optional[List[HeaderItem]]) -> None:
-        """Update the :class:`Gio.ListStore` for the header :class:`Gtk.ColumnView`.
+        """
+        Update the :class:`Gio.ListStore` for the header :class:`Gtk.ColumnView`.
 
         Clears the existing items and appends new ones if provided.
         Shows or hides the results group accordingly.
@@ -704,16 +722,17 @@ class HttpPage(Adw.PreferencesPage):
         :type header_items: Optional[list[HeaderItem]]
         :return: None
         """
-        self.header_list_store.remove_all() # type: ignore[attr-defined]
+        self.header_list_store.remove_all()  # type: ignore[attr-defined]
         if header_items:
             for item in header_items:
-                self.header_list_store.append(item) # type: ignore[attr-defined]
+                self.header_list_store.append(item)  # type: ignore[attr-defined]
             self._show_results()
         else:
             self._hide_results()
 
     def _show_results(self) -> None:
-        """Make the HTTP results group visible.
+        """
+        Make the HTTP results group visible.
 
         :return: None
         """
@@ -721,7 +740,8 @@ class HttpPage(Adw.PreferencesPage):
             self.http_results_group.set_visible(True)
 
     def _hide_results(self) -> None:
-        """Make the HTTP results group invisible.
+        """
+        Make the HTTP results group invisible.
 
         :return: None
         """
@@ -729,7 +749,8 @@ class HttpPage(Adw.PreferencesPage):
             self.http_results_group.set_visible(False)
 
     def _clear_error(self) -> None:
-        """Clear any error state in the UI.
+        """
+        Clear any error state in the UI.
 
         Hides the main window's error banner and removes the 'error' CSS class
         from the URL entry row.
@@ -745,7 +766,8 @@ class HttpPage(Adw.PreferencesPage):
             self.http_entry_row.remove_css_class("error")
 
     def _on_clear_results_clicked(self, _button: Gtk.Button) -> None:
-        """Handle the click event for the 'Clear Results' button.
+        """
+        Handle the click event for the 'Clear Results' button.
 
         Clears the displayed headers, error state, and the URL entry.
 
@@ -761,7 +783,8 @@ class HttpPage(Adw.PreferencesPage):
             self.http_entry_row.set_text("")
 
     def _on_color_setting_changed(self, settings: Gio.Settings, key: str) -> None:
-        """Handle changes to color-related GSettings.
+        """
+        Handle changes to color-related GSettings.
 
         Updates the internal color attributes and re-populates the column view
         to apply the new colors if results are currently displayed.
@@ -784,7 +807,8 @@ class HttpPage(Adw.PreferencesPage):
             self._update_column_view_model(self._current_header_items)
 
     def _on_global_output_font_changed(self, settings: Gio.Settings, key: str) -> None:
-        """Handle changes to the global output font GSettings key.
+        """
+        Handle changes to the global output font GSettings key.
 
         Updates the internal font description and re-populates the column view
         to apply the new font if results are currently displayed.
@@ -806,7 +830,8 @@ class HttpPage(Adw.PreferencesPage):
                 self._update_column_view_model(self._current_header_items)
 
     def _update_user_agent_model(self) -> None:
-        """Update the model for the User-Agent :class:`Adw.ComboRow`.
+        """
+        Update the model for the User-Agent :class:`Adw.ComboRow`.
 
         Populates the dropdown with a "None" option (system default),
         predefined User-Agents from :mod:`.constants`, and custom User-Agents from GSettings.
@@ -869,7 +894,9 @@ class HttpPage(Adw.PreferencesPage):
         if default_ua_title_pref and default_ua_title_pref != "[System Default]":
             if default_ua_title_pref in display_titles:
                 title_to_select = default_ua_title_pref
-                logger.info(f"HTTP Page: Applying preferred default User-Agent from GSettings: '{default_ua_title_pref}'.")
+                logger.info(
+                    f"HTTP Page: Applying preferred default User-Agent from GSettings: '{default_ua_title_pref}'."
+                )
             else:
                 # The preferred default is not in the current list (e.g., was removed from custom UAs).
                 # Fallback to "None" (system default) in this case.
@@ -882,10 +909,15 @@ class HttpPage(Adw.PreferencesPage):
             # ensure "None" (system default) is selected, unless a valid `current_selection_text`
             # already superseded this (e.g. user just changed it but model is refreshing).
             # If current_selection_text was valid and different from "None", it takes precedence.
-            if not (current_selection_text and current_selection_text in display_titles and current_selection_text != none_title) :
-                 title_to_select = none_title
-            logger.info(f"HTTP Page: User-Agent set to '{title_to_select}' (System Default or retained current selection) as per GSettings preference ('{default_ua_title_pref}').")
-
+            if not (
+                current_selection_text
+                and current_selection_text in display_titles
+                and current_selection_text != none_title
+            ):
+                title_to_select = none_title
+            logger.info(
+                f"HTTP Page: User-Agent set to '{title_to_select}' (System Default or retained current selection) as per GSettings preference ('{default_ua_title_pref}')."
+            )
 
         # Select the determined title
         if title_to_select in display_titles:
@@ -896,28 +928,30 @@ class HttpPage(Adw.PreferencesPage):
                 # For now, assuming _on_user_agent_changed_visual_feedback doesn't write to GSettings.
                 # _save_selected_user_agent_preference will handle GSettings persistence.
                 self.http_user_agent_row.set_selected(idx)
-            except ValueError: # Should not happen if title_to_select is in display_titles
-                if display_titles: # Should not be empty if none_title was added
-                    self.http_user_agent_row.set_selected(0) # Select "None"
+            except ValueError:  # Should not happen if title_to_select is in display_titles
+                if display_titles:  # Should not be empty if none_title was added
+                    self.http_user_agent_row.set_selected(0)  # Select "None"
         elif display_titles:  # Fallback if something went wrong
-            self.http_user_agent_row.set_selected(display_titles.index(none_title) if none_title in display_titles else 0)
-        else: # Should not happen as "None" is always added
+            self.http_user_agent_row.set_selected(
+                display_titles.index(none_title) if none_title in display_titles else 0
+            )
+        else:  # Should not happen as "None" is always added
             self.http_user_agent_row.set_selected(Gtk.INVALID_LIST_POSITION)
 
         # Update visual feedback based on the final selection
         self._on_user_agent_changed_visual_feedback(self.http_user_agent_row, None)
 
         selected_now_obj = self.http_user_agent_row.get_selected_item()
-        selected_now_text = selected_now_obj.get_string() if selected_now_obj else "Nothing"
 
         logging.info(
             "User-Agent dropdown model updated. Titles: %d. Selected: %s",
             len(display_titles),
-            selected_now.get_string() if selected_now else "None",
+            selected_now_obj.get_string() if selected_now_obj else "None",
         )
 
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:
-        """Create a Gtk.SignalListItemFactory for Gtk.ColumnView columns.
+        """
+        Create a Gtk.SignalListItemFactory for Gtk.ColumnView columns.
 
         This factory configures how items (:class:`HeaderItem`) are displayed in the
         columns of the :class:`Gtk.ColumnView`. It sets up labels, binds them to
@@ -935,21 +969,21 @@ class HttpPage(Adw.PreferencesPage):
         factory = Gtk.SignalListItemFactory()
 
         def setup_func(_factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem) -> None:
-            """Setup function for the list item factory. Creates and configures a :class:`Gtk.Label`."""
+            """Set up the list item factory. Create and configure a :class:`Gtk.Label`."""
             label = Gtk.Label(xalign=0.0, hexpand=True)
             if wrap_text:
-                label.set_wrap(True) # type: ignore[attr-defined]
+                label.set_wrap(True)  # type: ignore[attr-defined]
                 label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
                 label.set_max_width_chars(80)
-            list_item.set_child(label) # type: ignore[attr-defined]
+            list_item.set_child(label)  # type: ignore[attr-defined]
 
         def bind_func_internal(_factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem) -> None:
             """Bind function for the list item factory. Sets the label's text and style."""
-            label = list_item.get_child() # type: ignore[attr-defined]
-            item = list_item.get_item() # type: ignore[attr-defined]
-            if not (isinstance(label, Gtk.Label) and isinstance(item, HeaderItem)): # type: ignore[attr-defined]
+            label = list_item.get_child()  # type: ignore[attr-defined]
+            item = list_item.get_item()  # type: ignore[attr-defined]
+            if not (isinstance(label, Gtk.Label) and isinstance(item, HeaderItem)):  # type: ignore[attr-defined]
                 if isinstance(label, Gtk.Label):
-                    label.set_text("Error: Invalid item type.") # type: ignore[attr-defined]
+                    label.set_text("Error: Invalid item type.")  # type: ignore[attr-defined]
                 return
 
             text_to_display = getattr(item, attr_name, "")
@@ -981,7 +1015,8 @@ class HttpPage(Adw.PreferencesPage):
         return factory
 
     def trigger_fetch(self) -> None:
-        """Programmatically trigger the 'Fetch' action.
+        """
+        Programmatically trigger the 'Fetch' action.
 
         This method is typically called in response to a keyboard shortcut
         or an external event. It simulates a click on the 'Fetch' button

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,19 @@
-"""Main application module for Woes.
+"""
+Main application module for Woes.
 
 Handles application initialization, GResource loading, command-line option
 parsing, and launching the main application window and services.
 """
+
 import sys
 import os
 import logging
-from typing import Callable, List, Optional, Any
+from typing import Callable, Optional, Any
 import gi
+
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Adw, Gio, GLib
+from gi.repository import Adw, Gio, GLib, Gtk
 
 from .constants import (
     APP_ID,
@@ -22,6 +25,7 @@ from .constants import (
     APP_DESCRIPTION,
     APP_ISSUES_URL,
 )
+
 
 # GResource loading must happen before any modules that use Gtk.Template are imported.
 def _load_gresources_early():
@@ -52,10 +56,7 @@ def _load_gresources_early():
         )
         sys.exit(1)
 
-    logging.info(
-        "Attempting to load GResource file from: %s",
-        resource_file_path
-    )
+    logging.info("Attempting to load GResource file from: %s", resource_file_path)
 
     try:
         resource = Gio.Resource.load(resource_file_path)
@@ -69,9 +70,7 @@ def _load_gresources_early():
         Gio.Resource._register(resource)
         logging.info("Successfully loaded and registered GResource: %s", resource_file_path)
 
-        available_resources = resource.enumerate_children(
-            RESOURCE_PREFIX, Gio.ResourceLookupFlags.NONE
-        )
+        available_resources = resource.enumerate_children(RESOURCE_PREFIX, Gio.ResourceLookupFlags.NONE)
         if not available_resources:
             logging.warning(
                 "No resources found under prefix %s after loading %s.",
@@ -99,7 +98,7 @@ def _load_gresources_early():
         sys.exit(1)
 
 
-_load_gresources_early() # Call this as early as possible
+_load_gresources_early()  # Call this as early as possible
 
 from .window import WoesWindow
 from .preferences import Preferences
@@ -215,12 +214,11 @@ class WoesApplication(Adw.Application):
                 logging.exception("WoesApplication.do_activate: Error during win.present()")
             self.win = win
         else:
-            logging.error(
-                "WoesApplication.do_activate: Window object is None after creation attempt, cannot proceed."
-            )
+            logging.error("WoesApplication.do_activate: Window object is None after creation attempt, cannot proceed.")
 
     def _switch_to_page(self, page_name: str) -> None:
-        """Switch the main window's view to the specified page.
+        """
+        Switch the main window's view to the specified page.
 
         :param page_name: The name of the page to switch to (e.g., "http", "nmap").
         :type page_name: str
@@ -303,18 +301,22 @@ class WoesApplication(Adw.Application):
             # the actual page class instance (e.g., an instance of your HttpPage class).
             page_container_widget: Optional[Gtk.Widget] = status_page.get_child()
             if not page_container_widget:
-                logging.warning(f"{action_description} action: Page container widget (child of StatusPage) not found for {current_page_name}.")
+                logging.warning(
+                    f"{action_description} action: Page container widget (child of StatusPage) not found for {current_page_name}."
+                )
                 return
 
             actual_page_object: Optional[Gtk.Widget] = None
             # Scenario 1: The page_container_widget is the GtkBox, and its first child is the page instance.
-            if hasattr(page_container_widget, "get_first_child") and callable(getattr(page_container_widget, "get_first_child")):
+            if hasattr(page_container_widget, "get_first_child") and callable(page_container_widget.get_first_child):
                 # This assumes the GtkBox (like <object class="GtkBox" id="HttpPage">) is page_container_widget
                 # and its child (<object class="HttpPage">) is the actual page.
                 candidate: Optional[Gtk.Widget] = page_container_widget.get_first_child()
-                if hasattr(candidate, action_method_name): # Check if this candidate has the method
+                if hasattr(candidate, action_method_name):  # Check if this candidate has the method
                     actual_page_object = candidate
-                elif hasattr(page_container_widget, action_method_name): # Check if page_container_widget itself has the method
+                elif hasattr(
+                    page_container_widget, action_method_name
+                ):  # Check if page_container_widget itself has the method
                     # This could happen if AdwClampScrollable was the child of AdwStatusPage,
                     # and page_container_widget is that AdwClampScrollable, and *its* child is the actual page object.
                     # However, AdwClampScrollable itself does not have get_first_child.
@@ -325,37 +327,48 @@ class WoesApplication(Adw.Application):
                     # If that first child isn't our page, then we might be wrong about the structure.
                     # Let's refine: if page_container_widget.get_first_child() exists and has the method, use it.
                     # Else, check if page_container_widget itself has the method (e.g. if it IS the actual page object)
-                    actual_page_object = candidate # Keep candidate from above for now.
+                    actual_page_object = candidate  # Keep candidate from above for now.
                     if not actual_page_object or not hasattr(actual_page_object, action_method_name):
-                         # If the first child doesn't have the method, check if page_container_widget itself is the page
+                        # If the first child doesn't have the method, check if page_container_widget itself is the page
                         if hasattr(page_container_widget, action_method_name):
                             actual_page_object = page_container_widget
-                            logging.debug(f"Child of StatusPage (type: {type(page_container_widget)}) appears to be the actual page object itself.")
+                            logging.debug(
+                                f"Child of StatusPage (type: {type(page_container_widget)}) appears to be the actual page object itself."
+                            )
                         else:
-                             logging.warning(f"Neither page_container_widget (type: {type(page_container_widget)}) nor its first_child has method '{action_method_name}'.")
-                             return
-
+                            logging.warning(
+                                f"Neither page_container_widget (type: {type(page_container_widget)}) nor its first_child has method '{action_method_name}'."
+                            )
+                            return
 
             # Scenario 2: The page_container_widget IS the actual page instance.
             # This could happen if AdwStatusPage's child is set directly to the HttpPage/NmapPage instance.
             elif hasattr(page_container_widget, action_method_name):
                 actual_page_object = page_container_widget
-                logging.debug(f"Child of StatusPage (type: {type(page_container_widget)}) appears to be the actual page object itself (no get_first_child).")
+                logging.debug(
+                    f"Child of StatusPage (type: {type(page_container_widget)}) appears to be the actual page object itself (no get_first_child)."
+                )
             else:
-                logging.warning(f"Page container (type: {type(page_container_widget)}) does not have get_first_child and is not the page object. Structure: AdwViewStackPage -> AdwStatusPage -> ?")
+                logging.warning(
+                    f"Page container (type: {type(page_container_widget)}) does not have get_first_child and is not the page object. Structure: AdwViewStackPage -> AdwStatusPage -> ?"
+                )
                 return
 
             if actual_page_object:
                 if hasattr(actual_page_object, action_method_name):
-                    logging.debug(f"Attempting to call {action_method_name} on {type(actual_page_object)} for page {current_page_name}")
+                    logging.debug(
+                        f"Attempting to call {action_method_name} on {type(actual_page_object)} for page {current_page_name}"
+                    )
                     getattr(actual_page_object, action_method_name)()
                 else:
                     # This should ideally not be reached if the above logic is correct
-                    logging.warning(f"Retrieved actual page object for {current_page_name} (type: {type(actual_page_object)}), but it does not have method '{action_method_name}'. This indicates an issue in widget retrieval or page class structure.")
+                    logging.warning(
+                        f"Retrieved actual page object for {current_page_name} (type: {type(actual_page_object)}), but it does not have method '{action_method_name}'. This indicates an issue in widget retrieval or page class structure."
+                    )
             else:
                 logging.warning(f"Could not retrieve actual page object for {current_page_name} after checks.")
 
-        elif current_page_name == expected_page_name: # visible_stack_page is None
+        elif current_page_name == expected_page_name:  # visible_stack_page is None
             logging.warning(f"{action_description} action: AdwViewStackPage for {current_page_name} is None.")
         # No warning if it's not the expected_page_name page, as the action is specific to that page.
 
@@ -499,18 +512,17 @@ def main(version: str = VERSION) -> int:
 
     print("Attempting to directly access GSettings for test...")
     try:
-        # Ensure GResources are loaded as they contain the schema
-        _load_gresources_early() # This is already called above, but ensure it's effective.
+        # Ensure GResources are loaded as they contain the schema (called at module level)
 
         # Directly instantiate Gio.Settings with the application ID
         settings = Gio.Settings(schema_id=APP_ID)
 
         # Try to get the newly added setting
-        test_setting_value = settings.get_string('default-user-agent-title')
+        test_setting_value = settings.get_string("default-user-agent-title")
         print(f"Successfully read 'default-user-agent-title': {test_setting_value}")
 
         # Also try to get an existing setting to be sure
-        test_theme_value = settings.get_string('theme-preference')
+        test_theme_value = settings.get_string("theme-preference")
         print(f"Successfully read 'theme-preference': {test_theme_value}")
 
         print("Settings test passed.")
@@ -519,11 +531,7 @@ def main(version: str = VERSION) -> int:
         print(f"Error during settings test: {e}")
         sys.exit(1)
 
-    print("Settings access test complete. Exiting before full app run.")
-    sys.exit(0) # Exit cleanly after test.
-
-    # Original application run lines (commented out for this test run)
-    # app = WoesApplication(version=version)
-    # exit_status: int = app.run(sys.argv)
-    # logging.info("Application exited with status %s.", exit_status)
-    # return exit_status
+    app = WoesApplication(version=version)
+    exit_status: int = app.run(sys.argv)
+    logging.info("Application exited with status %s.", exit_status)
+    return exit_status

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 import re
 from enum import Enum
 from typing import Optional, List, Dict, Any
-import collections.abc  # For Sequence if needed, though not directly used here
 import yaml
 
 import gi
@@ -49,24 +48,24 @@ class NmapItem(GObject.Object):
         self.value = value
 
 
-# class NmapTargetRow(Gtk.ListBoxRow):
-#     """A :class:`Gtk.ListBoxRow` customized to display an NmapItem's key."""
-#
-#     nmap_item = GObject.Property(type=NmapItem)
-#
-#     def __init__(self, nmap_item: NmapItem, **kwargs: Any):
-#         """
-#         Initialize an NmapTargetRow.
-#
-#         :param nmap_item: The :class:`.NmapItem` to display.
-#         :type nmap_item: NmapItem
-#         :param kwargs: Additional keyword arguments for :class:`Gtk.ListBoxRow`.
-#         :type kwargs: Any
-#         """
-#         super().__init__(**kwargs)
-#         self.nmap_item = nmap_item
-#         label = Gtk.Label(label=nmap_item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
-#         self.set_child(label)
+class NmapTargetRow(Gtk.ListBoxRow):
+    """A :class:`Gtk.ListBoxRow` customized to display an NmapItem's key."""
+
+    nmap_item = GObject.Property(type=NmapItem)
+
+    def __init__(self, nmap_item: NmapItem, **kwargs: Any):
+        """
+        Initialize an NmapTargetRow.
+
+        :param nmap_item: The :class:`.NmapItem` to display.
+        :type nmap_item: NmapItem
+        :param kwargs: Additional keyword arguments for :class:`Gtk.ListBoxRow`.
+        :type kwargs: Any
+        """
+        super().__init__(**kwargs)
+        self.nmap_item = nmap_item
+        label = Gtk.Label(label=nmap_item.key, halign=Gtk.Align.START, margin_start=6, margin_end=6)
+        self.set_child(label)
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
@@ -132,9 +131,7 @@ class NmapPage(Adw.PreferencesPage):
 
     def _init_page_ui(self):
         """Initialize NmapPage UI components."""
-        self.nmap_host_listbox.bind_model(
-            self.nmap_target_listbox_store, self._create_target_listbox_row
-        )
+        self.nmap_host_listbox.bind_model(self.nmap_target_listbox_store, self._create_target_listbox_row)
         child = self.nmap_detail_box.get_first_child()
         while child and child != self.nmap_detail_placeholder:
             self.nmap_detail_box.remove(child)
@@ -192,9 +189,7 @@ class NmapPage(Adw.PreferencesPage):
                 logger.info("Requesting cancellation of previous Nmap scan task.")
                 self.current_nmap_cancellable.cancel()
             if not self.current_nmap_task.is_done():  # Re-check after cancel attempt
-                logger.warning(
-                    "Previous scan task still running. Please cancel it explicitly or wait."
-                )
+                logger.warning("Previous scan task still running. Please cancel it explicitly or wait.")
                 # Optionally, prevent starting a new scan here if the old one couldn't be cancelled quickly
                 # show_global_toast(self, "Previous scan is still finalizing. Please wait.")
                 # return
@@ -209,9 +204,7 @@ class NmapPage(Adw.PreferencesPage):
             "scan_all_ports": self.nmap_all_ports_switchrow.get_active(),
             "selected_script": (
                 item.get_string()
-                if isinstance(
-                    item := self.nmap_scripts_dropdown.get_selected_item(), Gtk.StringObject
-                )
+                if isinstance(item := self.nmap_scripts_dropdown.get_selected_item(), Gtk.StringObject)
                 and item.get_string() != "None"
                 else None
             ),
@@ -231,9 +224,7 @@ class NmapPage(Adw.PreferencesPage):
         }
         logger.info(f"NmapPage: Starting Nmap scan task with params: {scan_params}")
 
-        self.current_nmap_task = Gio.Task.new(
-            self, self.current_nmap_cancellable, self._nmap_scan_task_done_cb, None
-        )
+        self.current_nmap_task = Gio.Task.new(self, self.current_nmap_cancellable, self._nmap_scan_task_done_cb, None)
         self._current_nmap_scan_params = scan_params
         self.current_nmap_task.run_in_thread(self._run_nmap_scan_thread_func)
 
@@ -306,9 +297,7 @@ class NmapPage(Adw.PreferencesPage):
                 f"Nmap scan error: {e}",
             )
         except Exception as e:
-            logger.exception(
-                "Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__
-            )
+            logger.exception("Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__)
             task.return_new_error_literal(
                 GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN),
                 NmapScanErrorType.UNEXPECTED.value,
@@ -331,9 +320,7 @@ class NmapPage(Adw.PreferencesPage):
         :type _user_data: Optional[Any]
         """
         original_target = (
-            self._current_nmap_scan_params["target"]
-            if self._current_nmap_scan_params
-            else "unknown target"
+            self._current_nmap_scan_params["target"] if self._current_nmap_scan_params else "unknown target"
         )
 
         logger.info(f"Nmap scan task done for {original_target}.")
@@ -344,20 +331,16 @@ class NmapPage(Adw.PreferencesPage):
 
             if isinstance(propagated_value, nmap.PortScanner):
                 nm_results_final = propagated_value
-            elif hasattr(propagated_value, "value") and isinstance(
-                getattr(propagated_value, "value"), nmap.PortScanner
-            ):
+            elif hasattr(propagated_value, "value") and isinstance(propagated_value.value, nmap.PortScanner):
                 logger.debug(
                     f"NmapPage: Received wrapped object {type(propagated_value)} with .value attribute containing nmap.PortScanner. Unwrapping."
                 )
-                nm_results_final = getattr(propagated_value, "value")
+                nm_results_final = propagated_value.value
             elif hasattr(propagated_value, "value"):
                 logger.error(
-                    f"NmapPage: Received wrapped object {type(propagated_value)} with .value of type {type(getattr(propagated_value, 'value'))}. Expected nmap.PortScanner."
+                    f"NmapPage: Received wrapped object {type(propagated_value)} with .value of type {type(propagated_value.value)}. Expected nmap.PortScanner."
                 )
-                self._handle_scan_error(
-                    original_target, "Scan returned unexpectedly wrapped data of the wrong type."
-                )
+                self._handle_scan_error(original_target, "Scan returned unexpectedly wrapped data of the wrong type.")
             else:
                 logger.error(
                     f"Nmap scan for {original_target} returned unexpected result type: {type(propagated_value)}"
@@ -371,24 +354,16 @@ class NmapPage(Adw.PreferencesPage):
             logger.warning(
                 f"Nmap scan for {original_target} failed or was cancelled. Domain: {e.domain}, Code: {e.code}, Message: {e.message}"
             )
-            if e.matches(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value
-            ):
+            if e.matches(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value):
                 self._set_scan_status(ScanStatus.IDLE, f"Scan for {original_target} cancelled.")
                 self._clear_results()
-            elif e.matches(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.SCAN_FAILED.value
-            ):
+            elif e.matches(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.SCAN_FAILED.value):
                 self._handle_scan_error(original_target, e.message)
             else:  # UNEXPECTED or other GLib.Error
                 self._handle_scan_error(original_target, f"Scan error: {e.message}")
         except Exception as e:
-            logger.exception(
-                f"NmapPage: Unexpected Python error in _nmap_scan_task_done_cb for {original_target}:"
-            )
-            self._handle_scan_error(
-                original_target, f"Unexpected error processing scan results: {e}"
-            )
+            logger.exception(f"NmapPage: Unexpected Python error in _nmap_scan_task_done_cb for {original_target}:")
+            self._handle_scan_error(original_target, f"Unexpected error processing scan results: {e}")
         finally:
             self.current_nmap_task = None
             self.current_nmap_cancellable = None
@@ -462,9 +437,7 @@ class NmapPage(Adw.PreferencesPage):
 
         if row is None:
             self.nmap_detail_placeholder.set_title("No Host Selected")
-            self.nmap_detail_placeholder.set_description(
-                "Select a host from the list to view details."
-            )
+            self.nmap_detail_placeholder.set_description("Select a host from the list to view details.")
             if not self.nmap_detail_placeholder.get_parent():
                 self.nmap_detail_box.append(self.nmap_detail_placeholder)
             self.nmap_detail_placeholder.set_visible(True)
@@ -488,9 +461,7 @@ class NmapPage(Adw.PreferencesPage):
 
             except yaml.YAMLError as e:
                 logger.error("Error parsing YAML for host %s: %s", selected_target_key, e)
-                error_label = Gtk.Label(
-                    label=f"Error: Could not parse scan results for {selected_target_key}.\n{e}"
-                )
+                error_label = Gtk.Label(label=f"Error: Could not parse scan results for {selected_target_key}.\n{e}")
                 error_label.set_wrap(True)
                 error_label.set_halign(Gtk.Align.START)
                 self.nmap_detail_box.append(error_label)
@@ -512,9 +483,7 @@ class NmapPage(Adw.PreferencesPage):
         else:
             logger.warning("Could not retrieve NmapItem from selected row or item_obj is None.")
             self.nmap_detail_placeholder.set_title("Error")
-            self.nmap_detail_placeholder.set_description(
-                "Could not load details for the selected host."
-            )
+            self.nmap_detail_placeholder.set_description("Could not load details for the selected host.")
             if not self.nmap_detail_placeholder.get_parent():
                 self.nmap_detail_box.append(self.nmap_detail_placeholder)
             self.nmap_detail_placeholder.set_visible(True)
@@ -595,9 +564,7 @@ class NmapPage(Adw.PreferencesPage):
         expander = Adw.ExpanderRow(title=f"Host Information - {host_key}")
         expander.set_expanded(True)
         status_info = host_data.get("status", {})
-        status_subtitle = (
-            f"{status_info.get('state', 'N/A')} (Reason: {status_info.get('reason', 'N/A')})"
-        )
+        status_subtitle = f"{status_info.get('state', 'N/A')} (Reason: {status_info.get('reason', 'N/A')})"
         status_row = Adw.ActionRow(title="Status", subtitle=status_subtitle)
         expander.add_row(status_row)
         addresses_info = host_data.get("addresses", {})
@@ -640,16 +607,10 @@ class NmapPage(Adw.PreferencesPage):
                         title = f"Port {port_id}/{proto.upper()} ({state})"
                         subtitle_parts = [name, product, version]
                         subtitle = " ".join(filter(None, subtitle_parts))
-                        subtitle = (
-                            f"{subtitle} (Reason: {reason})" if subtitle else f"Reason: {reason}"
-                        )
+                        subtitle = f"{subtitle} (Reason: {reason})" if subtitle else f"Reason: {reason}"
                         expander.add_row(Adw.ActionRow(title=title, subtitle=subtitle))
         if not ports_found:
-            expander.add_row(
-                Adw.ActionRow(
-                    title="Ports", subtitle="No open ports reported or port data available."
-                )
-            )
+            expander.add_row(Adw.ActionRow(title="Ports", subtitle="No open ports reported or port data available."))
         self.nmap_detail_box.append(expander)
 
     def _add_os_expander(self, host_data: Dict[str, Any], host_key: str):
@@ -687,15 +648,11 @@ class NmapPage(Adw.PreferencesPage):
                         f"Type: {os_class.get('type', 'N/A')}, Vendor: {vendor}, Family: {osfamily}, Gen: {osgen}"
                     )
             subtitle = "\n".join(osclass_details) if osclass_details else "No OS class details."
-            row = Adw.ActionRow(
-                title=title, subtitle=subtitle if subtitle != "No OS class details." else ""
-            )
+            row = Adw.ActionRow(title=title, subtitle=subtitle if subtitle != "No OS class details." else "")
             expander.add_row(row)
             os_details_added = True
         if not os_details_added:
-            expander.add_row(
-                Adw.ActionRow(title="OS Detection", subtitle="No specific OS matches found.")
-            )
+            expander.add_row(Adw.ActionRow(title="OS Detection", subtitle="No specific OS matches found."))
         self.nmap_detail_box.append(expander)
 
     def _update_results_view(self, hosts: List[str], results_map: Dict[str, str]):
@@ -710,9 +667,7 @@ class NmapPage(Adw.PreferencesPage):
         if not hosts:
             self._clear_dynamic_details()
             self.nmap_detail_placeholder.set_title("No Hosts Found")
-            self.nmap_detail_placeholder.set_description(
-                "The scan did not find any responsive hosts."
-            )
+            self.nmap_detail_placeholder.set_description("The scan did not find any responsive hosts.")
             if not self.nmap_detail_placeholder.get_parent():
                 self.nmap_detail_box.append(self.nmap_detail_placeholder)
             self.nmap_detail_placeholder.set_visible(True)
@@ -858,9 +813,7 @@ class NmapPage(Adw.PreferencesPage):
                     if script_output and isinstance(script_output, str):
                         formatted_output = "\n".join(
                             [
-                                f"|_ {script_id}: {line.strip()}"
-                                if i == 0
-                                else f"|  {line.strip()}"
+                                f"|_ {script_id}: {line.strip()}" if i == 0 else f"|  {line.strip()}"
                                 for i, line in enumerate(script_output.strip().split("\n"))
                             ]
                         )
@@ -872,9 +825,7 @@ class NmapPage(Adw.PreferencesPage):
         if hostnames_list:
             summary_lines.append("\nHostnames:")
             for hn_entry in hostnames_list:
-                summary_lines.append(
-                    f"  {hn_entry.get('name', 'N/A')} ({hn_entry.get('type', 'N/A')})"
-                )
+                summary_lines.append(f"  {hn_entry.get('name', 'N/A')} ({hn_entry.get('type', 'N/A')})")
 
         host_scripts = host_data_dict.get("hostscript")
         if host_scripts and isinstance(host_scripts, list):
@@ -885,9 +836,7 @@ class NmapPage(Adw.PreferencesPage):
                         script_item.get("id", "N/A"),
                         script_item.get("output", "N/A"),
                     )
-                    formatted_output = "\n".join(
-                        [f"    {line.strip()}" for line in script_output.strip().split("\n")]
-                    )
+                    formatted_output = "\n".join([f"    {line.strip()}" for line in script_output.strip().split("\n")])
                     summary_lines.append(f"  Script: {script_id}\n{formatted_output}")
 
         ports_data = []
@@ -898,8 +847,7 @@ class NmapPage(Adw.PreferencesPage):
                         p_state = port_info.get("state", "N/A")
                         if p_state not in ["closed", "filtered out"]:
                             p_name, p_product, p_version, p_reason = (
-                                port_info.get(k, "")
-                                for k in ["name", "product", "version", "reason"]
+                                port_info.get(k, "") for k in ["name", "product", "version", "reason"]
                             )
                             port_str = f"{port_id}/{proto.upper():<4} {p_state:<10} {p_name}"
                             if p_product:
@@ -915,12 +863,8 @@ class NmapPage(Adw.PreferencesPage):
                                     if script_output and isinstance(script_output, str):
                                         formatted_script_output = "\n".join(
                                             [
-                                                f"  |_{script_id}: {line.strip()}"
-                                                if i == 0
-                                                else f"  | {line.strip()}"
-                                                for i, line in enumerate(
-                                                    script_output.strip().split("\n")
-                                                )
+                                                f"  |_{script_id}: {line.strip()}" if i == 0 else f"  | {line.strip()}"
+                                                for i, line in enumerate(script_output.strip().split("\n"))
                                             ]
                                         )
                                         ports_data.append(formatted_script_output)
@@ -937,11 +881,7 @@ class NmapPage(Adw.PreferencesPage):
                 summary_lines.append(f"  Name: {match.get('name', 'N/A')}")
                 summary_lines.append(f"  Accuracy: {match.get('accuracy', 'N/A')}%")
                 if "osclass" in match:
-                    osclasses = (
-                        match["osclass"]
-                        if isinstance(match["osclass"], list)
-                        else [match["osclass"]]
-                    )
+                    osclasses = match["osclass"] if isinstance(match["osclass"], list) else [match["osclass"]]
                     for os_class in osclasses:
                         if isinstance(os_class, dict):
                             summary_lines.append("  OS Class:")

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -4,7 +4,9 @@ Provides the NmapScanner class and related utilities for performing Nmap scans.
 This module includes functionality for building Nmap commands, handling
 privilege escalation, executing scans, and processing results.
 """
+
 import logging
+
 logger = logging.getLogger(__name__)
 import re
 import platform
@@ -14,12 +16,12 @@ import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, List, Optional, TypedDict, Union # Use dict, list
+from typing import Any, Dict, List, Optional, TypedDict, Union  # Use dict, list
 
 try:
     from gi.repository import Gio
 except ImportError:
-    Gio = None # type: ignore
+    Gio = None  # type: ignore
 
 import nmap
 from nmap import PortScannerError
@@ -163,7 +165,6 @@ class NmapScanner:
         self.current_process: Optional[subprocess.Popen[str]] = None
         self.current_cancellable: Optional[Gio.Cancellable] = None
 
-
     def __del__(self) -> None:
         """Ensure the ThreadPoolExecutor is shut down and any running Nmap process is terminated."""
         logger.debug("NmapScanner.__del__ called.")
@@ -181,10 +182,9 @@ class NmapScanner:
                 logger.exception(f"Unexpected error terminating Nmap process during deletion: {e}")
             self.current_process = None
 
-        if hasattr(self, 'executor') and self.executor is not None:
+        if hasattr(self, "executor") and self.executor is not None:
             self.executor.shutdown(wait=True)
         logger.debug("NmapScanner cleanup complete.")
-
 
     def validate_target_input(self, target: str) -> bool:
         """
@@ -234,9 +234,7 @@ class NmapScanner:
         logger.debug(f"All target segments validated successfully for input '{target}'.")
         return True
 
-    def build_nmap_options(
-        self, os_fingerprinting: bool, scan_all_ports: bool, selected_script: str
-    ) -> str:
+    def build_nmap_options(self, os_fingerprinting: bool, scan_all_ports: bool, selected_script: str) -> str:
         """
         Construct Nmap command-line options string based on boolean flags.
 
@@ -268,7 +266,7 @@ class NmapScanner:
         :return: A list of arguments for the Nmap command.
         :rtype: list[str]
         """
-        nmap_args_list: list[str] = ["nmap", "-sS"] # -sS (TCP SYN scan) requires root
+        nmap_args_list: list[str] = ["nmap", "-sS"]  # -sS (TCP SYN scan) requires root
 
         if params.get("os_fingerprinting"):
             nmap_args_list.append("-O")
@@ -276,8 +274,8 @@ class NmapScanner:
             nmap_args_list.append("-sV")
         if params.get("scan_all_ports"):
             nmap_args_list.append("-p-")
-        if params.get("selected_script") and params["selected_script"] != "None": # type: ignore[comparison-overlap]
-            nmap_args_list.append(f"--script={params['selected_script']}") # type: ignore[literal-required]
+        if params.get("selected_script") and params["selected_script"] != "None":  # type: ignore[comparison-overlap]
+            nmap_args_list.append(f"--script={params['selected_script']}")  # type: ignore[literal-required]
         if params.get("no_ping"):
             nmap_args_list.append("-Pn")
 
@@ -292,7 +290,7 @@ class NmapScanner:
             nmap_args_list.append(f"--dns-servers={custom_dns_server.strip()}")
             logger.info("Using custom DNS server for Nmap scan: %s", custom_dns_server.strip())
 
-        nmap_args_list.extend(["-oX", "-", params['target']])
+        nmap_args_list.extend(["-oX", "-", params["target"]])
         logger.debug("Built Nmap arguments: %s", nmap_args_list)
         return nmap_args_list
 
@@ -323,9 +321,12 @@ class NmapScanner:
             final_command_parts = [nmap_path] + nmap_args_list[1:]
         return final_command_parts
 
-
     def _parse_nmap_error_message(
-        self, returncode: int, nmap_xml_output: str, nmap_stderr: str, needs_escalation: bool,
+        self,
+        returncode: int,
+        nmap_xml_output: str,
+        nmap_stderr: str,
+        needs_escalation: bool,
     ) -> str:
         """
         Construct a detailed error message from Nmap's output when a scan fails.
@@ -352,14 +353,25 @@ class NmapScanner:
             error_message += f" Stderr: {nmap_stderr.strip()}"
 
         if needs_escalation:
-            if (platform.system() == "Darwin" and returncode == 1 and not nmap_xml_output.strip() and not nmap_stderr.strip()):
+            if (
+                platform.system() == "Darwin"
+                and returncode == 1
+                and not nmap_xml_output.strip()
+                and not nmap_stderr.strip()
+            ):
                 error_message = "User cancelled the request for administrator privileges."
-            elif (platform.system() == "Linux" and returncode in [1, 126, 127] and not nmap_xml_output.strip() and not nmap_stderr.strip()):
+            elif (
+                platform.system() == "Linux"
+                and returncode in [1, 126, 127]
+                and not nmap_xml_output.strip()
+                and not nmap_stderr.strip()
+            ):
                 error_message = "User cancelled the request for administrator privileges or authentication failed."
         return error_message
 
     def run_nmap_scan(  # pylint: disable=too-many-locals # Justified: manages subprocess lifecycle, I/O, and multiple error states.
-        self, params: NmapScanParameters,
+        self,
+        params: NmapScanParameters,
         cancellable: Optional[Gio.Cancellable] = None,
     ) -> nmap.PortScanner:
         """
@@ -378,10 +390,7 @@ class NmapScanner:
         :return: An :class:`nmap.PortScanner` object containing the scan results.
         :rtype: nmap.PortScanner
         """
-        logger.debug(
-            "run_nmap_scan called with params: %s, Cancellable: %s",
-            params, bool(cancellable)
-        )
+        logger.debug("run_nmap_scan called with params: %s, Cancellable: %s", params, bool(cancellable))
         self.nm = nmap.PortScanner()
         self.current_cancellable = cancellable
 
@@ -390,7 +399,10 @@ class NmapScanner:
 
         final_command_parts: list[str] = self._prepare_final_nmap_command(nmap_args_list, needs_escalation)
 
-        logger.info("Executing Nmap command (first few parts): %s...", " ".join(shlex.quote(part) for part in final_command_parts[:4]))
+        logger.info(
+            "Executing Nmap command (first few parts): %s...",
+            " ".join(shlex.quote(part) for part in final_command_parts[:4]),
+        )
 
         stdout_str: str = ""
         stderr_str: str = ""
@@ -400,11 +412,13 @@ class NmapScanner:
             if self.current_cancellable and self.current_cancellable.is_cancelled():
                 raise ScanCancelledError("Scan cancelled before process start.")
 
-            self.current_process = subprocess.Popen(final_command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8")
+            self.current_process = subprocess.Popen(
+                final_command_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8"
+            )
 
             while self.current_process.poll() is None:
                 if self.current_cancellable and self.current_cancellable.is_cancelled():
-                    logger.info("Cancellation requested for Nmap scan of target: %s", params['target']) # type: ignore[literal-required]
+                    logger.info("Cancellation requested for Nmap scan of target: %s", params["target"])  # type: ignore[literal-required]
                     self.current_process.terminate()
                     try:
                         self.current_process.wait(timeout=1)
@@ -412,7 +426,7 @@ class NmapScanner:
                         logger.warning("Nmap process did not terminate gracefully, killing.")
                         self.current_process.kill()
                     self.current_process = None
-                    raise ScanCancelledError(f"Nmap scan for {params['target']} was cancelled.") # type: ignore[literal-required]
+                    raise ScanCancelledError(f"Nmap scan for {params['target']} was cancelled.")  # type: ignore[literal-required]
                 time.sleep(0.2)
 
             if self.current_process:
@@ -435,11 +449,13 @@ class NmapScanner:
 
             try:
                 logger.debug("Attempting to parse Nmap XML output (first 500 chars): %s", stdout_str[:500])
-                self.nm.analyse_nmap_xml_scan(nmap_xml_output=stdout_str) # type: ignore[no-untyped-call]
+                self.nm.analyse_nmap_xml_scan(nmap_xml_output=stdout_str)  # type: ignore[no-untyped-call]
             except PortScannerError as e_parse:
                 logger.exception("Failed to parse Nmap XML output:")
                 logger.debug("Problematic Nmap XML Output (full, on parse error):\n%s", stdout_str)
-                raise PortScannerError(f"Failed to parse Nmap XML output: {e_parse}. Stderr was: '{stderr_str.strip()}'") from e_parse
+                raise PortScannerError(
+                    f"Failed to parse Nmap XML output: {e_parse}. Stderr was: '{stderr_str.strip()}'"
+                ) from e_parse
 
             return self.nm
 
@@ -469,7 +485,6 @@ class NmapScanner:
             self.current_process = None
             self.current_cancellable = None
 
-
     def convert_results_to_yaml(self, nm: nmap.PortScanner) -> dict[str, str]:
         """
         Convert Nmap scan results to YAML for each host.
@@ -482,14 +497,14 @@ class NmapScanner:
         """
         logger.debug(f"Converting Nmap results to YAML for {len(nm.all_hosts())} hosts.")
         all_results: dict[str, str] = {}
-        prescan_scripts_data: list[Any] = nm.scaninfo().get('prescript', []) # type: ignore[no-untyped-call]
+        prescan_scripts_data: list[Any] = nm.scaninfo().get("prescript", [])  # type: ignore[no-untyped-call]
         logger.debug("Pre-scan script data: %s", prescan_scripts_data)
         for host in nm.all_hosts():
             logger.debug("Processing results for host: %s", host)
             host_data = nm[host]
             plain_dict = self.to_plain_dict(host_data)
             if prescan_scripts_data:
-                plain_dict["prescript_results"] = prescan_scripts_data # type: ignore
+                plain_dict["prescript_results"] = prescan_scripts_data  # type: ignore
             yaml_output = yaml.safe_dump(plain_dict, default_flow_style=False)
             all_results[host] = yaml_output
         return all_results

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -6,12 +6,14 @@ preferences such as font scaling, color themes, source view style schemes,
 custom DNS server settings, and HTTP output colors. It interacts with
 GSettings to persist these preferences.
 """
+
 import logging
 import re
 from typing import Optional
 
 import gi
-gi.require_version("Adw", "1") # Must be called before importing from gi.repository
+
+gi.require_version("Adw", "1")  # Must be called before importing from gi.repository
 gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, Gio, Gtk, GLib, GObject, Gdk
 
@@ -65,26 +67,25 @@ class Preferences(Adw.PreferencesWindow):
 
     __gtype_name__ = "Preferences"
 
-    font_scale_combo_row: Adw.ComboRow = Gtk.Template.Child("font_scale_combo_row") # type: ignore
-    theme_combo_row: Adw.ComboRow = Gtk.Template.Child("theme_combo_row") # type: ignore
-    dns_server_entryrow: Adw.EntryRow = Gtk.Template.Child("dns_server_entryrow") # type: ignore
-    prefs_dns_apply_button: Gtk.Button = Gtk.Template.Child("prefs_dns_apply_button") # type: ignore
-    preferences_error_banner: Adw.Banner = Gtk.Template.Child("preferences_error_banner") # type: ignore
+    font_scale_combo_row: Adw.ComboRow = Gtk.Template.Child("font_scale_combo_row")  # type: ignore
+    theme_combo_row: Adw.ComboRow = Gtk.Template.Child("theme_combo_row")  # type: ignore
+    dns_server_entryrow: Adw.EntryRow = Gtk.Template.Child("dns_server_entryrow")  # type: ignore
+    prefs_dns_apply_button: Gtk.Button = Gtk.Template.Child("prefs_dns_apply_button")  # type: ignore
+    preferences_error_banner: Adw.Banner = Gtk.Template.Child("preferences_error_banner")  # type: ignore
 
     # HTTP Output Color Rows
-    http_header_key_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_header_key_color_button") # type: ignore
-    http_header_value_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_header_value_color_button") # type: ignore
-    http_special_row_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_special_row_color_button") # type: ignore
+    http_header_key_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_header_key_color_button")  # type: ignore
+    http_header_value_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_header_value_color_button")  # type: ignore
+    http_special_row_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_special_row_color_button")  # type: ignore
 
     # Custom User Agent UI
-    new_custom_ua_title_entry: Gtk.Entry = Gtk.Template.Child("new_custom_ua_title_entry") # type: ignore
-    new_custom_ua_value_entry: Gtk.Entry = Gtk.Template.Child("new_custom_ua_value_entry") # type: ignore
-    add_custom_ua_button: Gtk.Button = Gtk.Template.Child("add_custom_ua_button") # type: ignore
-    custom_ua_list_container: Gtk.Box = Gtk.Template.Child("custom_ua_list_container") # type: ignore
+    new_custom_ua_title_entry: Gtk.Entry = Gtk.Template.Child("new_custom_ua_title_entry")  # type: ignore
+    new_custom_ua_value_entry: Gtk.Entry = Gtk.Template.Child("new_custom_ua_value_entry")  # type: ignore
+    add_custom_ua_button: Gtk.Button = Gtk.Template.Child("add_custom_ua_button")  # type: ignore
+    custom_ua_list_container: Gtk.Box = Gtk.Template.Child("custom_ua_list_container")  # type: ignore
 
     # Global Font Preference UI Element
-    global_output_font_button: Gtk.FontButton = Gtk.Template.Child("global_output_font_button") # type: ignore
-
+    global_output_font_button: Gtk.FontButton = Gtk.Template.Child("global_output_font_button")  # type: ignore
 
     def __init__(self, main_window: Optional[Gtk.Window] = None):
         """
@@ -105,32 +106,41 @@ class Preferences(Adw.PreferencesWindow):
                 if not dnspython_available:
                     self.dns_server_entryrow.set_sensitive(False)
                     self.dns_server_entryrow.set_subtitle("Requires 'dnspython' library to be installed.")
-                    self.dns_server_entryrow.set_tooltip_text("Custom DNS functionality is disabled because the 'dnspython' library is not installed.")
+                    self.dns_server_entryrow.set_tooltip_text(
+                        "Custom DNS functionality is disabled because the 'dnspython' library is not installed."
+                    )
                     if self.prefs_dns_apply_button:
                         self.prefs_dns_apply_button.set_sensitive(False)
                 else:
                     self.dns_server_entryrow.set_sensitive(True)
                     self.dns_server_entryrow.set_subtitle("")
-                    self.dns_server_entryrow.set_tooltip_text("Enter your custom DNS server IP address. Leave empty to use system default.")
+                    self.dns_server_entryrow.set_tooltip_text(
+                        "Enter your custom DNS server IP address. Leave empty to use system default."
+                    )
                     if self.prefs_dns_apply_button:
                         self.prefs_dns_apply_button.set_sensitive(True)
                 logging.info(
                     "'dnspython' status: %s. Custom DNS server entry in preferences updated.",
-                    "found" if dnspython_available else "not found"
+                    "found" if dnspython_available else "not found",
                 )
             else:
-                logging.warning("Adw.EntryRow 'dns_server_entryrow' does not have 'set_subtitle' method. Using tooltip fallback.")
+                logging.warning(
+                    "Adw.EntryRow 'dns_server_entryrow' does not have 'set_subtitle' method. Using tooltip fallback."
+                )
                 if not dnspython_available:
                     self.dns_server_entryrow.set_sensitive(False)
-                    self.dns_server_entryrow.set_tooltip_text("Custom DNS disabled: 'dnspython' library not found. Install it for this feature.")
+                    self.dns_server_entryrow.set_tooltip_text(
+                        "Custom DNS disabled: 'dnspython' library not found. Install it for this feature."
+                    )
                     if self.prefs_dns_apply_button:
                         self.prefs_dns_apply_button.set_sensitive(False)
                 else:
                     self.dns_server_entryrow.set_sensitive(True)
-                    self.dns_server_entryrow.set_tooltip_text("Enter custom DNS server IP. Leave empty for system default.")
+                    self.dns_server_entryrow.set_tooltip_text(
+                        "Enter custom DNS server IP. Leave empty for system default."
+                    )
         else:
             logging.error("'dns_server_entryrow' template child not found during __init__.")
-
 
     def load_ui(self):
         """
@@ -147,15 +157,21 @@ class Preferences(Adw.PreferencesWindow):
         if self.http_header_key_color_button:
             dialog_hk = Gtk.ColorDialog(title="Select Header Key Colour", modal=True, with_alpha=True)
             self.http_header_key_color_button.set_dialog(dialog_hk)
-            self.http_header_key_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-header-key-color")
+            self.http_header_key_color_button.connect(
+                "notify::rgba", self.on_http_color_changed, "http-output-header-key-color"
+            )
         if self.http_header_value_color_button:
             dialog_hv = Gtk.ColorDialog(title="Select Header Value Colour", modal=True, with_alpha=True)
             self.http_header_value_color_button.set_dialog(dialog_hv)
-            self.http_header_value_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-header-value-color")
+            self.http_header_value_color_button.connect(
+                "notify::rgba", self.on_http_color_changed, "http-output-header-value-color"
+            )
         if self.http_special_row_color_button:
             dialog_sr = Gtk.ColorDialog(title="Select Special Row Colour", modal=True, with_alpha=True)
             self.http_special_row_color_button.set_dialog(dialog_sr)
-            self.http_special_row_color_button.connect("notify::rgba", self.on_http_color_changed, "http-output-special-row-color")
+            self.http_special_row_color_button.connect(
+                "notify::rgba", self.on_http_color_changed, "http-output-special-row-color"
+            )
 
         # Custom User Agent Signals
         if self.add_custom_ua_button:
@@ -171,7 +187,6 @@ class Preferences(Adw.PreferencesWindow):
         if self.global_output_font_button:
             self.global_output_font_button.connect("font-set", self.on_global_font_setting_changed)
 
-
     def on_global_font_setting_changed(self, font_button: Gtk.FontButton):
         """
         Handle the 'font-set' signal from the global output :class:`Gtk.FontButton`.
@@ -183,7 +198,7 @@ class Preferences(Adw.PreferencesWindow):
         :param font_button: The :class:`Gtk.FontButton` that emitted the signal.
         :type font_button: Gtk.FontButton
         """
-        font_desc_str = font_button.get_font() # Gets "Family [Style] Size"
+        font_desc_str = font_button.get_font()  # Gets "Family [Style] Size"
         if font_desc_str:
             self.settings.set_string("output-font", font_desc_str)
             logging.debug(f"Global output font set to: {font_desc_str}")
@@ -241,9 +256,7 @@ class Preferences(Adw.PreferencesWindow):
 
             self.preferences_error_banner.set_title(error_message)
             self.preferences_error_banner.set_revealed(True)
-            GLib.timeout_add_seconds(
-                4, self.hide_banner_and_clear_error_state, self.dns_server_entryrow
-            )
+            GLib.timeout_add_seconds(4, self.hide_banner_and_clear_error_state, self.dns_server_entryrow)
 
     def hide_banner_and_clear_error_state(self, entry_row_widget: Optional[Adw.EntryRow] = None) -> bool:
         """
@@ -372,9 +385,13 @@ class Preferences(Adw.PreferencesWindow):
                 if color.parse(color_string):
                     button.set_rgba(color)
                 else:
-                    logging.warning(f"Gdk.RGBA.parse returned false for color string '{color_string}' for GSettings key '{gsettings_key}'.")
+                    logging.warning(
+                        f"Gdk.RGBA.parse returned false for color string '{color_string}' for GSettings key '{gsettings_key}'."
+                    )
             except GLib.Error as e:
-                logging.warning(f"Failed to parse color string '{color_string}' for GSettings key '{gsettings_key}': {e}.")
+                logging.warning(
+                    f"Failed to parse color string '{color_string}' for GSettings key '{gsettings_key}': {e}."
+                )
 
     def _render_custom_ua_list(self):
         """
@@ -389,22 +406,24 @@ class Preferences(Adw.PreferencesWindow):
 
         child = self.custom_ua_list_container.get_first_child()
         while child:
-            self.custom_ua_list_container.remove(child) # type: ignore[union-attr]
-            child = self.custom_ua_list_container.get_first_child() # type: ignore[union-attr]
+            self.custom_ua_list_container.remove(child)  # type: ignore[union-attr]
+            child = self.custom_ua_list_container.get_first_child()  # type: ignore[union-attr]
 
         variant = self.settings.get_value("custom-user-agents")
-        custom_ua_pairs: list[tuple[str,str]] = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else []) # type: ignore[union-attr]
+        custom_ua_pairs: list[tuple[str, str]] = list(
+            variant.unpack() if variant and variant.get_type_string() == "a(ss)" else []
+        )  # type: ignore[union-attr]
 
         for title, value in custom_ua_pairs:
             row = Adw.ActionRow(title=title, subtitle=value)
-            row.set_activatable(False) # type: ignore[no-untyped-call]
+            row.set_activatable(False)  # type: ignore[no-untyped-call]
             remove_button = Gtk.Button(icon_name="edit-delete-symbolic", valign=Gtk.Align.CENTER)
-            remove_button.add_css_class("flat") # type: ignore[no-untyped-call]
-            remove_button.set_tooltip_text(f"Remove '{title}'") # type: ignore[no-untyped-call]
+            remove_button.add_css_class("flat")  # type: ignore[no-untyped-call]
+            remove_button.set_tooltip_text(f"Remove '{title}'")  # type: ignore[no-untyped-call]
             remove_button.connect("clicked", lambda _btn, t=title: self._on_remove_custom_ua_clicked(t))
-            row.add_suffix(remove_button) # type: ignore[no-untyped-call]
-            row.set_activatable_widget(remove_button) # type: ignore[no-untyped-call]
-            self.custom_ua_list_container.append(row) # type: ignore[union-attr]
+            row.add_suffix(remove_button)  # type: ignore[no-untyped-call]
+            row.set_activatable_widget(remove_button)  # type: ignore[no-untyped-call]
+            self.custom_ua_list_container.append(row)  # type: ignore[union-attr]
 
     def _on_add_custom_ua_clicked(self, _widget: Gtk.Widget) -> None:
         """
@@ -427,31 +446,33 @@ class Preferences(Adw.PreferencesWindow):
         if not title_text or not value_text:
             logging.info("Attempted to add custom User-Agent with empty title or value.")
             if not title_text and self.new_custom_ua_title_entry:
-                self.new_custom_ua_title_entry.add_css_class("error") # type: ignore[union-attr]
+                self.new_custom_ua_title_entry.add_css_class("error")  # type: ignore[union-attr]
             elif self.new_custom_ua_title_entry:
-                 self.new_custom_ua_title_entry.remove_css_class("error") # type: ignore[union-attr]
+                self.new_custom_ua_title_entry.remove_css_class("error")  # type: ignore[union-attr]
             if not value_text and self.new_custom_ua_value_entry:
-                self.new_custom_ua_value_entry.add_css_class("error") # type: ignore[union-attr]
+                self.new_custom_ua_value_entry.add_css_class("error")  # type: ignore[union-attr]
             elif self.new_custom_ua_value_entry:
-                self.new_custom_ua_value_entry.remove_css_class("error") # type: ignore[union-attr]
+                self.new_custom_ua_value_entry.remove_css_class("error")  # type: ignore[union-attr]
             return
 
         if self.new_custom_ua_title_entry:
-            self.new_custom_ua_title_entry.remove_css_class("error") # type: ignore[union-attr]
+            self.new_custom_ua_title_entry.remove_css_class("error")  # type: ignore[union-attr]
         if self.new_custom_ua_value_entry:
-            self.new_custom_ua_value_entry.remove_css_class("error") # type: ignore[union-attr]
+            self.new_custom_ua_value_entry.remove_css_class("error")  # type: ignore[union-attr]
 
         variant = self.settings.get_value("custom-user-agents")
-        current_ua_pairs: list[tuple[str,str]] = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else []) # type: ignore[union-attr]
+        current_ua_pairs: list[tuple[str, str]] = list(
+            variant.unpack() if variant and variant.get_type_string() == "a(ss)" else []
+        )  # type: ignore[union-attr]
 
         existing_titles = [pair[0] for pair in current_ua_pairs]
         if title_text in existing_titles:
             logging.info(f"Custom User-Agent title '{title_text}' already exists.")
             if self.new_custom_ua_title_entry:
-                 self.new_custom_ua_title_entry.add_css_class("error") # type: ignore[union-attr]
+                self.new_custom_ua_title_entry.add_css_class("error")  # type: ignore[union-attr]
             return
         elif self.new_custom_ua_title_entry:
-            self.new_custom_ua_title_entry.remove_css_class("error") # type: ignore[union-attr]
+            self.new_custom_ua_title_entry.remove_css_class("error")  # type: ignore[union-attr]
 
         current_ua_pairs.append((title_text, value_text))
         new_variant = GLib.Variant("a(ss)", current_ua_pairs)
@@ -459,9 +480,9 @@ class Preferences(Adw.PreferencesWindow):
         if self.settings.set_value("custom-user-agents", new_variant):
             logging.info(f"Added custom User-Agent: '{title_text}' -> '{value_text}'")
             if self.new_custom_ua_title_entry:
-                self.new_custom_ua_title_entry.set_text("") # type: ignore[union-attr]
+                self.new_custom_ua_title_entry.set_text("")  # type: ignore[union-attr]
             if self.new_custom_ua_value_entry:
-                self.new_custom_ua_value_entry.set_text("") # type: ignore[union-attr]
+                self.new_custom_ua_value_entry.set_text("")  # type: ignore[union-attr]
             self._render_custom_ua_list()
         else:
             logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {title_text}")
@@ -477,7 +498,9 @@ class Preferences(Adw.PreferencesWindow):
         :type title_to_remove: str
         """
         variant = self.settings.get_value("custom-user-agents")
-        current_ua_pairs: list[tuple[str,str]] = list(variant.unpack() if variant and variant.get_type_string() == 'a(ss)' else []) # type: ignore[union-attr]
+        current_ua_pairs: list[tuple[str, str]] = list(
+            variant.unpack() if variant and variant.get_type_string() == "a(ss)" else []
+        )  # type: ignore[union-attr]
 
         original_length = len(current_ua_pairs)
         updated_ua_pairs = [pair for pair in current_ua_pairs if pair[0] != title_to_remove]
@@ -492,9 +515,7 @@ class Preferences(Adw.PreferencesWindow):
         else:
             logging.warning(f"Attempted to remove non-existent User-Agent with title: {title_to_remove}")
 
-    def _select_combo_row_item(
-        self, combo_row: Adw.ComboRow, setting_value: str, case_sensitive: bool = True
-    ) -> bool:
+    def _select_combo_row_item(self, combo_row: Adw.ComboRow, setting_value: str, case_sensitive: bool = True) -> bool:
         """
         Select an item in an :class:`Adw.ComboRow` based on its string value.
 
@@ -512,8 +533,8 @@ class Preferences(Adw.PreferencesWindow):
         """
         model = combo_row.get_model()
         if isinstance(model, Gtk.StringList):
-            for i in range(model.get_n_items()): # type: ignore[attr-defined]
-                item_string = model.get_string(i) # type: ignore[attr-defined]
+            for i in range(model.get_n_items()):  # type: ignore[attr-defined]
+                item_string = model.get_string(i)  # type: ignore[attr-defined]
                 match_condition = (
                     (item_string == setting_value)
                     if case_sensitive
@@ -533,31 +554,31 @@ class Preferences(Adw.PreferencesWindow):
         UI control (e.g., selects the correct item in a :class:`Adw.ComboRow`, sets text in an :class:`Adw.EntryRow`).
         """
         font_scale_pref = self.settings.get_string("font-scaling-percentage")
-        if not self._select_combo_row_item(self.font_scale_combo_row, font_scale_pref): # type: ignore[arg-type]
-            self.font_scale_combo_row.set_selected(0) # type: ignore[union-attr]
+        if not self._select_combo_row_item(self.font_scale_combo_row, font_scale_pref):  # type: ignore[arg-type]
+            self.font_scale_combo_row.set_selected(0)  # type: ignore[union-attr]
 
         theme_pref_value = self.settings.get_string("theme-preference")
-        if not self._select_combo_row_item(self.theme_combo_row, theme_pref_value): # type: ignore[arg-type]
-            self.theme_combo_row.set_selected(0) # type: ignore[union-attr]
+        if not self._select_combo_row_item(self.theme_combo_row, theme_pref_value):  # type: ignore[arg-type]
+            self.theme_combo_row.set_selected(0)  # type: ignore[union-attr]
 
         dns_server = self.settings.get_string("custom-dns-server")
-        self.dns_server_entryrow.set_text(dns_server) # type: ignore[union-attr]
+        self.dns_server_entryrow.set_text(dns_server)  # type: ignore[union-attr]
 
         if self.http_header_key_color_button:
-            self._load_color_button_preference(self.http_header_key_color_button, "http-output-header-key-color") # type: ignore[arg-type]
+            self._load_color_button_preference(self.http_header_key_color_button, "http-output-header-key-color")  # type: ignore[arg-type]
         if self.http_header_value_color_button:
-            self._load_color_button_preference(self.http_header_value_color_button, "http-output-header-value-color") # type: ignore[arg-type]
+            self._load_color_button_preference(self.http_header_value_color_button, "http-output-header-value-color")  # type: ignore[arg-type]
         if self.http_special_row_color_button:
-            self._load_color_button_preference(self.http_special_row_color_button, "http-output-special-row-color") # type: ignore[arg-type]
+            self._load_color_button_preference(self.http_special_row_color_button, "http-output-special-row-color")  # type: ignore[arg-type]
 
         self._render_custom_ua_list()
 
         output_font_str = self.settings.get_string("output-font")
         if self.global_output_font_button:
             if output_font_str:
-                self.global_output_font_button.set_font(output_font_str) # type: ignore[union-attr]
+                self.global_output_font_button.set_font(output_font_str)  # type: ignore[union-attr]
             else:
                 default_font = "Sans 10"
-                self.global_output_font_button.set_font(default_font) # type: ignore[union-attr]
+                self.global_output_font_button.set_font(default_font)  # type: ignore[union-attr]
                 self.settings.set_string("output-font", default_font)
                 logging.warning(f"GSettings 'output-font' was empty, set to default: {default_font}")

--- a/src/style_utils.py
+++ b/src/style_utils.py
@@ -5,13 +5,14 @@ This module provides functions for applying font preferences, themes,
 and :class:`GtkSource.View` style schemes. It interacts with GSettings to retrieve
 system and application-specific style configurations.
 """
+
 import logging
 import re
 import platform
 from typing import Optional, Tuple
-import collections.abc # For Sequence if needed
 
 import gi
+
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 gi.require_version("GtkSource", "5")
@@ -117,17 +118,13 @@ def apply_system_font_preferences(app_settings: Gio.Settings):
     font_size_to_apply_pt: float = BASE_FONT_SIZE_PT
 
     if platform.system() == "Linux":
-        font_family_to_apply, font_size_to_apply_pt = _get_linux_font_preferences(
-            font_size_to_apply_pt
-        )
+        font_family_to_apply, font_size_to_apply_pt = _get_linux_font_preferences(font_size_to_apply_pt)
 
     parsed_app_percentage = _get_app_font_scaling(app_settings)
     final_font_size_pt = font_size_to_apply_pt * (parsed_app_percentage / 100.0)
 
     if font_family_to_apply:
-        css_font_family = (
-            f"'{font_family_to_apply}'" if " " in font_family_to_apply else font_family_to_apply
-        )
+        css_font_family = f"'{font_family_to_apply}'" if " " in font_family_to_apply else font_family_to_apply
         css = f"* {{ font-family: {css_font_family}; font-size: {final_font_size_pt:.2f}pt; }}"
     else:
         css = f"* {{ font-size: {final_font_size_pt:.2f}pt; }}"

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,10 @@
 """General utility functions for the Woes application."""
+
 import logging
 import ipaddress
 import re
 from urllib.parse import urlparse
 from typing import Optional, List
-import collections.abc # For Sequence if needed
 
 import gi
 from gi.repository import Gtk, Adw
@@ -27,26 +27,17 @@ def show_global_error(widget: Gtk.Widget, message: str):
     """
     try:
         main_window = widget.get_native()
-        if main_window and hasattr(main_window, 'show_error'):
+        if main_window and hasattr(main_window, "show_error"):
             main_window.show_error(message)
             logger.error(f"Global error displayed via main window: {message}")
         else:
-            logger.warning(
-                "Could not find main window or show_error method to display global error: %s",
-                message
-            )
+            logger.warning("Could not find main window or show_error method to display global error: %s", message)
     except Exception as e:
-        logger.exception(
-            "An unexpected error occurred while trying to show global error '%s': %s",
-            message, e
-        )
+        logger.exception("An unexpected error occurred while trying to show global error '%s': %s", message, e)
 
 
 def show_global_toast(
-    widget: Gtk.Widget,
-    message: str,
-    timeout: int = 2,
-    priority: Adw.ToastPriority = Adw.ToastPriority.NORMAL
+    widget: Gtk.Widget, message: str, timeout: int = 2, priority: Adw.ToastPriority = Adw.ToastPriority.NORMAL
 ):
     """
     Display a global toast message using the main window's toast overlay.
@@ -65,19 +56,13 @@ def show_global_toast(
     """
     try:
         main_window = widget.get_native()
-        if main_window and hasattr(main_window, 'show_toast'):
+        if main_window and hasattr(main_window, "show_toast"):
             main_window.show_toast(message, priority=priority, timeout=timeout)
             logger.info(f"Global toast shown via main window: {message}")
         else:
-            logger.warning(
-                "Could not find main window or show_toast method to display global toast: %s",
-                message
-            )
+            logger.warning("Could not find main window or show_toast method to display global toast: %s", message)
     except Exception as e:
-        logger.exception(
-            "An unexpected error occurred while trying to show global toast '%s': %s",
-            message, e
-        )
+        logger.exception("An unexpected error occurred while trying to show global toast '%s': %s", message, e)
 
 
 def is_valid_ip(address: str) -> bool:
@@ -96,6 +81,7 @@ def is_valid_ip(address: str) -> bool:
         return True
     except ValueError:
         return False
+
 
 def is_valid_domain(domain: str) -> bool:
     """
@@ -145,8 +131,8 @@ def is_valid_url(url: str, schemes: Optional[List[str]] = None) -> bool:
     :rtype: bool
     """
     effective_schemes: list[str]
-    if schemes is None: # Default to http and https if not provided
-        effective_schemes = ['http', 'https']
+    if schemes is None:  # Default to http and https if not provided
+        effective_schemes = ["http", "https"]
     else:
         effective_schemes = schemes
 
@@ -161,5 +147,5 @@ def is_valid_url(url: str, schemes: Optional[List[str]] = None) -> bool:
         if effective_schemes and parsed_url.scheme not in effective_schemes:
             return False
         return True
-    except ValueError: # urlparse can raise ValueError for some malformed URLs, though it's rare
+    except ValueError:  # urlparse can raise ValueError for some malformed URLs, though it's rare
         return False

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -1,10 +1,13 @@
-"""Defines the WebScan page for the Woes application.
+"""
+Defines the WebScan page for the Woes application.
 
 This page provides a simple interface to run Nikto scans against a target URL
 and display the results.
 """
+
 import subprocess
 import logging
+
 logger = logging.getLogger(__name__)
 import re
 import ast
@@ -76,7 +79,7 @@ class WebScanPage(Adw.PreferencesPage):
 
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
-        self.current_nikto_process: Optional[subprocess.Popen[str]] = None # Added Popen type hint
+        self.current_nikto_process: Optional[subprocess.Popen[str]] = None  # Added Popen type hint
         self._current_webscan_params: Optional[dict[str, Any]] = None
         self.settings: Gio.Settings = Gio.Settings.new(APP_ID)
         self.style_manager: Adw.StyleManager = Adw.StyleManager.get_default()
@@ -120,8 +123,7 @@ class WebScanPage(Adw.PreferencesPage):
 
     def __del__(self):
         """Clean up when the WebScanPage is destroyed."""
-        if self.current_web_scan_cancellable and \
-           not self.current_web_scan_cancellable.is_cancelled():
+        if self.current_web_scan_cancellable and not self.current_web_scan_cancellable.is_cancelled():
             logger.info("WebScanPage being destroyed, cancelling ongoing Nikto scan.")
             self.current_web_scan_cancellable.cancel()
 
@@ -164,11 +166,7 @@ class WebScanPage(Adw.PreferencesPage):
         :type _button: Gtk.Button
         """
         dialog = Gtk.FileChooserNative.new(
-            "Save Nikto Output",
-            self.get_native(),
-            Gtk.FileChooserAction.SAVE,
-            "_Save",
-            "_Cancel"
+            "Save Nikto Output", self.get_native(), Gtk.FileChooserAction.SAVE, "_Save", "_Cancel"
         )
         dialog.set_modal(True)
 
@@ -207,11 +205,10 @@ class WebScanPage(Adw.PreferencesPage):
         :type _button: Gtk.Button
         """
         logger.info("Cancel scan button clicked.")
-        if self.current_web_scan_cancellable and \
-           not self.current_web_scan_cancellable.is_cancelled():
+        if self.current_web_scan_cancellable and not self.current_web_scan_cancellable.is_cancelled():
             self.current_web_scan_cancellable.cancel()
             logger.info("Nikto scan cancellation requested via button.")
-            if hasattr(self, 'webscan_cancel_button'):
+            if hasattr(self, "webscan_cancel_button"):
                 self.webscan_cancel_button.set_sensitive(False)
         else:
             logger.warning("No active scan or cancellable to cancel.")
@@ -223,7 +220,7 @@ class WebScanPage(Adw.PreferencesPage):
         :param _button: The :class:`Gtk.Button` that was clicked (unused).
         :type _button: Gtk.Button
         """
-        if not hasattr(self, 'source_view') or not self.source_view:
+        if not hasattr(self, "source_view") or not self.source_view:
             return
         buffer = self.source_view.get_buffer()
         if not buffer:
@@ -240,7 +237,7 @@ class WebScanPage(Adw.PreferencesPage):
         :param _button: The :class:`Gtk.Button` that was clicked (unused).
         :type _button: Gtk.Button
         """
-        if not hasattr(self, 'source_view') or not self.source_view:
+        if not hasattr(self, "source_view") or not self.source_view:
             return
         buffer = self.source_view.get_buffer()
         if not buffer:
@@ -260,7 +257,7 @@ class WebScanPage(Adw.PreferencesPage):
                         logger.info("Webscan results copied to clipboard successfully.")
                     else:
                         logger.warning("Failed to get default clipboard for copying webscan results.")
-                except Exception as e: # Clipboard operations can be unreliable
+                except Exception as e:  # Clipboard operations can be unreliable
                     logger.error(f"Error copying webscan results to clipboard: {e}", exc_info=True)
             else:
                 logger.info("No webscan results to copy.")
@@ -272,28 +269,30 @@ class WebScanPage(Adw.PreferencesPage):
         :param _widget: The :class:`Gtk.Button` that was clicked (unused).
         :type _widget: Gtk.Button
         """
-        if not hasattr(self, 'source_view') or not self.source_view:
+        if not hasattr(self, "source_view") or not self.source_view:
             return
         buffer = self.source_view.get_buffer()
         if not buffer:
             return
         target_url = self.url_entry.get_text().strip()
-        if target_url and not (target_url.startswith("http://") or target_url.startswith("https://") or target_url.startswith("ftp://")):
+        if target_url and not (
+            target_url.startswith("http://") or target_url.startswith("https://") or target_url.startswith("ftp://")
+        ):
             logger.info(f"No scheme found in URL '{target_url}'. Prepending 'https://'.")
             target_url = "https://" + target_url
 
         if not target_url:
             show_global_toast(self, "Target URL cannot be empty.")
             main_window = self.get_native()
-            if not (main_window and hasattr(main_window, 'show_toast')):
+            if not (main_window and hasattr(main_window, "show_toast")):
                 show_global_error(self, "Target URL cannot be empty.")
             self.scan_button.set_sensitive(True)
             return
 
-        if not is_valid_url(target_url, schemes=['http', 'https', 'ftp']):
+        if not is_valid_url(target_url, schemes=["http", "https", "ftp"]):
             show_global_toast(self, "Invalid URL format. Please enter a valid URL.")
             main_window = self.get_native()
-            if not (main_window and hasattr(main_window, 'show_toast')):
+            if not (main_window and hasattr(main_window, "show_toast")):
                 show_global_error(self, "Invalid URL format. Please enter a valid URL.")
             self.scan_button.set_sensitive(True)
             return
@@ -313,7 +312,6 @@ class WebScanPage(Adw.PreferencesPage):
             self.webscan_cancel_button.set_visible(True)
             self.webscan_cancel_button.set_sensitive(True)
 
-
         if self.current_web_scan_task and not self.current_web_scan_task.is_done():
             if self.current_web_scan_cancellable and not self.current_web_scan_cancellable.is_cancelled():
                 logger.info("Cancelling previous web scan task before starting new one.")
@@ -331,19 +329,21 @@ class WebScanPage(Adw.PreferencesPage):
             "evasion": self.evasion_switch.get_active(),
             "mutate": self.mutate_switch.get_active(),
             "maxtime": self.maxtime_entry_row.get_text().strip(),
-            "nikto_format": self.nikto_format_combo_row.get_selected_item().get_string() if self.nikto_format_combo_row.get_selected_item() else "default (text)",
+            "nikto_format": self.nikto_format_combo_row.get_selected_item().get_string()
+            if self.nikto_format_combo_row.get_selected_item()
+            else "default (text)",
             "no404": self.no404_switch.get_active(),
-            "auth_bypass": self.auth_bypass_switch.get_active()
+            "auth_bypass": self.auth_bypass_switch.get_active(),
         }
-        task_data_for_thread["nikto_output_filename"] = self.nikto_output_file_row.get_text().strip() if self.nikto_output_file_row else ""
+        task_data_for_thread["nikto_output_filename"] = (
+            self.nikto_output_file_row.get_text().strip() if self.nikto_output_file_row else ""
+        )
         self._current_webscan_params = task_data_for_thread
         task.run_in_thread(self._run_scan_task_thread_func)
 
-    def _run_scan_task_thread_func(self,
-                                   task: Gio.Task,
-                                   _source_object: GObject.Object,
-                                   _task_data_unused: Any,
-                                   cancellable: Gio.Cancellable):
+    def _run_scan_task_thread_func(
+        self, task: Gio.Task, _source_object: GObject.Object, _task_data_unused: Any, cancellable: Gio.Cancellable
+    ):
         """
         Execute the Nikto scan in a separate thread, with cancellation support.
 
@@ -361,7 +361,11 @@ class WebScanPage(Adw.PreferencesPage):
 
         if not scan_params:
             logger.error("WebScanPage: _run_scan_task_thread_func: _current_webscan_params is None.")
-            task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, "Missing scan parameters in thread.")
+            task.return_new_error_literal(
+                GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                WebScanErrorType.GENERIC.value,
+                "Missing scan parameters in thread.",
+            )
             return
 
         target_url = scan_params["target_url"]
@@ -387,14 +391,16 @@ class WebScanPage(Adw.PreferencesPage):
                 logger.info(f"Force SSL is ON and original scheme was not http/https. Ensured URL is: {target_url}")
 
         if target_url.startswith("ftp://"):
-            logger.warning("FTP URL provided for Nikto's -h option. Nikto primarily scans HTTP/S. Attempting to use the host part with http://. This may not yield meaningful web scan results.")
+            logger.warning(
+                "FTP URL provided for Nikto's -h option. Nikto primarily scans HTTP/S. Attempting to use the host part with http://. This may not yield meaningful web scan results."
+            )
             target_url = target_url.replace("ftp://", "http://", 1)
 
         if "://" not in target_url:
             logger.warning(f"URL '{target_url}' still schemeless in scan thread. Defaulting to http://.")
             target_url = "http://" + target_url
 
-        nikto_command = ['nikto', '-h', target_url]
+        nikto_command = ["nikto", "-h", target_url]
 
         output_filename = scan_params.get("nikto_output_filename", "").strip()
         formats_requiring_file = ["csv", "xml", "html"]
@@ -406,26 +412,26 @@ class WebScanPage(Adw.PreferencesPage):
                 task.return_new_error_literal(
                     GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
                     WebScanErrorType.GENERIC.value,
-                    "Output format requires a filename, but none was provided."
+                    "Output format requires a filename, but none was provided.",
                 )
                 return
-            nikto_command.extend(['-o', output_filename])
+            nikto_command.extend(["-o", output_filename])
 
         if force_ssl:
-            nikto_command.append('-ssl')
+            nikto_command.append("-ssl")
         if evasion_active:
-            nikto_command.extend(['-evasion', '1'])
+            nikto_command.extend(["-evasion", "1"])
 
         if mutate_active:
             plugin_argument = "@@DEFAULT;tests(,all)"
-            nikto_command.extend(['-Plugin', plugin_argument])
+            nikto_command.extend(["-Plugin", plugin_argument])
             logger.info(f"Using -Plugin {plugin_argument} instead of deprecated -mutate.")
 
         if maxtime_str:
             try:
                 maxtime_val = int(maxtime_str)
                 if maxtime_val > 0:
-                    nikto_command.extend(['-maxtime', str(maxtime_val) + 's'])
+                    nikto_command.extend(["-maxtime", str(maxtime_val) + "s"])
                 else:
                     logger.warning(f"Invalid maxtime value '{maxtime_str}', must be positive. Ignoring.")
             except ValueError:
@@ -433,35 +439,41 @@ class WebScanPage(Adw.PreferencesPage):
 
         tuning_options = []
         if cgi_vulns:
-            tuning_options.append('2')
+            tuning_options.append("2")
         if interesting_content:
-            tuning_options.append('1')
+            tuning_options.append("1")
         if auth_bypass_active:
-            tuning_options.append('9')
+            tuning_options.append("9")
 
         if tuning_options:
             tuning_string = "".join(sorted(list(set(tuning_options))))
             if tuning_string:
-                nikto_command.extend(['-Tuning', tuning_string])
+                nikto_command.extend(["-Tuning", tuning_string])
 
         if nikto_format_str and nikto_format_str not in ["default (text)", "txt (text)"]:
             format_cli_value = nikto_format_str
             if nikto_format_str == "html":
                 format_cli_value = "htm"
             if format_cli_value not in ["txt"]:
-                 nikto_command.extend(['-Format', format_cli_value])
+                nikto_command.extend(["-Format", format_cli_value])
 
         if no404_active:
-            nikto_command.append('-no404')
+            nikto_command.append("-no404")
 
         logger.debug(f"Constructed Nikto command: {nikto_command}")
 
         try:
             if cancellable.is_cancelled():
-                task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.CANCELLED.value, "Scan cancelled before Nikto process start.")
+                task.return_new_error_literal(
+                    GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                    WebScanErrorType.CANCELLED.value,
+                    "Scan cancelled before Nikto process start.",
+                )
                 return
 
-            process = subprocess.Popen(nikto_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8")
+            process = subprocess.Popen(
+                nikto_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding="utf-8"
+            )
             self.current_nikto_process = process
 
             stdout_str, stderr_str = "", ""
@@ -478,7 +490,11 @@ class WebScanPage(Adw.PreferencesPage):
                             process.kill()
                         except Exception as e_term:
                             logger.error(f"Error terminating Nikto process: {e_term}")
-                    task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.CANCELLED.value, "Scan cancelled by user.")
+                    task.return_new_error_literal(
+                        GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                        WebScanErrorType.CANCELLED.value,
+                        "Scan cancelled by user.",
+                    )
                     self.current_nikto_process = None
                     return
 
@@ -508,37 +524,55 @@ class WebScanPage(Adw.PreferencesPage):
 
             if isinstance(stderr_str, str):
                 stripped_stderr = stderr_str.strip()
-                if stripped_stderr.startswith("('") and \
-                   (stripped_stderr.endswith(tuple_end_marker) or stripped_stderr.endswith(tuple_end_marker_alt)):
+                if stripped_stderr.startswith("('") and (
+                    stripped_stderr.endswith(tuple_end_marker) or stripped_stderr.endswith(tuple_end_marker_alt)
+                ):
                     logger.debug("Attempting to parse tuple string from stderr_str.")
                     try:
                         parsed_tuple = ast.literal_eval(stripped_stderr)
-                        if isinstance(parsed_tuple, tuple) and len(parsed_tuple) >= 1 and isinstance(parsed_tuple[0], str):
+                        if (
+                            isinstance(parsed_tuple, tuple)
+                            and len(parsed_tuple) >= 1
+                            and isinstance(parsed_tuple[0], str)
+                        ):
                             main_report_content = parsed_tuple[0]
                             aux_output = stdout_str
                             report_extracted_from_tuple = True
                             logger.info("Report extracted from string representation of tuple in stderr.")
                         else:
-                            logger.warning("stderr_str looked like a tuple string but ast.literal_eval returned unexpected structure.")
+                            logger.warning(
+                                "stderr_str looked like a tuple string but ast.literal_eval returned unexpected structure."
+                            )
                     except Exception as e_eval_stderr:
-                        logger.warning(f"ast.literal_eval failed for stderr_str: {e_eval_stderr}. String (first 200): {stripped_stderr[:200]}")
+                        logger.warning(
+                            f"ast.literal_eval failed for stderr_str: {e_eval_stderr}. String (first 200): {stripped_stderr[:200]}"
+                        )
 
             if not report_extracted_from_tuple and isinstance(stdout_str, str):
                 stripped_stdout = stdout_str.strip()
-                if stripped_stdout.startswith("('") and \
-                   (stripped_stdout.endswith(tuple_end_marker) or stripped_stdout.endswith(tuple_end_marker_alt)):
+                if stripped_stdout.startswith("('") and (
+                    stripped_stdout.endswith(tuple_end_marker) or stripped_stdout.endswith(tuple_end_marker_alt)
+                ):
                     logger.debug("Attempting to parse tuple string from stdout_str.")
                     try:
                         parsed_tuple = ast.literal_eval(stripped_stdout)
-                        if isinstance(parsed_tuple, tuple) and len(parsed_tuple) >= 1 and isinstance(parsed_tuple[0], str):
+                        if (
+                            isinstance(parsed_tuple, tuple)
+                            and len(parsed_tuple) >= 1
+                            and isinstance(parsed_tuple[0], str)
+                        ):
                             main_report_content = parsed_tuple[0]
                             aux_output = stderr_str
                             report_extracted_from_tuple = True
                             logger.info("Report extracted from string representation of tuple in stdout.")
                         else:
-                            logger.warning("stdout_str looked like a tuple string but ast.literal_eval returned unexpected structure.")
+                            logger.warning(
+                                "stdout_str looked like a tuple string but ast.literal_eval returned unexpected structure."
+                            )
                     except Exception as e_eval_stdout:
-                        logger.warning(f"ast.literal_eval failed for stdout_str: {e_eval_stdout}. String (first 200): {stripped_stdout[:200]}")
+                        logger.warning(
+                            f"ast.literal_eval failed for stdout_str: {e_eval_stdout}. String (first 200): {stripped_stdout[:200]}"
+                        )
 
             if not report_extracted_from_tuple:
                 logger.info("No tuple-like string processed. Using direct stdout/stderr.")
@@ -555,45 +589,50 @@ class WebScanPage(Adw.PreferencesPage):
             if main_report_content is None:
                 main_report_content = ""
             if not isinstance(main_report_content, str):
-                logger.warning(f"main_report_content was type {type(main_report_content)}, converting to string. Value (first 100 chars): {str(main_report_content)[:100]}")
+                logger.warning(
+                    f"main_report_content was type {type(main_report_content)}, converting to string. Value (first 100 chars): {str(main_report_content)[:100]}"
+                )
                 main_report_content = str(main_report_content)
 
-            main_report_content = main_report_content.replace('\\n', '\n')
+            main_report_content = main_report_content.replace("\\n", "\n")
             logger.debug("Applied newline unescaping to main_report_content.")
-
 
             if aux_output is not None:
                 if not isinstance(aux_output, str):
-                    logger.warning(f"aux_output was type {type(aux_output)}, converting to string. Value (first 100 chars): {str(aux_output)[:100]}")
+                    logger.warning(
+                        f"aux_output was type {type(aux_output)}, converting to string. Value (first 100 chars): {str(aux_output)[:100]}"
+                    )
                     aux_output = str(aux_output)
 
                 if aux_output.strip() == "" or aux_output.strip().lower() == "none":
                     aux_output = None
                     logger.debug("aux_output was empty or 'None', set to actual None.")
                 elif aux_output:
-                     aux_output = aux_output.replace('\\n', '\n')
-                     logger.debug("Applied newline unescaping to aux_output.")
+                    aux_output = aux_output.replace("\\n", "\n")
+                    logger.debug("Applied newline unescaping to aux_output.")
 
             if aux_output and rfi_warning_signature in aux_output:
-                aux_output = aux_output.replace(rfi_warning_signature, '').strip()
+                aux_output = aux_output.replace(rfi_warning_signature, "").strip()
                 if not aux_output.strip():
                     aux_output = None
                 logger.info("Filtered RFIURL warning from Nikto's aux_output.")
 
-
             if process.returncode not in [0, 1]:
                 error_output_detail = main_report_content if main_report_content else (aux_output or "")
-                logger.error(f"Nikto process finished with an unexpected error code {process.returncode}. Output/Stderr: {error_output_detail[:500]}...")
+                logger.error(
+                    f"Nikto process finished with an unexpected error code {process.returncode}. Output/Stderr: {error_output_detail[:500]}..."
+                )
                 task.return_new_error_literal(
                     GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
                     WebScanErrorType.GENERIC.value,
-                    f"Nikto execution error (code {process.returncode}). Output (if any):\n{error_output_detail}"
+                    f"Nikto execution error (code {process.returncode}). Output (if any):\n{error_output_detail}",
                 )
                 return
 
-            logger.debug(f"PRE-RETURN: main_report_content TYPE: {type(main_report_content)}, VALUE: {str(main_report_content)[:200]}")
+            logger.debug(
+                f"PRE-RETURN: main_report_content TYPE: {type(main_report_content)}, VALUE: {str(main_report_content)[:200]}"
+            )
             logger.debug(f"PRE-RETURN: aux_output TYPE: {type(aux_output)}, VALUE: {str(aux_output)[:200]}")
-
 
             if rfi_warning_detected_in_raw:
                 instructional_message = (
@@ -622,16 +661,24 @@ class WebScanPage(Adw.PreferencesPage):
                     aux_output = instructional_message.strip()
                 logger.info("Appended RFIURL instructional message to aux_output.")
 
-            task.return_value((
-                str(main_report_content) if main_report_content is not None else "",
-                str(aux_output) if aux_output is not None else None
-            ))
+            task.return_value(
+                (
+                    str(main_report_content) if main_report_content is not None else "",
+                    str(aux_output) if aux_output is not None else None,
+                )
+            )
         except FileNotFoundError:
             logger.error("Nikto command not found. Ensure it's in PATH.")
-            task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.NIKTO_NOT_FOUND.value, "Nikto command not found. Please ensure it is installed and in your system's PATH.")
+            task.return_new_error_literal(
+                GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                WebScanErrorType.NIKTO_NOT_FOUND.value,
+                "Nikto command not found. Please ensure it is installed and in your system's PATH.",
+            )
         except Exception as e:
             logger.exception(f"An unexpected error occurred during Nikto scan task: {e}")
-            task.return_new_error_literal(GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, str(e))
+            task.return_new_error_literal(
+                GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, str(e)
+            )
         finally:
             self.current_nikto_process = None
 
@@ -657,10 +704,13 @@ class WebScanPage(Adw.PreferencesPage):
         try:
             returned_data = result.propagate_value()
 
-
             if isinstance(returned_data, tuple) and len(returned_data) == 2:
                 s_out, s_err = returned_data
-            elif hasattr(returned_data, 'value') and isinstance(returned_data.value, tuple) and len(returned_data.value) == 2:
+            elif (
+                hasattr(returned_data, "value")
+                and isinstance(returned_data.value, tuple)
+                and len(returned_data.value) == 2
+            ):
                 s_out, s_err = returned_data.value
             else:
                 s_out, s_err = None, None
@@ -673,43 +723,49 @@ class WebScanPage(Adw.PreferencesPage):
                 logger.info("_on_scan_task_done: s_out (main report) is None, defaulting to empty string.")
                 final_stdout = ""
             elif not isinstance(s_out, str):
-                logger.warning(f"_on_scan_task_done: s_out (main report) was type {type(s_out)}, expected str. Converting. Value (first 100 chars): {str(s_out)[:100]}")
+                logger.warning(
+                    f"_on_scan_task_done: s_out (main report) was type {type(s_out)}, expected str. Converting. Value (first 100 chars): {str(s_out)[:100]}"
+                )
                 final_stdout = str(s_out)
             else:
                 final_stdout = s_out
 
             if final_stdout:
-                final_stdout = final_stdout.replace('\\n', '\n')
+                final_stdout = final_stdout.replace("\\n", "\n")
                 logger.debug("Applied .replace('\\\\n', '\\n') to final_stdout in _on_scan_task_done.")
 
             final_stderr: Optional[str] = None
             if s_err is not None:
                 if not isinstance(s_err, str):
-                    logger.warning(f"_on_scan_task_done: s_err (auxiliary output) was type {type(s_err)}, expected str. Converting. Value (first 100 chars): {str(s_err)[:100]}")
+                    logger.warning(
+                        f"_on_scan_task_done: s_err (auxiliary output) was type {type(s_err)}, expected str. Converting. Value (first 100 chars): {str(s_err)[:100]}"
+                    )
                     final_stderr = str(s_err)
                 else:
                     final_stderr = s_err
 
                 if final_stderr:
-                    final_stderr = final_stderr.replace('\\n', '\n')
+                    final_stderr = final_stderr.replace("\\n", "\n")
                     logger.debug("Applied .replace('\\\\n', '\\n') to final_stderr in _on_scan_task_done.")
 
             self._update_textview(final_stdout, final_stderr, is_error_message=False)
 
             if self.webscan_status_action_row:
-                    if final_stdout or final_stderr:
-                        self.webscan_status_action_row.set_subtitle("Scan complete. See results below.")
-                    else:
-                        self.webscan_status_action_row.set_subtitle("Scan complete. No output received.")
+                if final_stdout or final_stderr:
+                    self.webscan_status_action_row.set_subtitle("Scan complete. See results below.")
+                else:
+                    self.webscan_status_action_row.set_subtitle("Scan complete. No output received.")
             elif s_out is None and s_err is None and not (isinstance(returned_data, tuple) and len(returned_data) == 2):
                 if self.webscan_status_action_row and self.webscan_status_action_row.get_subtitle() == "Scanning...":
-                     self.webscan_status_action_row.set_subtitle("Error: Unexpected scan result format.")
+                    self.webscan_status_action_row.set_subtitle("Error: Unexpected scan result format.")
             else:
                 if self.webscan_status_action_row:
                     self.webscan_status_action_row.set_subtitle("Scan complete. No output received.")
 
         except GLib.Error as e:
-            logger.warning(f"Nikto scan task for {target_url} failed or was cancelled: {e.message} (Domain: {e.domain}, Code: {e.code})")
+            logger.warning(
+                f"Nikto scan task for {target_url} failed or was cancelled: {e.message} (Domain: {e.domain}, Code: {e.code})"
+            )
 
             brief_user_message = e.message
             detailed_output_for_textview = f"Error: {e.message}"
@@ -740,8 +796,12 @@ class WebScanPage(Adw.PreferencesPage):
                 self.webscan_status_action_row.set_subtitle(brief_user_message)
             show_global_error(self, brief_user_message)
 
-            if detailed_output_for_textview and isinstance(detailed_output_for_textview, str) and '\\n' in detailed_output_for_textview:
-                detailed_output_for_textview = detailed_output_for_textview.replace('\\n', '\n')
+            if (
+                detailed_output_for_textview
+                and isinstance(detailed_output_for_textview, str)
+                and "\\n" in detailed_output_for_textview
+            ):
+                detailed_output_for_textview = detailed_output_for_textview.replace("\\n", "\n")
                 logger.debug("Applied .replace('\\\\n', '\\n') to GLib.Error message for textview.")
             self._update_textview(None, detailed_output_for_textview, is_error_message=True)
 
@@ -749,9 +809,13 @@ class WebScanPage(Adw.PreferencesPage):
             logger.exception(f"Unexpected Python error in _on_scan_task_done for {target_url}:")
             user_message = "An unexpected error occurred."
             detailed_error_msg_for_textview = f"Error: {user_message} ({str(e_generic)})"
-            if detailed_error_msg_for_textview and isinstance(detailed_error_msg_for_textview, str) and '\\n' in detailed_error_msg_for_textview:
-                 detailed_error_msg_for_textview = detailed_error_msg_for_textview.replace('\\n', '\n')
-                 logger.debug("Applied .replace('\\\\n', '\\n') to generic Exception message for textview.")
+            if (
+                detailed_error_msg_for_textview
+                and isinstance(detailed_error_msg_for_textview, str)
+                and "\\n" in detailed_error_msg_for_textview
+            ):
+                detailed_error_msg_for_textview = detailed_error_msg_for_textview.replace("\\n", "\n")
+                logger.debug("Applied .replace('\\\\n', '\\n') to generic Exception message for textview.")
 
             if self.webscan_status_action_row:
                 self.webscan_status_action_row.set_subtitle(user_message)
@@ -766,17 +830,19 @@ class WebScanPage(Adw.PreferencesPage):
                 self.webscan_status_spinner.stop()
                 self.webscan_status_spinner.set_visible(False)
 
-            if self.webscan_status_action_row :
+            if self.webscan_status_action_row:
                 current_subtitle = self.webscan_status_action_row.get_subtitle()
                 if current_subtitle == "Scanning...":
-                     self.webscan_status_action_row.set_subtitle("Scan finished.")
+                    self.webscan_status_action_row.set_subtitle("Scan finished.")
 
             self.current_web_scan_task = None
             self.current_web_scan_cancellable = None
             self.current_nikto_process = None
             self._update_results_actions_sensitivity()
 
-    def _update_textview(self, stdout_content: Optional[str], stderr_content: Optional[str], is_error_message: bool = False):
+    def _update_textview(
+        self, stdout_content: Optional[str], stderr_content: Optional[str], is_error_message: bool = False
+    ):
         """
         Update the results :class:`Gtk.TextView` with Nikto's stdout and error messages/stderr.
 
@@ -788,7 +854,7 @@ class WebScanPage(Adw.PreferencesPage):
                                  Otherwise, it's treated as raw stderr output from Nikto. Defaults to ``False``.
         :type is_error_message: bool
         """
-        if not hasattr(self, 'source_view') or not self.source_view:
+        if not hasattr(self, "source_view") or not self.source_view:
             return
         buffer = self.source_view.get_buffer()
         if not buffer:
@@ -808,7 +874,7 @@ class WebScanPage(Adw.PreferencesPage):
             scroll_adj.set_value(scroll_adj.get_upper() - scroll_adj.get_page_size())
 
     def _update_results_actions_sensitivity(self):
-        if not hasattr(self, 'source_view') or not self.source_view:
+        if not hasattr(self, "source_view") or not self.source_view:
             if self.clear_results_button:
                 self.clear_results_button.set_sensitive(False)
             if self.copy_results_button:
@@ -839,7 +905,9 @@ class WebScanPage(Adw.PreferencesPage):
         else:
             logger.warning("Webscan scan button not available or not sensitive, cannot trigger scan.")
 
+
 WEB_SCAN_ERROR_DOMAIN = "web-scan-error-domain"
+
 
 class WebScanErrorType(int, Enum):
     """Enumeration of Web Scan error types for :class:`Gio.Task` error reporting."""

--- a/src/window.py
+++ b/src/window.py
@@ -5,6 +5,7 @@ This module contains the :class:`WoesWindow` class, which is the primary
 :class:`Adw.ApplicationWindow`. It handles UI setup, GSettings bindings for
 window state and theme preferences, and integrates system font settings.
 """
+
 import logging
 import platform
 from typing import Optional, Any
@@ -19,10 +20,6 @@ from .constants import (
     TEXT_SCALING_FACTOR_KEY,
 )
 from .style_utils import apply_font_size, apply_theme
-from .webscan_page import WebScanPage
-from .nmap_page import NmapPage
-from .http_page import HttpPage
-from .dns_page import DNSPage
 
 
 gi.require_version("Adw", "1")
@@ -55,7 +52,7 @@ class WoesWindow(Adw.ApplicationWindow):
     main_error_banner: Adw.Banner = Gtk.Template.Child("main_error_banner")
     toast_overlay: Adw.ToastOverlay = Gtk.Template.Child("toast_overlay")
 
-    def __init__(self, **kwargs: Any): # GObject.GObject is too restrictive if no args passed
+    def __init__(self, **kwargs: Any):  # GObject.GObject is too restrictive if no args passed
         """
         Initialize the WoesWindow.
 
@@ -69,16 +66,13 @@ class WoesWindow(Adw.ApplicationWindow):
         self._output_font_gsettings_key = "output-font"
         self.textview_font_css_provider = Gtk.CssProvider()
         Gtk.StyleContext.add_provider_for_display(
-            Gdk.Display.get_default(),
-            self.textview_font_css_provider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            Gdk.Display.get_default(), self.textview_font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
         initial_font_str = self.settings.get_string(self._output_font_gsettings_key)
         self.update_textview_font_style(initial_font_str if initial_font_str else "Sans 10")
 
         self.settings.connect(
-            f"changed::{self._output_font_gsettings_key}",
-            self._on_global_output_font_setting_changed_for_css
+            f"changed::{self._output_font_gsettings_key}", self._on_global_output_font_setting_changed_for_css
         )
 
         self.settings.bind("window-width", self, "default-width", Gio.SettingsBindFlags.DEFAULT)
@@ -92,12 +86,15 @@ class WoesWindow(Adw.ApplicationWindow):
             try:
                 self.gnome_interface_settings = Gio.Settings.new(GNOME_INTERFACE_SCHEMA)
                 self.gnome_interface_settings.connect(f"changed::{FONT_NAME_KEY}", self._on_gnome_font_setting_changed)
-                self.gnome_interface_settings.connect(f"changed::{TEXT_SCALING_FACTOR_KEY}", self._on_gnome_font_setting_changed)
+                self.gnome_interface_settings.connect(
+                    f"changed::{TEXT_SCALING_FACTOR_KEY}", self._on_gnome_font_setting_changed
+                )
                 logging.debug("Successfully connected to GNOME interface settings schema: %s", GNOME_INTERFACE_SCHEMA)
             except GLib.Error as e:
                 logging.warning(
                     "Could not connect to GNOME interface settings (%s): %s. System font integration will be limited.",
-                    GNOME_INTERFACE_SCHEMA, e
+                    GNOME_INTERFACE_SCHEMA,
+                    e,
                 )
 
         self.settings.connect("changed::theme-preference", self._on_theme_preference_setting_changed)
@@ -113,6 +110,17 @@ class WoesWindow(Adw.ApplicationWindow):
             self.hide_error()
 
     def _on_global_output_font_setting_changed_for_css(self, settings: Gio.Settings, key: str):
+        """
+        Handle changes to the 'output-font' GSettings key for TextView CSS.
+
+        Updates the CSS style for Nmap and Webscan TextViews when the
+        'output-font' setting changes.
+
+        :param settings: The :class:`Gio.Settings` object that emitted the signal.
+        :type settings: Gio.Settings
+        :param key: The GSettings key that changed (should be 'output-font').
+        :type key: str
+        """
         if key == self._output_font_gsettings_key:
             new_font_str = settings.get_string(key)
             self.update_textview_font_style(new_font_str if new_font_str else "Sans 10")
@@ -127,7 +135,7 @@ class WoesWindow(Adw.ApplicationWindow):
         `textview_font_css_provider`. If the provided `font_desc_str` is
         invalid or empty, it defaults to "Sans 10".
         """
-        logger = logging.getLogger(__name__) # Ensure logger is accessible
+        logger = logging.getLogger(__name__)  # Ensure logger is accessible
         font_desc = Pango.FontDescription.from_string(font_desc_str)
 
         if not font_desc_str or not font_desc.get_family():
@@ -135,14 +143,14 @@ class WoesWindow(Adw.ApplicationWindow):
             font_desc = Pango.FontDescription.from_string("Sans 10")
 
         family = font_desc.get_family()
-        safe_family = family.replace("'", "\\'") if family else "Sans" # Escape single quotes for CSS
+        safe_family = family.replace("'", "\\'") if family else "Sans"  # Escape single quotes for CSS
 
         size_pt = font_desc.get_size() / Pango.SCALE
-        weight = font_desc.get_weight() # Corrected: Direct value
-        style_enum_val = font_desc.get_style() # Corrected: Direct enum member
+        weight = font_desc.get_weight()  # Corrected: Direct value
+        style_enum_val = font_desc.get_style()  # Corrected: Direct enum member
 
         css_style_map = {
-            Pango.Style.NORMAL: "normal", # Corrected: Use enum member as key
+            Pango.Style.NORMAL: "normal",  # Corrected: Use enum member as key
             Pango.Style.OBLIQUE: "oblique",
             Pango.Style.ITALIC: "italic",
         }
@@ -158,7 +166,7 @@ class WoesWindow(Adw.ApplicationWindow):
         )
 
         try:
-            self.textview_font_css_provider.load_from_data(css_string.encode('UTF-8'))
+            self.textview_font_css_provider.load_from_data(css_string.encode("UTF-8"))
             logger.info(f"Applied CSS for TextViews with font: {font_desc_str}")
         except GLib.Error as e:
             logger.error(f"Error loading CSS string for TextViews: {e}. CSS was: {css_string}")
@@ -210,7 +218,7 @@ class WoesWindow(Adw.ApplicationWindow):
         else:
             logging.warning("main_error_banner not available to hide.")
 
-    def _on_gnome_font_setting_changed(self, gnome_settings_obj: Gio.Settings, key_name: str):
+    def _on_gnome_font_setting_changed(self, _gnome_settings_obj: Gio.Settings, key_name: str):
         """
         Handle changes to GNOME's system font settings.
 
@@ -225,10 +233,7 @@ class WoesWindow(Adw.ApplicationWindow):
                          (e.g., 'font-name', 'text-scaling-factor').
         :type key_name: str
         """
-        logging.debug(
-            "GNOME font setting '%s' changed. Re-applying font preferences.",
-            key_name
-        )
+        logging.debug("GNOME font setting '%s' changed. Re-applying font preferences.", key_name)
         apply_font_size(self.settings)
 
     def setup_ui(self):
@@ -273,7 +278,7 @@ class WoesWindow(Adw.ApplicationWindow):
         apply_theme(self.style_manager, theme_pref)
         self.load_css()
 
-    def _on_font_scaling_setting_changed(self, settings: Gio.Settings, key: str):
+    def _on_font_scaling_setting_changed(self, _settings: Gio.Settings, key: str):
         """
         Handle changes to the 'font-scaling-percentage' GSettings key.
 
@@ -285,10 +290,7 @@ class WoesWindow(Adw.ApplicationWindow):
         :param key: The name of the GSettings key that changed (should be 'font-scaling-percentage').
         :type key: str
         """
-        logging.debug(
-            "App font scaling setting '%s' changed. Re-applying font preferences.",
-            key
-            )
+        logging.debug("App font scaling setting '%s' changed. Re-applying font preferences.", key)
         apply_font_size(self.settings)
 
     def load_css(self):
@@ -316,7 +318,9 @@ class WoesWindow(Adw.ApplicationWindow):
         except Exception as e:
             logging.error(
                 "An unexpected error of type %s occurred while loading CSS from %s: %s",
-                type(e).__name__, css_path, e,
+                type(e).__name__,
+                css_path,
+                e,
             )
 
     def reload_css(self):
@@ -345,7 +349,7 @@ class WoesWindow(Adw.ApplicationWindow):
         except Exception as e:
             logging.error("An unexpected error of type %s occurred while applying preferences: %s", type(e).__name__, e)
 
-    def on_page_switched(self, widget: Adw.ViewSwitcherTitle, _gparam: GObject.ParamSpec):
+    def on_page_switched(self, _widget: Adw.ViewSwitcherTitle, _gparam: GObject.ParamSpec):
         """
         Handle the page switch event from the :class:`Adw.ViewSwitcherTitle`.
 
@@ -358,13 +362,9 @@ class WoesWindow(Adw.ApplicationWindow):
         :type _gparam: GObject.ParamSpec
         """
         if self.stack:
-            logging.debug(
-                "Page switched, new visible page: %s",
-                self.stack.get_visible_child_name()
-                )
+            logging.debug("Page switched, new visible page: %s", self.stack.get_visible_child_name())
         else:
             logging.warning("on_page_switched called but self.stack is not available.")
-
 
     def show_toast(self, title: str, priority: Adw.ToastPriority = Adw.ToastPriority.NORMAL, timeout: int = 2) -> None:
         """


### PR DESCRIPTION
This commit addresses several issues:
- Removes a premature exit call in `src/main.py` that caused the application to terminate after a settings test.
- Corrects a misleading print statement in `src/main.py`.
- Removes a redundant function call in `src/main.py`.
- I ran `ruff check --fix .` and `ruff format .` across the codebase to resolve linting errors and ensure consistent formatting. This included:
    - Updating `pyproject.toml` to use `E722` instead of the old `B001` ruff rule.
    - Fixing various specific linting errors (B904, ARG002, F841, F821, D401).
- Adds a missing docstring to a method in `src/window.py`.
- I restored several files that had syntax errors due to previous problematic docstring update attempts.

Note: UI-based testing could not be performed due to `ImportError` with the `gi` module in the execution environment, likely caused by missing environment setup (e.g., `GI_TYPELIB_PATH`). The changes are based on static analysis and code review.

The primary goal of fixing the premature exit and cleaning the codebase with `ruff` has been achieved.