### PR TITLE
Fix: Resolve 'Invalid object type HttpPage' error on startup

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -53,6 +53,7 @@ class DNSPage(Gtk.Box):
     dns_status_spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: GObject.GObject):
+        logging.debug("DNSPage.__init__ called")
         """
         Initialize the DNSPage.
 

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -129,6 +129,7 @@ class HttpPage(Gtk.Box):
     http_status_spinner: Gtk.Spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: Any):
+        logging.debug("HttpPage.__init__ called")
         """
         Initialize the HttpPage.
 

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -91,6 +91,7 @@ class NmapPage(Gtk.Box):
     nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
 
     def __init__(self, **kwargs: Any):
+        logging.debug("NmapPage.__init__ called")
         """
         Initialize the NmapPage.
 

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -54,6 +54,7 @@ class WebScanPage(Gtk.Box):
     auth_bypass_switch: Adw.SwitchRow = Gtk.Template.Child()
 
     def __init__(self, **kwargs: Any):
+        logging.debug("WebScanPage.__init__ called")
         """
         Initialize the WebScanPage.
 

--- a/src/window.py
+++ b/src/window.py
@@ -25,6 +25,13 @@ from .style_utils import apply_font_size, apply_theme
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 
+from .http_page import HttpPage
+from .nmap_page import NmapPage
+from .dns_page import DNSPage
+from .webscan_page import WebScanPage
+
+logging.debug("Custom page widgets (HttpPage, NmapPage, DNSPage, WebScanPage) imported into window.py")
+
 # Imports for custom page widgets
 
 @Gtk.Template(resource_path=f"{RESOURCE_PREFIX}/window.ui")
@@ -54,6 +61,7 @@ class WoesWindow(Adw.ApplicationWindow):
     toast_overlay: Adw.ToastOverlay = Gtk.Template.Child("toast_overlay")
 
     def __init__(self, **kwargs: Any):  # GObject.GObject is too restrictive if no args passed
+        logging.debug("WoesWindow.__init__ called")
         """
         Initialize the WoesWindow.
 


### PR DESCRIPTION
The error "Error building template class 'WoesWindow' for an instance of type 'WoesWindow': .:0:0 Invalid object type 'HttpPage'" was caused by the Gtk.Template system attempting to instantiate `HttpPage` (and similar custom widgets like `NmapPage`, `DNSPage`, `WebScanPage`) from the `window.ui` definition before these Python classes were known to the Gtk type system.

This commit fixes the issue by importing `HttpPage`, `NmapPage`, `DNSPage`, and `WebScanPage` into `src/window.py` before the `WoesWindow` class definition. This ensures that these types are registered with GObject before `WoesWindow` (which uses them in its UI template) is instantiated.

Additionally, this commit adds debug logging messages to:
- `src/window.py`: To confirm the import of page widgets and the initialization of `WoesWindow`.
- `src/http_page.py`, `src/nmap_page.py`, `src/dns_page.py`, `src/webscan_page.py`: To trace the initialization of each page class.

These changes ensure the application starts correctly and provide additional diagnostic information when running with the `--debug` flag, addressing the issues you reported. The secondary warning "switcher_title or stack not found during setup_ui" is also resolved as a consequence of the template now loading correctly.