### PR TITLE
Fix: Address font rendering, HTTP copy, and EntryRow warning

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -1,10 +1,13 @@
 """Provides a Helper class for :class:`Gtk.ColumnView` context menus and keyboard shortcuts."""
 
+import logging
 from typing import Optional
 from gi.repository import Gdk, Gtk, GObject
 import gi
 
 gi.require_version("Gtk", "4.0")
+
+logger = logging.getLogger(__name__)
 
 
 class Helper:
@@ -110,18 +113,23 @@ class Helper:
 
         :return: None
         """
+        logger.debug("copy_context_item_to_clipboard called.")
         if (
             not isinstance(self.widget, Gtk.ColumnView)
             or not hasattr(self, "last_right_click_coords")
             or self.last_right_click_coords is None
         ):
+            logger.debug("Pre-conditions not met for copy_context_item_to_clipboard (widget type, coords).")
             return
 
         x_coord, y_coord = self.last_right_click_coords
+        logger.debug(f"Coordinates for pick: x={x_coord}, y={y_coord}")
 
         picked_widget = self.widget.pick(x_coord, y_coord, Gtk.PickFlags.DEFAULT)  # type: ignore[no-untyped-call]
+        logger.debug(f"widget.pick result: {picked_widget}")
 
         if picked_widget is None:
+            logger.debug("No widget picked at coordinates.")
             return
 
         target_list_item_widget: Optional[Gtk.ListItem] = None
@@ -132,23 +140,29 @@ class Helper:
                 target_list_item_widget = current_widget
                 break
             if current_widget == self.widget:  # Stop if we've reached the ColumnView itself
+                logger.debug("Reached ColumnView widget while traversing up, Gtk.ListItem not found in path.")
                 break
             current_widget = current_widget.get_parent()
 
         if not target_list_item_widget:
+            logger.debug("Gtk.ListItem widget not found by traversing up from picked_widget.")
             return
+        logger.debug(f"Found target_list_item_widget: {target_list_item_widget}")
 
         item_obj: Optional[GObject.Object] = target_list_item_widget.get_item()
 
         if item_obj is None:
+            logger.debug("item_obj is None from target_list_item_widget.get_item().")
             return
+        logger.debug(f"Got item_obj: {item_obj}, type: {type(item_obj)}")
 
         text_to_copy: str = ""
         try:
-            # Assuming item_obj is HeaderItem-like (has 'key', 'value', 'is_special_row')
+            logger.debug("Attempting to treat item_obj as HeaderItem-like (attributes: key, value, is_special_row).")
             key_attr = getattr(item_obj, "key", None)
             value_attr = getattr(item_obj, "value", None)
             is_special_attr = getattr(item_obj, "is_special_row", False)
+            logger.debug(f"Retrieved attributes: key='{key_attr}', value='{value_attr}', is_special={is_special_attr}")
 
             if is_special_attr:
                 text_to_copy = str(key_attr if key_attr is not None else "")
@@ -161,14 +175,21 @@ class Helper:
                 text_to_copy = f"{str(key_attr if key_attr is not None else '')}: {str(value_attr if value_attr is not None else '')}"
 
             clipboard: Gdk.Clipboard = self.widget.get_clipboard()  # type: ignore[assignment]
+            if not text_to_copy:
+                logger.debug("text_to_copy is empty after attribute processing.")
+            else:
+                logger.debug(f"Constructed text_to_copy: '{text_to_copy}'")
+
+            clipboard: Gdk.Clipboard = self.widget.get_clipboard()  # type: ignore[assignment]
             if clipboard:
                 content_provider = Gdk.ContentProvider.new_for_value(text_to_copy)
                 clipboard.set_content(content_provider)  # type: ignore[no-untyped-call]
+                logger.debug("Successfully set clipboard content.")
+            else:
+                logger.warning("Failed to get clipboard object.")
 
-        except AttributeError:
-            # This might happen if item_obj is not a HeaderItem-like object.
-            # Consider logging this error for debugging if necessary.
-            pass
+        except AttributeError as e:
+            logger.warning(f"AttributeError in copy_context_item_to_clipboard: {e}")
 
     def on_copy_menu_item_activated(self, _button: Gtk.Button) -> None:
         """

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -118,7 +118,13 @@ class NmapPage(Gtk.Box):
         self.nmap_output_textview.set_editable(False)
         self.nmap_output_textview.set_hexpand(True)
         self.nmap_output_textview.set_vexpand(True)
