### PR TITLE
Fix: Resolve Gtk template error by correcting page base classes

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -31,7 +31,7 @@ gi.require_version("Gtk", "4.0")
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/dns_page.ui")
-class DNSPage(Adw.PreferencesPage):
+class DNSPage(Gtk.Box):
     """
     Activity page for performing DNS lookups and displaying results.
 
@@ -58,7 +58,7 @@ class DNSPage(Adw.PreferencesPage):
 
         Sets up UI elements, connects signals, and initializes GSettings.
 
-        :param kwargs: Keyword arguments passed to the :class:`Adw.PreferencesPage` constructor.
+        :param kwargs: Keyword arguments passed to the :class:`Gtk.Box` constructor.
         :type kwargs: GObject.GObject
         """
         super().__init__(**kwargs)

--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -4,9 +4,7 @@
   <!-- interface-name dns_page.ui -->
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>
-  <template class="DNSPage" parent="AdwPreferencesPage">
-    <property name="icon-name">org.gnome.Epiphany-symbolic</property>
-    <property name="title" translatable="yes">DNS Lookup</property>
+  <template class="DNSPage" parent="GtkBox">
     <property name="width-request">1000</property>
     <child>
       <object class="AdwPreferencesGroup">

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -4,9 +4,7 @@
   <!-- interface-name http_page.ui -->
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>
-  <template class="HttpPage" parent="AdwPreferencesPage">
-    <property name="icon-name">network-transmit-receive-symbolic</property>
-    <property name="title" translatable="yes">HTTP Headers</property>
+  <template class="HttpPage" parent="GtkBox">
     <property name="width-request">800</property>
     <child>
       <object class="AdwPreferencesGroup" id="http_request_group">

--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -4,7 +4,7 @@
   <!-- interface-name nmap_page.ui -->
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>
-  <template class="NmapPage" parent="AdwPreferencesPage">
+  <template class="NmapPage" parent="GtkBox">
     <property name="height-request">600</property>
     <property name="width-request">700</property>
     <child>

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -5,9 +5,8 @@
   <requires lib="GtkSource" version="5.0"/>
   <requires lib="gtk" version="4.0"/>
   <requires lib="libadwaita" version="1.0"/>
-  <template class="WebScanPage" parent="AdwPreferencesPage">
+  <template class="WebScanPage" parent="GtkBox">
     <property name="hexpand">True</property>
-    <property name="title">Web Scan</property>
     <child>
       <object class="AdwPreferencesGroup">
         <property name="description" translatable="yes">Enter a URL to scan for common web vulnerabilities using Nikto.</property>

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -83,7 +83,7 @@ class HeaderItem(GObject.Object):
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/http_page.ui")
-class HttpPage(Adw.PreferencesPage):
+class HttpPage(Gtk.Box):
     """
     Activity page for fetching and inspecting HTTP headers.
 
@@ -135,7 +135,7 @@ class HttpPage(Adw.PreferencesPage):
         Initializes UI elements, GSettings, the header list store for the
         column view, and connects signals.
 
-        :param kwargs: Keyword arguments passed to the :class:`Adw.PreferencesPage` constructor.
+        :param kwargs: Keyword arguments passed to the :class:`Gtk.Box` constructor.
         :type kwargs: Any
         """
         super().__init__(**kwargs)

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -70,7 +70,7 @@ class NmapTargetRow(Gtk.ListBoxRow):
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/nmap_page.ui")
-class NmapPage(Adw.PreferencesPage):
+class NmapPage(Gtk.Box):
     """Activity page for performing Nmap scans and viewing results."""
 
     __gtype_name__ = "NmapPage"
@@ -95,7 +95,7 @@ class NmapPage(Adw.PreferencesPage):
         """
         Initialize the NmapPage.
 
-        :param kwargs: Keyword arguments passed to the :class:`Adw.PreferencesPage` constructor.
+        :param kwargs: Keyword arguments passed to the :class:`Gtk.Box` constructor.
         :type kwargs: Any
         """
         super().__init__(**kwargs)

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -26,7 +26,7 @@ gi.require_version("Adw", "1")
 
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/webscan_page.ui")
-class WebScanPage(Adw.PreferencesPage):
+class WebScanPage(Gtk.Box):
     """Page for conducting web scans using Nikto, displaying results and errors."""
 
     __gtype_name__ = "WebScanPage"


### PR DESCRIPTION
Resolves a Gtk-CRITICAL error "Invalid object type 'PageName'" that occurred during WoesWindow template instantiation. The error was caused by application pages (HttpPage, NmapPage, DNSPage, WebScanPage) incorrectly inheriting from Adw.PreferencesPage while being used as general content views within the main application window's Adw.ViewStack.

Adw.PreferencesPage is intended for use within an Adw.PreferencesWindow.

The following changes have been made:
- The base class for HttpPage, NmapPage, DNSPage, and WebScanPage in their respective Python files has been changed from Adw.PreferencesPage to Gtk.Box.
- The corresponding UI template files (.ui) for these pages have been updated to set parent="GtkBox" for the <template> tag and remove properties not applicable to Gtk.Box (like icon-name and title, which are managed by the Adw.ViewStackPage in window.ui).

This architectural correction ensures pages are compatible with their usage in the main window's view stack, allowing the application to start and load pages correctly.