### PR TITLE
Fix: Resolve blank UI by correcting AdwViewSwitcherTitle type in UI d…

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -13,7 +13,7 @@
             <child>
               <object class="AdwHeaderBar" id="header_bar">
             <property name="title-widget">
-              <object class="AdwViewSwitcher" id="switcher_title">
+              <object class="AdwViewSwitcherTitle" id="switcher_title">
                 <property name="halign">baseline-fill</property>
                 <property name="policy">wide</property>
                 <property name="stack">stack</property>


### PR DESCRIPTION
…efinition

The application was displaying a blank window and logging a warning "switcher_title or stack not found during setup_ui".

This was caused by a type mismatch for the `switcher_title` widget. In `src/window.py`, `switcher_title` is declared as an `Adw.ViewSwitcherTitle` and loaded via `Gtk.Template.Child("switcher_title")`. However, in the `src/gtk/window.ui` file, the widget with `id="switcher_title"` was incorrectly defined as an `AdwViewSwitcher` object.

This commit changes the class of the `switcher_title` widget in `src/gtk/window.ui` from `AdwViewSwitcher` to `AdwViewSwitcherTitle`. This ensures that the type in the UI definition matches the type expected by the Python code, allowing `Gtk.Template.Child` to correctly bind the widget. This should resolve the warning and allow the UI to load correctly.