### PR TITLE
It looks like this commit addresses several issues:

### DIFF
--- a/build-flatpak.py
+++ b/build-flatpak.py
@@ -5,13 +5,13 @@ import os
 import subprocess
 
 # Configuration (replace with your actual values)
-APP_ID = "com.example.Woes"  # Replace with your Flatpak App ID
+APP_ID = "com.github.mclellac.woes"  # Replace with your Flatpak App ID
 RUNTIME_REPO = "flathub"
 RUNTIME = "org.gnome.Platform"
 RUNTIME_VERSION = "45"  # Or your desired GNOME runtime version
 SDK = "org.gnome.Sdk"
 BRANCH = "main"  # Or your desired branch
-FLATPAK_MODULE_FILE = f"{APP_ID}.json"  # Or your module file name
+FLATPAK_MODULE_FILE = "com.github.mclellac.woes.json"  # Or your module file name
 OUTPUT_DIR = "flatpak_build"
 REPO_NAME = "woes_repo"  # Name for the local Flatpak repository
 
@@ -23,49 +23,19 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 # sources, and cleanup steps according to your project's needs.
 # Refer to Flatpak documentation for details:
 # https://docs.flatpak.org/en/latest/first-build.html
-module_content = f"""
-{{
-    "app-id": "{APP_ID}",
-    "runtime": "{RUNTIME}",
-    "runtime-version": "{RUNTIME_VERSION}",
-    "sdk": "{SDK}",
-    "command": "woes",
-    "finish-args": [
-        "--share=network",
-        "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
-        "--filesystem=home"
-    ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/man",
-        "*.la",
-        "*.a"
-    ],
-    "modules": [
-        {{
-            "name": "woes",
-            "buildsystem": "meson",
-            "sources": [
-                {{
-                    "type": "dir",
-                    "path": "."
-                }}
-            ]
-        }}
-    ]
-}}
-"""
-with open(FLATPAK_MODULE_FILE, "w", encoding="utf-8") as f:
-    f.write(module_content)
-
-print(f"Generated Flatpak module file: {FLATPAK_MODULE_FILE}")
+# The manifest file (com.github.mclellac.woes.json) is now static and part of the repository.
+# Ensure it exists and is correctly formatted.
+if not os.path.exists(FLATPAK_MODULE_FILE):
+    print(f"Error: Flatpak module file {FLATPAK_MODULE_FILE} not found.")
+    print("Please ensure the manifest file exists in the root of the repository.")
+    exit(1)
+else:
+    print(f"Using existing Flatpak module file: {FLATPAK_MODULE_FILE}")
 
 # 2. Initialize Flatpak repository (if it doesn't exist)
+# The APP_ID in build-init command is taken from the manifest file directly by flatpak-builder,
+# but it's good practice to ensure our APP_ID variable matches.
+# The command itself doesn't strictly need APP_ID if it can infer from manifest, but let's keep it for clarity.
 if not os.path.exists(os.path.join(OUTPUT_DIR, REPO_NAME)):
     print(f"Initializing Flatpak repository: {REPO_NAME}")
     subprocess.run(
@@ -73,7 +43,7 @@ if not os.path.exists(os.path.join(OUTPUT_DIR, REPO_NAME)):
             "flatpak",
             "build-init",
             os.path.join(OUTPUT_DIR, REPO_NAME),
-            APP_ID,
+            APP_ID, # This should match the app-id in your static manifest
             SDK,
             RUNTIME,
             RUNTIME_VERSION,
@@ -85,7 +55,8 @@ else:
     print(f"Flatpak repository {REPO_NAME} already exists.")
 
 # 3. Build the application
-print(f"Building {APP_ID}...")
+# The flatpak build command reads the APP_ID from the manifest file.
+print(f"Building {APP_ID} using manifest {FLATPAK_MODULE_FILE}...")
 subprocess.run(["flatpak", "build", os.path.join(OUTPUT_DIR, REPO_NAME), FLATPAK_MODULE_FILE], check=True)
 
 # 4. Finish the build (optional, for creating a runnable Flatpak)
@@ -108,8 +79,8 @@ subprocess.run(
         "build-bundle",
         os.path.join(OUTPUT_DIR, REPO_NAME),
         bundle_path,
-        APP_ID,
-        "--runtime-repo=https://dl.flathub.org/repo/flathub.flatpakrepo",
+        APP_ID, # This should match the app-id in your static manifest
+        f"--runtime-repo=https://dl.flathub.org/repo/{RUNTIME_REPO}.flatpakrepo", # Use configured RUNTIME_REPO
     ],
     check=True,
 )

