### PR TITLE
Fix: Remove incorrect explicit type references from window.py

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -31,12 +31,6 @@ from . import nmap_page
 from . import dns_page
 from . import webscan_page
 
-# Explicitly reference types to potentially aid GType registration
-_ = http_page.HttpPage
-_ = nmap_page.NmapPage
-_ = dns_page.DNSPage
-_ = webscan_page.WebScanPage
-
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/window.ui")
 class WoesWindow(Adw.ApplicationWindow):
     """


### PR DESCRIPTION
Reverts a previous change that attempted to explicitly reference page class types (e.g., http_page.HttpPage) in src/window.py. This change was causing a `NameError: name 'http_page' is not defined` because the module names were not directly in scope.

Removing these lines resolves the NameError.

Note: This commit only fixes the NameError. The underlying Gtk-CRITICAL error "Invalid object type 'HttpPage'" encountered earlier is likely to persist. Further investigation into the build system, GResource compilation, or environment-specific GObject type registration may be needed to resolve that issue.