-        self.nmap_output_textview.override_font(self._output_font_desc)
+        # self.nmap_output_textview.override_font(self._output_font_desc) # Replaced by CssProvider
+
+        self.font_css_provider = Gtk.CssProvider()
+        self.nmap_output_textview.get_style_context().add_provider(
+            self.font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+        self._update_font_css() # Initial font application
 
         self.nmap_output_scrolled_window = Gtk.ScrolledWindow()
         self.nmap_output_scrolled_window.set_child(self.nmap_output_textview)
@@ -189,10 +195,28 @@ class NmapPage(Gtk.Box):
             self._output_font_desc = Pango.FontDescription.from_string(
                 output_font_str if output_font_str else "Monospace 10"
             )
-            if hasattr(self, "nmap_output_textview") and self.nmap_output_textview:
-                self.nmap_output_textview.override_font(self._output_font_desc)
-            else:
-                logger.warning("NmapPage: nmap_output_textview not available to apply font change.")
+            # if hasattr(self, "nmap_output_textview") and self.nmap_output_textview: # Replaced by CssProvider
+            #     self.nmap_output_textview.override_font(self._output_font_desc)
+            # else:
+            #     logger.warning("NmapPage: nmap_output_textview not available to apply font change.")
+            self._update_font_css()
+
+    def _update_font_css(self) -> None:
+        """Update the CSS provider with the current font description."""
+        if not hasattr(self, "font_css_provider") or not self.font_css_provider:
+            logger.warning("NmapPage: font_css_provider is not available to update CSS.")
+            return
+        if not hasattr(self, "_output_font_desc") or not self._output_font_desc:
+            logger.warning("NmapPage: _output_font_desc is not available to update CSS.")
+            return
+
+        font_str = self._output_font_desc.to_string()
+        css = f"* {{ font: {font_str}; }}"
+        try:
+            self.font_css_provider.load_from_string(css)
+        except GLib.Error as e: # Catch potential errors from load_from_string
+            logger.error(f"NmapPage: Error loading CSS string '{css}': {e}")
+
 
     def _on_cancel_scan_clicked(self, _button: Gtk.Button) -> None:
         """

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -128,9 +128,6 @@ class Preferences(Adw.PreferencesWindow):
                     "found" if dnspython_available else "not found",
                 )
             else:
-                logging.warning(
-                    "Adw.EntryRow 'dns_server_entryrow' does not have 'set_subtitle' method. Using tooltip fallback."
-                )
                 if not dnspython_available:
                     self.dns_server_entryrow.set_sensitive(False)
                     self.dns_server_entryrow.set_tooltip_text(

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -90,8 +90,16 @@ class WebScanPage(Gtk.Box):
         self._output_font_desc: Pango.FontDescription = Pango.FontDescription.from_string(
             output_font_str if output_font_str else "Monospace 10"
         )
+        # if hasattr(self, "source_view") and self.source_view: # Replaced by CssProvider
+        #     self.source_view.override_font(self._output_font_desc)
+
+        self.font_css_provider = Gtk.CssProvider()
         if hasattr(self, "source_view") and self.source_view:
-            self.source_view.override_font(self._output_font_desc)
+            self.source_view.get_style_context().add_provider(
+                self.font_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
+            )
+        self._update_font_css() # Initial font application
+
 
         if self.scan_button:
             self.scan_button.get_style_context().add_class("suggested-action")
@@ -139,10 +147,27 @@ class WebScanPage(Gtk.Box):
             self._output_font_desc = Pango.FontDescription.from_string(
                 output_font_str if output_font_str else "Monospace 10"
             )
-            if hasattr(self, "source_view") and self.source_view:
-                self.source_view.override_font(self._output_font_desc)
-            else:
-                logger.warning("WebScanPage: source_view not available to apply font change.")
+            # if hasattr(self, "source_view") and self.source_view: # Replaced by CssProvider
+            #     self.source_view.override_font(self._output_font_desc)
+            # else:
+            #     logger.warning("WebScanPage: source_view not available to apply font change.")
+            self._update_font_css()
+
+    def _update_font_css(self) -> None:
+        """Update the CSS provider with the current font description."""
+        if not hasattr(self, "font_css_provider") or not self.font_css_provider:
+            logger.warning("WebScanPage: font_css_provider is not available to update CSS.")
+            return
+        if not hasattr(self, "_output_font_desc") or not self._output_font_desc:
+            logger.warning("WebScanPage: _output_font_desc is not available to update CSS.")
+            return
+
+        font_str = self._output_font_desc.to_string()
+        css = f"* {{ font: {font_str}; }}"
+        try:
+            self.font_css_provider.load_from_string(css)
+        except GLib.Error as e: # Catch potential errors from load_from_string
+            logger.error(f"WebScanPage: Error loading CSS string '{css}': {e}")
 
     def __del__(self):
         """Clean up when the WebScanPage is destroyed."""


### PR DESCRIPTION
This commit resolves several issues based on your feedback:

1.  **Fix Font Application for Nmap & WebScan Results:**
    - Corrected an `AttributeError` in `nmap_page.py` and `webscan_page.py` where `override_font` was incorrectly called on `Gtk.TextView`.
    - Implemented font updates using `Gtk.CssProvider` in both modules. The 'output-font' GSetting is now correctly applied, and the views update dynamically when the font preference changes.

2.  **Diagnose HTTP Page Context Menu Copy:**
    - Added comprehensive logging to the `copy_context_item_to_clipboard` method in `src/helper.py`.
    - This will help identify why the right-click "Copy" action in the HTTP page's results view might be failing.
    - Changed silent `AttributeError` catching to logged warnings.

3.  **Cleanup Adw.EntryRow Subtitle Warning:**
    - Removed a `logging.warning` in `src/preferences.py` related to `Adw.EntryRow` not having a `set_subtitle` method.
    - The code correctly uses `hasattr` to check for this and falls back to using tooltips, so the warning was informational and not indicative of an error.