--- a/src/custom_dns_adapter.py
+++ b/src/custom_dns_adapter.py
@@ -8,7 +8,7 @@ for hostname resolution and handles Server Name Indication (SNI) for HTTPS conne
 import logging
 import socket
 import ssl
-from typing import Optional, Tuple, Any  # Use list, dict
+from typing import Optional, Tuple, Any
 
 import requests
 import requests.utils  # For urlparse, urlunparse

--- a/src/dns_client.py
+++ b/src/dns_client.py
@@ -1,7 +1,7 @@
 """Module for performing DNS lookups."""
 
 import logging
-from typing import Optional, List, Dict, Any  # Use list, dict
+from typing import Optional, List, Dict, Any
 import ipaddress
 
 import dns.resolver

--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -324,7 +324,6 @@ class DNSPage(Adw.PreferencesPage):
             ellipsize=Pango.EllipsizeMode.END,
         )
         value_label.override_font(self._output_font_desc)
-        # suffix_box removed
         row.add_suffix(value_label)  # type: ignore
         row.add_suffix(
             self._create_copy_button(main_value_text, f"{main_value_tooltip_prefix}: {main_value_text}", row)
@@ -393,7 +392,6 @@ class DNSPage(Adw.PreferencesPage):
         value_label.override_font(self._output_font_desc)
         copy_button = self._create_copy_button(value_text, f"{copy_tooltip_prefix}: {value_text}", expander_row)
 
-        # content_box removed
         if is_value_primary_content:  # For TXT segments where the value is the main content of the row
             detail_row.add_prefix(value_label)  # type: ignore
             detail_row.add_prefix(copy_button)  # type: ignore
@@ -1016,7 +1014,6 @@ class DNSPage(Adw.PreferencesPage):
             ellipsize=Pango.EllipsizeMode.END,
         )
         copy_button_exchange = self._create_copy_button(exchange_value, f"Copy Exchange: {exchange_value}", row)
-        # mx_detail_row_title_box removed
 
         mx_detail_row = Adw.ActionRow(subtitle=f"Preference: {preference_value}")  # type: ignore
         mx_detail_row.add_prefix(exchange_value_label)  # type: ignore
@@ -1137,7 +1134,7 @@ class DNSPage(Adw.PreferencesPage):
         elif record_type == "SOA":
             return self._build_soa_record_row(record_data, name, base_subtitle)
         elif record_data.get("data"):
