### PR TITLE
Fix: Set main page containers to vertical orientation

### DIFF
--- a/src/gtk/dns_page.ui
+++ b/src/gtk/dns_page.ui
@@ -5,6 +5,7 @@
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>
   <template class="DNSPage" parent="GtkBox">
+    <property name="orientation">vertical</property>
     <property name="width-request">1000</property>
     <child>
       <object class="AdwPreferencesGroup">

--- a/src/gtk/http_page.ui
+++ b/src/gtk/http_page.ui
@@ -5,6 +5,7 @@
   <requires lib="gtk" version="4.18"/>
   <requires lib="libadwaita" version="1.7"/>
   <template class="HttpPage" parent="GtkBox">
+    <property name="orientation">vertical</property>
     <property name="width-request">800</property>
     <child>
       <object class="AdwPreferencesGroup" id="http_request_group">

--- a/src/gtk/webscan_page.ui
+++ b/src/gtk/webscan_page.ui
@@ -6,6 +6,7 @@
   <requires lib="gtk" version="4.0"/>
   <requires lib="libadwaita" version="1.0"/>
   <template class="WebScanPage" parent="GtkBox">
+    <property name="orientation">vertical</property>
     <property name="hexpand">True</property>
     <child>
       <object class="AdwPreferencesGroup">


### PR DESCRIPTION
The DNS, HTTP, and WebScan pages were displaying their input/action groups and result groups side-by-side (horizontally). This caused the pages to be too wide and could lead to widget overlapping when the window was resized.

This change explicitly sets the `orientation` property of the root GtkBox in each of these three page UI definition files (`dns_page.ui`, `http_page.ui`, `webscan_page.ui`) to `vertical`.

This ensures that the result group is displayed below the input/action group, adhering to GNOME HIG and preventing the described layout issues.