### PR TITLE
Fix: Attempt to resolve GType registration for pages

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -31,6 +31,12 @@ from . import nmap_page
 from . import dns_page
 from . import webscan_page
 
+# Explicitly reference types to potentially aid GType registration
+_ = http_page.HttpPage
+_ = nmap_page.NmapPage
+_ = dns_page.DNSPage
+_ = webscan_page.WebScanPage
+
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/window.ui")
 class WoesWindow(Adw.ApplicationWindow):
     """


### PR DESCRIPTION
This commit introduces explicit type referencing for HttpPage, NmapPage, DNSPage, and WebScanPage within src/window.py before the WoesWindow class definition.

This is a defensive measure aimed at ensuring these custom widget types are fully processed and registered with the GObject type system before the WoesWindow UI template (window.ui) is parsed by Gtk.Builder. This attempts to resolve a persistent "Gtk-CRITICAL: Invalid object type" error that occurred during WoesWindow instantiation, even after correcting page base classes and UI template parentage.

If this change resolves the issue, it suggests a subtle interaction with the GObject type system or module loading order that required this explicit reference.