-            return self._build_generic_data_record_row(record_data, name, base_subtitle, record_type)  # Renamed
+            return self._build_generic_data_record_row(record_data, name, base_subtitle, record_type)
         else:
             logger.warning(
                 "Could not create row for unknown record_data type or missing data field: %s (Type: %s)",

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -142,6 +142,12 @@
             <property name="title" translatable="yes">Custom User Agents</property>
             <property name="description" translatable="yes">Manage your list of custom User-Agent strings for the HTTP Page.</property>
             <child>
+              <object class="AdwComboRow" id="user_agent_combo_row">
+                <property name="title" translatable="yes">Default User Agent</property>
+                <!-- Model will be populated from code -->
+              </object>
+            </child>
+            <child>
               <object class="AdwEntryRow" id="new_custom_ua_title_entry">
                 <property name="title" translatable="yes">Display Title</property>
                 <property name="tooltip-text" translatable="yes">A short, user-friendly title for the User-Agent (e.g., 'My Custom Bot')</property>

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -1,7 +1,7 @@
 """Module for fetching HTTP headers and processing responses."""
 
 import logging
-from typing import Optional, Dict, List, Any  # Use dict, list
+from typing import Optional, Dict, List, Any
 
 import requests
 import requests.utils  # For urlparse, urlunparse
@@ -127,8 +127,6 @@ class HttpFetcher:
         """
         Prepare initial request-specific headers and session-wide headers.
 
-        Moved from ``HttpPage``.
-
         :return: A tuple containing two dictionaries:
                  - ``initial_request_specific_headers``: Headers for the first request only.
                  - ``session_headers``: Headers to apply to the :class:`requests.Session`.
@@ -169,8 +167,6 @@ class HttpFetcher:
         """
         Execute the HTTP GET request using the configured session.
 
-        Moved from ``HttpPage``.
-
         :param initial_request_headers: Headers to send with the initial request.
         :type initial_request_headers: dict[str, str]
         :raises .HttpRequestTimeoutError: If the request times out.
@@ -207,8 +203,6 @@ class HttpFetcher:
     def _process_http_response(self, response: requests.Response) -> List[Dict[str, Any]]:
         """
         Process the HTTP response, including redirects.
-
-        Moved from ``HttpPage``.
 
         :param response: The final :class:`requests.Response` object.
         :type response: requests.Response
@@ -249,8 +243,6 @@ class HttpFetcher:
     def _get_detailed_connection_error_message(self, exc: Exception, url: str) -> Optional[str]:
         """
         Attempt to find a 'Connection Refused' error within a chain of exceptions.
-
-        Moved from ``HttpPage``.
 
         :param exc: The initial exception object.
         :type exc: Exception
@@ -333,8 +325,6 @@ class HttpFetcher:
     def _format_http_error(self, e: requests.exceptions.HTTPError) -> str:
         """
         Format an :exc:`requests.exceptions.HTTPError` into a user-friendly string.
-
-        Moved from ``HttpPage``.
 
         :param e: The :exc:`requests.exceptions.HTTPError` object.
         :type e: requests.exceptions.HTTPError

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -18,7 +18,8 @@ gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk, Pango
 
-from .constants import RESOURCE_PREFIX, USER_AGENTS, APP_ID
+from .constants import RESOURCE_PREFIX, APP_ID # USER_AGENTS removed
+from .preferences import STANDARD_USER_AGENTS # Import from preferences
 from .utils import show_global_error, show_global_toast, is_valid_url
 from .helper import Helper
 from .http_client import (
@@ -374,10 +375,48 @@ class HttpPage(Adw.PreferencesPage):
 
         host_header = self.http_host_header_row.get_text().strip()
         user_agent_to_send: Optional[str] = None
-        selected_title_obj = self.http_user_agent_row.get_selected_item()
-        if isinstance(selected_title_obj, Gtk.StringObject):
-            selected_title = selected_title_obj.get_string()
-            user_agent_to_send = self._ua_title_to_value_map.get(selected_title)
+        # Determine the User-Agent string to send
+        # Priority: 1. UI override, 2. GSettings default, 3. Fallback
+
+        # 1. Check UI override from http_user_agent_row
+        selected_title_obj_ui = self.http_user_agent_row.get_selected_item()
+        ui_selected_ua_title: Optional[str] = None
+        if isinstance(selected_title_obj_ui, Gtk.StringObject):
+            ui_selected_ua_title = selected_title_obj_ui.get_string()
+
+        if ui_selected_ua_title and ui_selected_ua_title != "None": # "None" means use default logic
+            user_agent_to_send = self._ua_title_to_value_map.get(ui_selected_ua_title)
+            logger.debug(f"Using User-Agent from UI selection: '{ui_selected_ua_title}' -> '{user_agent_to_send}'")
+        else:
+            # 2. No UI override or "None" selected, so use GSettings default
+            default_ua_title_pref = self.settings.get_string("default-user-agent-title")
+            logger.debug(f"UI override not used or 'None'. GSettings default-user-agent-title: '{default_ua_title_pref}'")
+
+            if default_ua_title_pref:
+                # Try to find it in standard UAs
+                for std_title, std_value in STANDARD_USER_AGENTS:
+                    if std_title == default_ua_title_pref:
+                        user_agent_to_send = std_value
+                        break
+                # If not in standard, try custom UAs (already populated in self._ua_title_to_value_map)
+                if user_agent_to_send is None and default_ua_title_pref in self._ua_title_to_value_map:
+                    user_agent_to_send = self._ua_title_to_value_map[default_ua_title_pref]
+
+                if user_agent_to_send:
+                    logger.info(f"Using default User-Agent from GSettings: '{default_ua_title_pref}' -> '{user_agent_to_send}'")
+                else:
+                    logger.warning(f"Default User-Agent title '{default_ua_title_pref}' from GSettings not found. Falling back.")
+
+            # 3. Fallback if GSettings default is not set, not found, or "None" was chosen in UI and GSettings is empty
+            if user_agent_to_send is None:
+                # Sensible fallback: first standard UA or a generic one
+                if STANDARD_USER_AGENTS:
+                    user_agent_to_send = STANDARD_USER_AGENTS[0][1] # Value of the first standard UA
+                    logger.info(f"Fell back to first standard User-Agent: '{STANDARD_USER_AGENTS[0][0]}'")
+                else: # Absolute fallback if STANDARD_USER_AGENTS is somehow empty
+                    user_agent_to_send = f"Woes/{APP_ID} (Fallback)"
+                    logger.info(f"Fell back to generic Woes User-Agent: '{user_agent_to_send}'")
+
         custom_dns_server = self.settings.get_string("custom-dns-server")
 
         self._http_task_data_for_thread = {
@@ -856,15 +895,18 @@ class HttpPage(Adw.PreferencesPage):
 
         display_titles: list[str] = []
 
-        none_title = "None"
+        none_title = "None" # Represents using the default resolution logic (GSettings -> Fallback)
         display_titles.append(none_title)
-        self._ua_title_to_value_map[none_title] = None
+        self._ua_title_to_value_map[none_title] = None # Explicitly map "None" to no specific UA string override
 
-        for ua_dict in USER_AGENTS:
-            title, value = ua_dict.get("title"), ua_dict.get("value")
-            if title and value and title not in self._ua_title_to_value_map:
+        # Populate with STANDARD_USER_AGENTS from preferences.py
+        for title, value in STANDARD_USER_AGENTS:
+            if title not in self._ua_title_to_value_map: # Avoid overwriting "None" if a standard UA is named "None"
                 display_titles.append(title)
                 self._ua_title_to_value_map[title] = value
+            else:
+                logger.warning(f"Standard User-Agent title '{title}' conflicts with an existing entry (e.g. 'None' or another standard/custom UA). Skipping.")
+
 
         variant = self.settings.get_value("custom-user-agents")
         custom_ua_pairs: list[tuple[str, str]] = list(
@@ -883,41 +925,23 @@ class HttpPage(Adw.PreferencesPage):
         title_to_select = none_title  # Default to "None" (system UA)
 
         # 1. If there's a current selection in the UI, try to maintain it,
-        #    unless it's no longer a valid choice.
+        #    unless it's no longer a valid choice. If current selection is valid, keep it.
         if current_selection_text and current_selection_text in display_titles:
             title_to_select = current_selection_text
-
-        # 2. If `default_ua_title_pref` from GSettings is a non-empty string,
-        #    it means the user has explicitly saved a preference. Try to apply it.
-        #    An empty string `''` for `default_ua_title_pref` means "System Default" (i.e., "None" option).
-        #    The legacy "[System Default]" string is also treated as "System Default".
-        if default_ua_title_pref and default_ua_title_pref != "[System Default]":
-            if default_ua_title_pref in display_titles:
-                title_to_select = default_ua_title_pref
-                logger.info(
-                    f"HTTP Page: Applying preferred default User-Agent from GSettings: '{default_ua_title_pref}'."
-                )
+            logger.debug(f"Retaining current UI selection for UA ComboBox: '{title_to_select}'")
+        # 2. If no valid current selection, or if current selection is "None", then apply GSettings default.
+        #    An empty string for `default_ua_title_pref` means "use the 'None' option in UI".
+        #    A non-empty `default_ua_title_pref` refers to a specific UA title.
+        elif default_ua_title_pref and default_ua_title_pref in display_titles:
+            title_to_select = default_ua_title_pref
+            logger.info(f"HTTP Page: Applying User-Agent from GSettings: '{default_ua_title_pref}'.")
+        else: # Fallback if GSettings default is not set, or not found in current list
+            title_to_select = none_title # Default to "None"
+            if default_ua_title_pref: # Log if a GSettings default was specified but not found
+                 logger.warning(f"HTTP Page: GSettings User-Agent title '{default_ua_title_pref}' not found. Using '{none_title}'.")
             else:
-                # The preferred default is not in the current list (e.g., was removed from custom UAs).
-                # Fallback to "None" (system default) in this case.
-                title_to_select = none_title
-                logger.warning(
-                    f"HTTP Page: Preferred default User-Agent title '{default_ua_title_pref}' from GSettings not found in available UAs. Falling back to 'None' (System Default)."
-                )
-        elif not default_ua_title_pref or default_ua_title_pref == "[System Default]":
-            # If GSettings stores empty string or the legacy "[System Default]",
-            # ensure "None" (system default) is selected, unless a valid `current_selection_text`
-            # already superseded this (e.g. user just changed it but model is refreshing).
-            # If current_selection_text was valid and different from "None", it takes precedence.
-            if not (
-                current_selection_text
-                and current_selection_text in display_titles
-                and current_selection_text != none_title
-            ):
-                title_to_select = none_title
-            logger.info(
-                f"HTTP Page: User-Agent set to '{title_to_select}' (System Default or retained current selection) as per GSettings preference ('{default_ua_title_pref}')."
-            )
+                 logger.info(f"HTTP Page: No GSettings User-Agent title. Using '{none_title}'.")
+
 
         # Select the determined title
         if title_to_select in display_titles:

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 import re
 from enum import Enum
 from typing import Optional, List, Dict, Any
-import collections.abc  # For Sequence if needed, though not directly used here
+import collections.abc
 import yaml
 
 import gi

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -16,7 +16,7 @@ import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, Dict, List, Optional, TypedDict, Union  # Use dict, list
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 try:
     from gi.repository import Gio

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -61,6 +61,8 @@ class Preferences(Adw.PreferencesWindow):
     :vartype add_custom_ua_button: Gtk.Button
     :ivar custom_ua_list_container: :class:`Gtk.Box` (or similar container) for custom User-Agent list.
     :vartype custom_ua_list_container: Gtk.Widget
+    :ivar user_agent_combo_row: :class:`Adw.ComboRow` for default user agent selection.
+    :vartype user_agent_combo_row: Adw.ComboRow
     :ivar global_output_font_button: :class:`Gtk.FontButton` for global output font.
     :vartype global_output_font_button: Gtk.FontButton
     """
@@ -79,6 +81,7 @@ class Preferences(Adw.PreferencesWindow):
     http_special_row_color_button: Gtk.ColorDialogButton = Gtk.Template.Child("http_special_row_color_button")  # type: ignore
 
     # Custom User Agent UI
+    user_agent_combo_row: Adw.ComboRow = Gtk.Template.Child("user_agent_combo_row")  # type: ignore
     new_custom_ua_title_entry: Gtk.Entry = Gtk.Template.Child("new_custom_ua_title_entry")  # type: ignore
     new_custom_ua_value_entry: Gtk.Entry = Gtk.Template.Child("new_custom_ua_value_entry")  # type: ignore
     add_custom_ua_button: Gtk.Button = Gtk.Template.Child("add_custom_ua_button")  # type: ignore
@@ -186,6 +189,9 @@ class Preferences(Adw.PreferencesWindow):
         # Global Font Preference Signal
         if self.global_output_font_button:
             self.global_output_font_button.connect("font-set", self.on_global_font_setting_changed)
+
+        if self.user_agent_combo_row:
+            self.user_agent_combo_row.connect("notify::selected-item", self._on_default_user_agent_changed)
 
     def on_global_font_setting_changed(self, font_button: Gtk.FontButton):
         """
@@ -425,6 +431,8 @@ class Preferences(Adw.PreferencesWindow):
             row.set_activatable_widget(remove_button)  # type: ignore[no-untyped-call]
             self.custom_ua_list_container.append(row)  # type: ignore[union-attr]
 
+        self._populate_user_agent_combo_row() # Keep dropdown in sync
+
     def _on_add_custom_ua_clicked(self, _widget: Gtk.Widget) -> None:
         """
         Handle the 'Add User Agent' button click or :class:`Gtk.Entry` activation.
@@ -483,7 +491,7 @@ class Preferences(Adw.PreferencesWindow):
                 self.new_custom_ua_title_entry.set_text("")  # type: ignore[union-attr]
             if self.new_custom_ua_value_entry:
                 self.new_custom_ua_value_entry.set_text("")  # type: ignore[union-attr]
-            self._render_custom_ua_list()
+            # self._render_custom_ua_list() is called by GSettings "changed::custom-user-agents" signal
         else:
             logging.error(f"Failed to save custom User-Agent list to GSettings with new UA: {title_text}")
 
@@ -509,7 +517,7 @@ class Preferences(Adw.PreferencesWindow):
             new_variant = GLib.Variant("a(ss)", updated_ua_pairs)
             if self.settings.set_value("custom-user-agents", new_variant):
                 logging.info(f"Removed custom User-Agent with title: {title_to_remove}")
-                self._render_custom_ua_list()
+                # self._render_custom_ua_list() is called by GSettings "changed::custom-user-agents" signal
             else:
                 logging.error(f"Failed to save custom User-Agent list after removing title: {title_to_remove}")
         else:
@@ -571,7 +579,30 @@ class Preferences(Adw.PreferencesWindow):
         if self.http_special_row_color_button:
             self._load_color_button_preference(self.http_special_row_color_button, "http-output-special-row-color")  # type: ignore[arg-type]
 
+        # Call to _render_custom_ua_list also calls _populate_user_agent_combo_row
+        # which handles loading and setting the default user agent.
         self._render_custom_ua_list()
+
+        # Explicitly load and set the default user agent after populating the combo row.
+        # _populate_user_agent_combo_row will attempt to set a default, but this ensures
+        # the GSettings value is authoritative if it exists and is valid at startup.
+        default_ua_title = self.settings.get_string("default-user-agent-title")
+        if default_ua_title:
+            if not self._select_combo_row_item(self.user_agent_combo_row, default_ua_title):  # type: ignore[arg-type]
+                logging.warning(f"Saved default UA title '{default_ua_title}' not found in combo. Selecting first if available.")
+                if self.user_agent_combo_row and self.user_agent_combo_row.get_model() and self.user_agent_combo_row.get_model().get_n_items() > 0:  # type: ignore[union-attr, attr-defined]
+                    self.user_agent_combo_row.set_selected(0)  # type: ignore[union-attr]
+                    first_item = self.user_agent_combo_row.get_model().get_string(0) # type: ignore[union-attr, attr-defined]
+                    if first_item: # Update GSetting if the saved one was invalid and we selected the first one
+                         self.settings.set_string("default-user-agent-title", first_item)
+                else: # No items, clear GSetting
+                    self.settings.set_string("default-user-agent-title", "")
+        elif self.user_agent_combo_row and self.user_agent_combo_row.get_model() and self.user_agent_combo_row.get_model().get_n_items() > 0: # type: ignore[union-attr, attr-defined]
+             # No default saved, select first and save it
+            self.user_agent_combo_row.set_selected(0) # type: ignore[union-attr]
+            first_item_title = self.user_agent_combo_row.get_model().get_string(0) # type: ignore[union-attr, attr-defined]
+            if first_item_title:
+                self.settings.set_string("default-user-agent-title", first_item_title)
 
         output_font_str = self.settings.get_string("output-font")
         if self.global_output_font_button:
@@ -582,3 +613,88 @@ class Preferences(Adw.PreferencesWindow):
                 self.global_output_font_button.set_font(default_font)  # type: ignore[union-attr]
                 self.settings.set_string("output-font", default_font)
                 logging.warning(f"GSettings 'output-font' was empty, set to default: {default_font}")
+
+    def _populate_user_agent_combo_row(self):
+        """
+        Populate the 'user_agent_combo_row' with standard and custom user agents.
+        """
+        if not self.user_agent_combo_row:
+            logging.warning("user_agent_combo_row not found, cannot populate.")
+            return
+
+        current_selection_title = None
+        selected_item = self.user_agent_combo_row.get_selected_item()
+        if selected_item:
+             if isinstance(selected_item, Gtk.StringObject):
+                current_selection_title = selected_item.get_string()
+
+
+        model = Gtk.StringList()
+        all_ua_titles = []
+
+        # Add standard user agents
+        for title, _value in STANDARD_USER_AGENTS:
+            model.append(title)
+            all_ua_titles.append(title)
+
+        # Add custom user agents
+        variant = self.settings.get_value("custom-user-agents")
+        custom_ua_pairs: list[tuple[str, str]] = list(
+            variant.unpack() if variant and variant.get_type_string() == "a(ss)" else []
+        )
+
+        for title, _value in custom_ua_pairs:
+            if title not in all_ua_titles:
+                model.append(title)
+                all_ua_titles.append(title)
+            else:
+                logging.warning(f"Custom UA title '{title}' conflicts with a standard or another custom UA title. Skipping.")
+
+
+        self.user_agent_combo_row.set_model(model)
+
+        # Attempt to restore previous selection
+        if current_selection_title and current_selection_title in all_ua_titles:
+            if self._select_combo_row_item(self.user_agent_combo_row, current_selection_title):
+                logging.debug(f"Restored selection in UA combo: {current_selection_title}")
+                return
+
+        # If not restored, try GSettings default
+        default_ua_title_gsetting = self.settings.get_string("default-user-agent-title")
+        if default_ua_title_gsetting and default_ua_title_gsetting in all_ua_titles:
+            if self._select_combo_row_item(self.user_agent_combo_row, default_ua_title_gsetting):
+                logging.debug(f"Selected default UA from GSettings: {default_ua_title_gsetting}")
+                return
+
+        # Fallback: select the first item if available and no other selection was made
+        if model.get_n_items() > 0:
+            self.user_agent_combo_row.set_selected(0)
+            first_item_title = model.get_string(0)
+            logging.debug(f"No previous/GSettings default UA, selected first available: {first_item_title}")
+
+            if first_item_title and (not default_ua_title_gsetting or default_ua_title_gsetting not in all_ua_titles) :
+                 self.settings.set_string("default-user-agent-title", first_item_title)
+        else:
+            logging.warning("No user agents available to select in user_agent_combo_row.")
+            if default_ua_title_gsetting:
+                 self.settings.set_string("default-user-agent-title", "")
+
+
+    def _on_default_user_agent_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
+        """
+        Handle changes in the default user agent selection.
+        Saves the selected user agent *title* to GSettings.
+        """
+        selected_item_obj = combo_row.get_selected_item()
+        if isinstance(selected_item_obj, Gtk.StringObject):
+            selected_ua_title = selected_item_obj.get_string()
+            if selected_ua_title:
+                current_gsettings_val = self.settings.get_string("default-user-agent-title")
+                if selected_ua_title != current_gsettings_val:
+                    self.settings.set_string("default-user-agent-title", selected_ua_title)
+                    logging.debug(f"Default user agent title set to GSettings: {selected_ua_title}")
+        elif selected_item_obj is None and combo_row.get_model() is not None and combo_row.get_model().get_n_items() == 0: # type: ignore[attr-defined]
+            current_gsettings_val = self.settings.get_string("default-user-agent-title")
+            if current_gsettings_val != "":
+                self.settings.set_string("default-user-agent-title", "")
+                logging.debug("Default user agent selection cleared as list is empty.")

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -79,7 +79,7 @@ class WebScanPage(Adw.PreferencesPage):
 
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
-        self.current_nikto_process: Optional[subprocess.Popen[str]] = None  # Added Popen type hint
+        self.current_nikto_process: Optional[subprocess.Popen[str]] = None
         self._current_webscan_params: Optional[dict[str, Any]] = None
         self.settings: Gio.Settings = Gio.Settings.new(APP_ID)
         self.style_manager: Adw.StyleManager = Adw.StyleManager.get_default()


### PR DESCRIPTION
- **Preferences:**
    - It restores your ability to select a default User-Agent string in Preferences.
    - It adds a "Default User Agent" `Adw.ComboRow` to the Custom User Agents section.
    - The `HttpPage` will now use this default User-Agent if you haven't selected a specific one for a request.
    - Preferences are now grouped into "Appearance", "Output Font Settings", "Tool settings", "HTTP Output Colours", and "Custom User Agents".

- **Flatpak Build:**
    - The `build-flatpak.py` script will now use the existing `com.github.mclellac.woes.json` manifest file instead of generating its own.
    - The script will now use the correct App ID: `com.github.mclellac.woes`.

- **Comments:**
    - It removes unnecessary "meta comments" from various Python files.
    - It ensures docstrings and comments are formatted according to reStructuredText conventions.