### PR TITLE
Fix: Resolve Gtk-CRITICAL error by removing invalid 'policy' property

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -15,7 +15,6 @@
             <property name="title-widget">
               <object class="AdwViewSwitcherTitle" id="switcher_title">
                 <property name="halign">baseline-fill</property>
-                <property name="policy">wide</property>
                 <property name="stack">stack</property>
               </object>
             </property>


### PR DESCRIPTION
This commit addresses a Gtk-CRITICAL error:
`Error building template class 'WoesWindow': .:0:0 Invalid property: AdwViewSwitcherTitle.policy`

This error occurred because the `AdwViewSwitcherTitle` widget (with `id="switcher_title"`) in `src/gtk/window.ui` had a `policy` property, which is not valid for `AdwViewSwitcherTitle`. This property was likely a leftover from a previous definition where the widget might have been an `AdwViewSwitcher`.

The invalid property caused the `WoesWindow` template to fail during instantiation, leading to `switcher_title` not being found by the Python code. This, in turn, caused the "switcher_title or stack not found" warning and resulted in a blank UI.

This commit removes the `<property name="policy">wide</property>` line from the `AdwViewSwitcherTitle` definition in `src/gtk/window.ui`. This should allow the template to build correctly, ensure the widget is found, and resolve the blank window issue.