### PR TITLE
Fix: Correct USER_AGENTS dictionary access

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -384,9 +384,9 @@ class HttpPage(Adw.PreferencesPage):
             # User selected a specific UA in the HTTP page dropdown
             ua_found = False
             # Check in USER_AGENTS
-            for def_title, def_value in USER_AGENTS:
-                if def_title == selected_ua_title_in_http_page_dropdown:
-                    user_agent_to_send = def_value
+            for ua_dict in USER_AGENTS:
+                if ua_dict['title'] == selected_ua_title_in_http_page_dropdown:
+                    user_agent_to_send = ua_dict['value']
                     ua_found = True
                     break
             # If not in default, check custom (self._ua_title_to_value_map includes custom ones)
@@ -403,8 +403,8 @@ class HttpPage(Adw.PreferencesPage):
                     f"Selected UA title '{selected_ua_title_in_http_page_dropdown}' not found in any list. Falling back."
                 )
                 if USER_AGENTS:
-                    user_agent_to_send = USER_AGENTS[0][1]
-                    logger.info(f"Fell back to first default User-Agent: {USER_AGENTS[0][0]}")
+                    user_agent_to_send = USER_AGENTS[0]['value']
+                    logger.info(f"Fell back to first default User-Agent: {USER_AGENTS[0]['title']}")
                 else:
                     user_agent_to_send = f"Woes/{APP_ID} (Fallback)"
                     logger.info(f"Fell back to generic Woes User-Agent: {user_agent_to_send}")
@@ -417,9 +417,9 @@ class HttpPage(Adw.PreferencesPage):
             if default_ua_title_from_prefs:
                 ua_found_in_prefs = False
                 # Check in USER_AGENTS
-                for def_title, def_value in USER_AGENTS:
-                    if def_title == default_ua_title_from_prefs:
-                        user_agent_to_send = def_value
+                for ua_dict in USER_AGENTS:
+                    if ua_dict['title'] == default_ua_title_from_prefs:
+                        user_agent_to_send = ua_dict['value']
                         ua_found_in_prefs = True
                         break
                 # If not in default, check custom (self._ua_title_to_value_map includes custom ones)
@@ -446,8 +446,8 @@ class HttpPage(Adw.PreferencesPage):
 
             if user_agent_to_send is None:  # Fallback if GSettings default is empty or not found
                 if USER_AGENTS:
-                    user_agent_to_send = USER_AGENTS[0][1]
-                    logger.info(f"Fell back to first default User-Agent: {USER_AGENTS[0][0]}")
+                    user_agent_to_send = USER_AGENTS[0]['value']
+                    logger.info(f"Fell back to first default User-Agent: {USER_AGENTS[0]['title']}")
                 else:
                     user_agent_to_send = f"Woes/{APP_ID} (Fallback)"
                     logger.info(f"Fell back to generic Woes User-Agent: {user_agent_to_send}")
@@ -936,11 +936,13 @@ class HttpPage(Adw.PreferencesPage):
         self._ua_title_to_value_map[none_title] = None  # Explicitly map "None" to no specific UA string override
 
         # Populate with USER_AGENTS from constants.py
-        for title, value in USER_AGENTS:  # Iterate list of tuples
+        for ua_dict in USER_AGENTS:  # Iterate list of dictionaries
+            title = ua_dict['title']
+            value = ua_dict['value']
             if title not in self._ua_title_to_value_map:
                 display_titles.append(title)
                 self._ua_title_to_value_map[title] = value
-            else:  # Should not happen if titles are unique in USER_AGENTS
+            else:
                 logger.warning(
                     f"Default User-Agent title '{title}' conflicts with 'None' or another default UA. Skipping."
                 )

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -475,7 +475,7 @@ class Preferences(Adw.PreferencesWindow):
         )  # type: ignore[union-attr]
 
         # Check for duplicate titles (Default UAs + Custom UAs)
-        all_existing_titles = [pair[0] for pair in USER_AGENTS] + [pair[0] for pair in current_ua_pairs]
+        all_existing_titles = [ua_dict['title'] for ua_dict in USER_AGENTS] + [pair[0] for pair in current_ua_pairs]
         if title_text in all_existing_titles:
             logging.info(f"Custom User-Agent title '{title_text}' already exists or conflicts with a default UA.")
             if self.new_custom_ua_title_entry:
@@ -644,8 +644,10 @@ class Preferences(Adw.PreferencesWindow):
         all_ua_titles.append(NONE_OPTION_TITLE)
 
         # 2. Add standard user agents from constants.py
-        for title, _value in USER_AGENTS:
-            if title not in all_ua_titles: # Avoid duplicates if any standard UA has same title as NONE_OPTION_TITLE
+        for ua_dict in USER_AGENTS:
+            title = ua_dict['title']
+            # _value = ua_dict['value'] # Not strictly needed here if only title is used
+            if title not in all_ua_titles: # Avoid duplicates
                 model.append(title)
                 all_ua_titles.append(title)
             else:


### PR DESCRIPTION
This commit addresses a regression where User-Agent titles were incorrectly processed, leading to warnings and non-functional User-Agent selection. The issue was caused by attempting to unpack dictionary keys from the USER_AGENTS list (a list of dicts) as if they were tuple elements.

The following changes have been made:
- Modified src/http_page.py in methods _on_entry_row_activated and _update_user_agent_model to correctly access User-Agent titles and values using dictionary key lookups (e.g., ua_dict['title'], ua_dict['value']).
- Modified src/preferences.py in methods _on_add_custom_ua_clicked and _populate_user_agent_combo_row to use the same correct dictionary key access for User-Agent data.

These changes ensure that predefined User-Agents are loaded and processed correctly throughout the application, resolving the "title conflicts" warnings and restoring User-Agent functionality.