### PR TITLE
Fix Gtk-WARNINGs related to CSS and font styling.

### DIFF
--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -1,9 +1,9 @@
 /* Margin for GtkSourceView widgets */
 .source-view {
-    margin-top: 10;
-    margin-bottom: 10;
-    margin-left: 10;
-    margin-right: 10;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 10px;
+    margin-right: 10px;
 }
 
 /* HTTP Page Specific Styles */

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -202,7 +202,14 @@ class NmapPage(Gtk.Box):
             self._update_font_css()
 
     def _update_font_css(self) -> None:
-        """Update the CSS provider with the current font description."""
+        """
+        Update the CSS provider with the current font settings.
+
+        This method generates a CSS string to set the ``font-family`` and
+        ``font-size`` for the ``textview#nmap-raw-output-textview`` widget.
+        The font size is converted from Pango units (obtained from
+        ``self._output_font_desc``) to points.
+        """
         if not hasattr(self, "font_css_provider") or not self.font_css_provider:
             logger.warning("NmapPage: font_css_provider is not available to update CSS.")
             return
@@ -210,8 +217,19 @@ class NmapPage(Gtk.Box):
             logger.warning("NmapPage: _output_font_desc is not available to update CSS.")
             return
 
-        font_str = self._output_font_desc.to_string()
-        css = f"textview#nmap-raw-output-textview {{ font: '{font_str}'; }}"
+        font_family = self._output_font_desc.get_family()
+        size_in_pango_units = self._output_font_desc.get_size()
+
+        size_in_points = 0.0
+        if size_in_pango_units > 0 : # Pango.SCALE can be 0, avoid division by zero
+            size_in_points = size_in_pango_units / Pango.SCALE
+        else: # Default to a reasonable size if Pango size is 0 or invalid
+            size_in_points = 10.0
+            logger.warning(f"NmapPage: Pango font size was {size_in_pango_units}, defaulting to {size_in_points}pt.")
+
+        effective_font_family = font_family if font_family else "Monospace"
+
+        css = f"textview#nmap-raw-output-textview {{ font-family: '{effective_font_family}'; font-size: {size_in_points:.1f}pt; }}"
         try:
             self.font_css_provider.load_from_string(css)
         except GLib.Error as e: # Catch potential errors from load_from_string

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -154,7 +154,14 @@ class WebScanPage(Gtk.Box):
             self._update_font_css()
 
     def _update_font_css(self) -> None:
-        """Update the CSS provider with the current font description."""
+        """
+        Update the CSS provider with the current font settings.
+
+        This method generates a CSS string to set the ``font-family`` and
+        ``font-size`` for the ``textview#webscan-output-textview`` widget.
+        The font size is converted from Pango units (obtained from
+        ``self._output_font_desc``) to points.
+        """
         if not hasattr(self, "font_css_provider") or not self.font_css_provider:
             logger.warning("WebScanPage: font_css_provider is not available to update CSS.")
             return
@@ -162,8 +169,19 @@ class WebScanPage(Gtk.Box):
             logger.warning("WebScanPage: _output_font_desc is not available to update CSS.")
             return
 
-        font_str = self._output_font_desc.to_string()
-        css = f"textview#webscan-output-textview {{ font: '{font_str}'; }}"
+        font_family = self._output_font_desc.get_family()
+        size_in_pango_units = self._output_font_desc.get_size()
+
+        size_in_points = 0.0
+        if size_in_pango_units > 0: # Pango.SCALE can be 0, avoid division by zero
+            size_in_points = size_in_pango_units / Pango.SCALE
+        else: # Default to a reasonable size if Pango size is 0 or invalid
+            size_in_points = 10.0
+            logger.warning(f"WebScanPage: Pango font size was {size_in_pango_units}, defaulting to {size_in_points}pt.")
+
+        effective_font_family = font_family if font_family else "Monospace"
+
+        css = f"textview#webscan-output-textview {{ font-family: '{effective_font_family}'; font-size: {size_in_points:.1f}pt; }}"
         try:
             self.font_css_provider.load_from_string(css)
         except GLib.Error as e: # Catch potential errors from load_from_string


### PR DESCRIPTION
This commit addresses Gtk-WARNINGs that persisted or were introduced after the initial fixes:

1.  **Reverted Incorrect Margin Fix in `style.css`:**
    *   The `margin` properties (e.g., `margin-top`) for the
        `.source-view` class in `src/gtk/style.css` were changed
        back to using `px` units (e.g., `margin-top: 10px;`).
        The previous change to unitless numbers was incorrect and
        caused "Unit is missing" warnings.

2.  **Refined Font Styling CSS for Nmap and WebScan Pages:**
    *   Addressed "Expected a number" Gtk-WARNINGs by changing how
        font styles are applied in `src/nmap_page.py` and
        `src/webscan_page.py`.
    *   The `_update_font_css` methods in these files now generate
        CSS that explicitly sets `font-family` and `font-size`
        properties.
    *   Font size is retrieved from `Pango.FontDescription` in Pango
        units and converted to points (`pt`) using `Pango.SCALE`
        for use in the CSS.
    *   The CSS targets the specific TextViews by their IDs
        (`textview#nmap-raw-output-textview` and
        `textview#webscan-output-textview`).
    *   Fallbacks for font family (to "Monospace") and size (to 10.0pt)
        are included for robustness.

3.  **Docstrings Updated:**
    *   Docstrings for the `_update_font_css` methods in
        `nmap_page.py` and `webscan_page.py` were updated to
        reflect these changes.