### PR TITLE
Refactor Preferences window and correct User-Agent default logic.

### DIFF
--- a/data/com.github.mclellac.woes.gschema.xml
+++ b/data/com.github.mclellac.woes.gschema.xml
@@ -31,16 +31,6 @@
       <description>Specifies the custom DNS server IP address to be used for DNS lookups. Leave
         empty to use the system default.</description>
     </key>
-    <key name="custom-http-headers" type="a(sss)">
-      <default>[]</default>
-      <summary>Custom HTTP headers defined by the user</summary>
-      <description>Stores a list of custom HTTP headers. Each header is a triple: (display_title, header_name, header_value).</description>
-    </key>
-    <key name="default-http-header-title" type="s">
-      <default>''</default>
-      <summary>Title of the default HTTP header to be used</summary>
-      <description>Stores the title of the HTTP header selected as default. The actual header name and value are resolved from this title by looking through predefined and custom headers. An empty string means no default header is selected.</description>
-    </key>
     <key name="window-width" type="i">
       <default>900</default>
       <summary>Window Width</summary>

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,7 +3,7 @@ Global constants for the Woes application.
 
 This module defines various global constants used throughout the Woes application,
 including application identifiers, resource paths, theme names, version information,
-URLs, predefined User-Agent strings, and default HTTP header examples.
+URLs, and predefined User-Agent strings.
 """
 
 import os
@@ -140,19 +140,4 @@ USER_AGENTS = [
     {"title": "TimpiBot", "value": "Timpibot/0.8 (+http://www.timpi.io)"},
     {"title": "You.com YouBot", "value": "Mozilla/5.0 (compatible; YouBot (+http://www.you.com))"},
     {"title": "MistralAI User", "value": "Mozilla/5.0 (compatible; MistralAI-User/1.0; +https://mistral.ai/bot)"},
-]
-
-DEFAULT_HTTP_HEADERS = [
-    {
-        "title": "X-Forwarded-For: 127.0.0.1 (Example)",
-        "value": {"X-Forwarded-For": "127.0.0.1"}
-    },
-    {
-        "title": "X-Custom-Header: MyValue (Example)",
-        "value": {"X-Custom-Header": "MyValue"}
-    },
-    {
-        "title": "X-Client-Type: woes-app (Example)",
-        "value": {"X-Client-Type": "woes-app"}
-    }
 ]

--- a/src/gtk/preferences.ui
+++ b/src/gtk/preferences.ui
@@ -8,20 +8,20 @@
     <property name="modal">true</property>
     <property name="title">Preferences</property>
     <child>
-      <object class="AdwPreferencesPage" id="preferences_page">
+      <object class="AdwPreferencesPage" id="appearance_page">
+        <property name="title">Appearance</property>
+        <property name="icon-name">preferences-desktop-theme-symbolic</property>
         <child>
           <object class="AdwBanner" id="preferences_error_banner">
-            <property name="revealed">False</property> <!-- Initially hidden -->
-            <property name="valign">start</property> <!-- Keep it at the top -->
-            <!-- Title/message will be set from code -->
-             <property name="button-label" translatable="yes">Dismiss</property> <!-- Optional: if you want a dismiss button -->
-             <signal name="button-clicked" handler="on_error_banner_dismiss_clicked"/>
+            <property name="revealed">False</property>
+            <property name="valign">start</property>
+            <property name="button-label" translatable="yes">Dismiss</property>
+            <signal name="button-clicked" handler="on_error_banner_dismiss_clicked"/>
           </object>
         </child>
         <child>
           <object class="AdwPreferencesGroup" id="appearance_group">
-            <!-- Removed margin-top to let banner be flush if at top -->
-            <property name="title">Appearance</property>
+            <property name="title">Theme &amp; Font Size</property>
             <child>
               <object class="AdwComboRow" id="theme_combo_row">
                 <property name="title" translatable="yes">Theme</property>
@@ -60,116 +60,28 @@
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup" id="default_http_header_group">
-            <property name="title">Default HTTP Header</property>
-            <child>
-              <object class="AdwComboRow" id="default_http_header_combo_row">
-                <property name="title" translatable="yes">Default HTTP Header</property>
-                <property name="subtitle" translatable="yes">Select a default HTTP header to send with requests in the HTTP Page</property>
-                <!-- Model will be populated from code -->
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwPreferencesGroup" id="custom_http_headers_group">
-            <property name="title" translatable="yes">Custom HTTP Headers</property>
-            <property name="description" translatable="yes">Manage your list of custom HTTP headers for the HTTP Page.</property>
-            <child>
-              <object class="AdwEntryRow" id="new_custom_http_header_title_entry">
-                <property name="title" translatable="yes">Display Title</property>
-                <property name="tooltip-text" translatable="yes">A short, user-friendly title for the custom header set (e.g., 'My API Key')</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="new_custom_http_header_name_entry">
-                <property name="title" translatable="yes">Header Name</property>
-                <property name="tooltip-text" translatable="yes">The name of the HTTP header (e.g., 'Authorization')</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="new_custom_http_header_value_entry">
-                <property name="title" translatable="yes">Header Value</property>
-                <property name="tooltip-text" translatable="yes">The value of the HTTP header (e.g., 'Bearer yourtoken')</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="orientation">horizontal</property>
-                <property name="halign">end</property>
-                <property name="spacing">6</property>
-                <property name="margin-top">6</property>
-                <property name="margin-bottom">6</property>
-                <child>
-                  <object class="GtkButton" id="add_custom_http_header_button">
-                    <property name="label" translatable="yes">Add Custom HTTP Header</property>
-                    <property name="icon-name">list-add-symbolic</property>
-                    <property name="tooltip-text" translatable="yes">Add the new custom HTTP header to the list</property>
-                    <style>
-                      <class name="suggested-action"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="custom_http_header_list_container">
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <!-- Adw.ActionRows or similar representing custom HTTP headers will be added here from code -->
-                <style>
-                  <class name="boxed-list"/>
-                </style>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
           <object class="AdwPreferencesGroup" id="output_font_settings_group">
-            <property name="title" translatable="yes">Output Font Settings</property>
-            <property name="description" translatable="yes">Configure the global font for all tool output text areas.</property>
+            <property name="title" translatable="yes">Global Output Font</property>
+            <property name="description" translatable="yes">Configure the font for all tool output text areas.</property>
             <child>
               <object class="AdwActionRow" id="global_output_font_row">
                 <property name="title" translatable="yes">Output Area Font</property>
-                <property name="subtitle" translatable="yes">Select font family and size for all tool output text areas</property>
+                <property name="subtitle" translatable="yes">Select font family and size</property>
                 <child type="suffix">
                   <object class="GtkFontButton" id="global_output_font_button">
                     <property name="valign">center</property>
                     <property name="use-font">true</property>
-                    <property name="use-size">true</property> <!-- Enable size selection in the dialog -->
-                    <property name="font">Sans 10</property> <!-- Default, will be updated by GSettings -->
+                    <property name="use-size">true</property>
+                    <property name="font">Sans 10</property>
                   </object>
                 </child>
               </object>
             </child>
-          </object>
-        </child>
-        <child>
-          <object class="AdwPreferencesGroup" id="advanced_group">
-            <property name="title">Tool settings</property>
-            <child>
-              <object class="AdwEntryRow" id="dns_server_entryrow">
-                <property name="activates-default">True</property>
-                <property name="title">Custom DNS Server (Optional)</property>
-                <!-- <property name="subtitle">Leave empty to use system default DNS</property> -->
-                <child type="suffix">
-                  <object class="GtkButton" id="prefs_dns_apply_button">
-                    <property name="icon-name">object-select-symbolic</property>
-                    <property name="tooltip-text" translatable="yes">Apply</property>
-                    <property name="valign">center</property>
-                    <style>
-                      <class name="suggested-action"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <!-- Removed empty AdwActionRow -->
           </object>
         </child>
         <child>
           <object class="AdwPreferencesGroup" id="http_colors_group">
-            <property name="title">HTTP Output Colours</property>
+            <property name="title">HTTP Output Colors</property>
             <child>
               <object class="AdwActionRow">
                 <property name="title">Header Key Colour</property>
@@ -202,10 +114,37 @@
             </child>
           </object>
         </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwPreferencesPage" id="behavior_page">
+        <property name="title">Behavior</property>
+        <property name="icon-name">preferences-system-symbolic</property>
         <child>
-          <object class="AdwPreferencesGroup" id="custom_ua_group">
-            <property name="title" translatable="yes">Custom User Agents</property>
-            <property name="description" translatable="yes">Manage your list of custom User-Agent strings for the HTTP Page.</property>
+          <object class="AdwPreferencesGroup" id="network_configuration_group"> <!-- Renamed from advanced_group -->
+            <property name="title">Network Configuration</property> <!-- Renamed title -->
+            <child>
+              <object class="AdwEntryRow" id="dns_server_entryrow">
+                <property name="activates-default">True</property>
+                <property name="title">Custom DNS Server (Optional)</property>
+                <child type="suffix">
+                  <object class="GtkButton" id="prefs_dns_apply_button">
+                    <property name="icon-name">object-select-symbolic</property>
+                    <property name="tooltip-text" translatable="yes">Apply</property>
+                    <property name="valign">center</property>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwPreferencesGroup" id="user_agent_configuration_group"> <!-- Renamed from custom_ua_group -->
+            <property name="title" translatable="yes">User Agent Configuration</property> <!-- Renamed title -->
+            <property name="description" translatable="yes">Manage your list of custom User-Agent strings and select a default for the HTTP Page.</property>
             <child>
               <object class="AdwActionRow" id="default_ua_selection_row">
                 <property name="title" translatable="yes">Default User Agent for HTTP Page</property>
@@ -213,8 +152,7 @@
                 <child type="suffix">
                   <object class="AdwComboRow" id="user_agent_combo_row">
                     <property name="valign">center</property>
-                    <property name="title" translatable="yes">Default User Agent</property> <!-- This title is not directly visible but good for accessibility -->
-                    <!-- The model will be populated from code -->
+                    <property name="title" translatable="yes">Default User Agent</property>
                   </object>
                 </child>
               </object>
@@ -251,13 +189,11 @@
               </object>
             </child>
             <child>
-              <!-- This Gtk.ListBox will act as a container for dynamically added Adw.ActionRows -->
               <object class="GtkListBox" id="custom_ua_list_container">
-                <property name="selection-mode">none</property> <!-- We don't want rows to be selectable -->
+                <property name="selection-mode">none</property>
                 <style>
-                  <class name="boxed-list"/> <!-- Adwaita style for a list of rows -->
+                  <class name="boxed-list"/>
                 </style>
-                <!-- Adw.ActionRows representing custom UAs will be added here from code -->
               </object>
             </child>
           </object>

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -97,7 +97,6 @@ class HttpFetcher:
         host_header: Optional[str] = None,
         user_agent: Optional[str] = None,
         custom_dns_server: Optional[str] = None,
-        additional_headers: Optional[Dict[str, str]] = None,
         cancellable: Optional[Gio.Cancellable] = None,
     ):
         """
@@ -113,9 +112,6 @@ class HttpFetcher:
         :type user_agent: Optional[str]
         :param custom_dns_server: Optional custom DNS server IP. Defaults to ``None``.
         :type custom_dns_server: Optional[str]
-        :param additional_headers: Optional dictionary of additional headers to send with all requests
-                                   in the session. Defaults to ``None``.
-        :type additional_headers: Optional[Dict[str, str]]
         :param cancellable: Optional :class:`Gio.Cancellable` object for cancellation. Defaults to ``None``.
         :type cancellable: Optional[Gio.Cancellable]
         """
@@ -124,7 +120,6 @@ class HttpFetcher:
         self.host_header: Optional[str] = host_header
         self.user_agent: Optional[str] = user_agent
         self.custom_dns_server: Optional[str] = custom_dns_server
-        self.additional_headers: Optional[Dict[str, str]] = additional_headers
         self.cancellable: Optional[Gio.Cancellable] = cancellable
         self.session: requests.Session = requests.Session()
 
@@ -133,12 +128,10 @@ class HttpFetcher:
         Prepare initial request-specific headers and session-wide headers.
 
         The ``session_headers`` are built with the following precedence (later items override earlier):
-        1. `self.additional_headers` (general default headers).
-        2. `self.user_agent` (if provided, overrides 'User-Agent' from additional_headers).
-        3. Akamai Pragma headers (if `self.use_akamai_pragma` is true, overrides 'Pragma').
+        1. `self.user_agent` (if provided).
+        2. Akamai Pragma headers (if `self.use_akamai_pragma` is true, overrides 'Pragma').
 
-        The `self.host_header` is handled separately in ``initial_request_specific_headers``
-        and typically overrides any 'Host' set in session headers for the first request.
+        The `self.host_header` is handled separately in ``initial_request_specific_headers``.
 
         :return: A tuple containing two dictionaries:
                  - ``initial_request_specific_headers``: Headers for the first request only (e.g., Host).
@@ -148,32 +141,20 @@ class HttpFetcher:
         initial_request_specific_headers: dict[str, str] = {}
         session_headers: dict[str, str] = {}
 
-        # Start with additional_headers for the session
-        if self.additional_headers:
-            session_headers.update(self.additional_headers)
-            logger.info(f"HttpFetcher: Applying additional headers: {self.additional_headers}")
-
         # User-Agent override
         if self.user_agent:
-            session_headers["User-Agent"] = self.user_agent # This will override if 'User-Agent' was in additional_headers
+            session_headers["User-Agent"] = self.user_agent
             logger.info("HttpFetcher: Using custom User-Agent: '%s'", self.user_agent)
-        elif "User-Agent" not in session_headers: # Only log if no UA is set at all yet
+        else:
             logger.info("HttpFetcher: No custom User-Agent; `requests` default will be used.")
 
         # Host header is special and often set on the initial request directly
         if self.host_header:
             initial_request_specific_headers["Host"] = self.host_header
             logger.info("HttpFetcher: Using user-provided Host header for initial request: '%s'", self.host_header)
-            # If 'Host' was in additional_headers, it might be in session_headers.
-            # The initial_request_specific_headers usually takes precedence for the *first* request for 'Host'.
-            # For subsequent requests in a session (redirects), session_headers['Host'] would be used if present.
-            # To avoid confusion or requests library warnings, if Host is set for initial, don't also set in session.
-            if 'Host' in session_headers:
-                del session_headers['Host']
-                logger.info("HttpFetcher: Removed 'Host' from session headers as it's set for the initial request specifically.")
 
 
-        # Akamai Pragma headers - these should append or override Pragma from additional_headers
+        # Akamai Pragma headers
         if self.use_akamai_pragma:
             directives = [
                 "akamai-x-get-request-id",

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -18,7 +18,7 @@ gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, Gio, GObject, Gtk, GLib, Gdk, Pango
 
-from .constants import RESOURCE_PREFIX, APP_ID, USER_AGENTS, DEFAULT_HTTP_HEADERS
+from .constants import RESOURCE_PREFIX, APP_ID, USER_AGENTS
 from .utils import show_global_error, show_global_toast, is_valid_url
 from .helper import Helper
 from .http_client import (
@@ -276,10 +276,14 @@ class HttpPage(Gtk.Box):
         self, combo_row: Adw.ComboRow, _gparam: Optional[GObject.ParamSpec]
     ) -> None:
         """
-        Save the selected User-Agent title to GSettings.
+        Handle User-Agent selection changes in the HTTP Page's dropdown.
 
-        This method is connected to the 'notify::selected-item' signal of the User-Agent ComboRow.
-        It persists the user's choice.
+        This method is connected to the 'notify::selected-item' signal of the
+        User-Agent ComboRow on the HTTP Page. It logs the change for the current
+        session. It does *not* save this selection back to the global
+        `default-user-agent-title` GSettings key, ensuring that the HTTP Page's
+        User-Agent choice is session-specific and does not alter the
+        globally configured default User-Agent preference.
 
         :param combo_row: The :class:`Adw.ComboRow` for User-Agent selection.
         :type combo_row: Adw.ComboRow
@@ -293,18 +297,14 @@ class HttpPage(Gtk.Box):
         selected_item_obj = combo_row.get_selected_item()
         if isinstance(selected_item_obj, Gtk.StringObject):
             selected_title = selected_item_obj.get_string()
-            if selected_title == "None":  # "None" is the display title for system default
-                self.settings.set_string("default-user-agent-title", "")
-                logger.info("User-Agent preference saved: System Default (empty string).")
-            else:
-                self.settings.set_string("default-user-agent-title", selected_title)
-                logger.info(f"User-Agent preference saved: '{selected_title}'.")
+            logger.info(f"HTTP Page User-Agent selection changed to: '{selected_title}'. This is a session-specific change.")
+            # The line below is commented out to prevent HTTP page selection from changing global default.
+            # self.settings.set_string("default-user-agent-title", selected_title if selected_title != "None" else "")
         elif selected_item_obj is None:
-            # This case might occur if the model is empty or selection is cleared programmatically
-            # in a way that doesn't involve selecting the "None" Gtk.StringObject.
-            # Setting to empty string to signify no specific UA default.
-            self.settings.set_string("default-user-agent-title", "")
-            logger.info("User-Agent preference saved: No selection (empty string).")
+            logger.info("HTTP Page User-Agent selection cleared (None). This is a session-specific change.")
+            # The line below is commented out
+            # self.settings.set_string("default-user-agent-title", "")
+
 
     def _on_copy_results_clicked(self, _button: Gtk.Button) -> None:
         """
@@ -459,42 +459,12 @@ class HttpPage(Gtk.Box):
         logger.info(f"Final User-Agent string for request: {user_agent_to_send}")
         custom_dns_server = self.settings.get_string("custom-dns-server")
 
-        # Resolve Default HTTP Header
-        additional_headers: Optional[Dict[str, str]] = None
-        default_header_title = self.settings.get_string("default-http-header-title")
-
-        if default_header_title and default_header_title != "None": # Assuming "None" is the UI string for no selection
-            header_found = False
-            # Check predefined DEFAULT_HTTP_HEADERS
-            for header_def in DEFAULT_HTTP_HEADERS:
-                if header_def["title"] == default_header_title:
-                    additional_headers = header_def["value"].copy() # Ensure we pass a copy
-                    header_found = True
-                    logger.info(f"Using predefined default HTTP header: '{default_header_title}' -> {additional_headers}")
-                    break
-
-            # If not in predefined, check custom headers
-            if not header_found:
-                custom_headers_variant = self.settings.get_value("custom-http-headers")
-                custom_headers_triples: list[tuple[str, str, str]] = list(
-                    custom_headers_variant.unpack() if custom_headers_variant and custom_headers_variant.get_type_string() == "a(sss)" else []
-                )
-                for title, name, value in custom_headers_triples:
-                    if title == default_header_title:
-                        additional_headers = {name: value}
-                        logger.info(f"Using custom default HTTP header: '{default_header_title}' -> {additional_headers}")
-                        break
-
-            if not additional_headers: # Log if title was set but not found (should ideally not happen if UI is synced)
-                 logger.warning(f"Default HTTP header title '{default_header_title}' was set but not found in predefined or custom headers.")
-
         self._http_task_data_for_thread = {
             "url": url,
             "use_akamai_pragma": self.http_pragma_switch_row.get_active(),
             "host_header": host_header if host_header else None,
             "user_agent": user_agent_to_send,
             "custom_dns_server": custom_dns_server if custom_dns_server else None,
-            "additional_headers": additional_headers,
         }
         logger.debug("HttpPage: Starting header fetch task with data: %s", self._http_task_data_for_thread)
 
@@ -546,7 +516,6 @@ class HttpPage(Gtk.Box):
             host_header=current_task_data.get("host_header"),
             user_agent=current_task_data.get("user_agent"),
             custom_dns_server=current_task_data.get("custom_dns_server"),
-            additional_headers=current_task_data.get("additional_headers"),
             cancellable=cancellable,
         )
 
@@ -943,12 +912,18 @@ class HttpPage(Gtk.Box):
 
     def _update_user_agent_model(self) -> None:
         """
-        Update the model for the User-Agent :class:`Adw.ComboRow`.
+        Update the model for the User-Agent :class:`Adw.ComboRow` on the HTTP Page.
 
-        Populates the dropdown with a "None" option (system default),
-        predefined User-Agents from :mod:`.constants`, and custom User-Agents from GSettings.
-        It attempts to preserve the current selection or apply the application's
-        default User-Agent preference.
+        This method populates the dropdown with a "None" option, standard User-Agents
+        from :mod:`.constants.USER_AGENTS`, and any custom User-Agents defined in
+        GSettings.
+
+        Crucially, after populating, it sets the initial selection of this dropdown
+        based on the `default-user-agent-title` GSettings value. If this
+        preference is empty or the specified User-Agent title is not found in the
+        populated list, it defaults to selecting the "None" option. This ensures
+        the HTTP Page respects the global default User-Agent preference on
+        initialization.
 
         :return: None
         """
@@ -956,15 +931,15 @@ class HttpPage(Gtk.Box):
             logger.error("HttpPage._update_user_agent_model: http_user_agent_row is None.")
             return
         self._ua_title_to_value_map.clear()
-        current_selection_text: Optional[str] = None
+        # current_selection_text: Optional[str] = None # Removed as per new logic
 
-        if (
-            self.http_user_agent_row.get_model()
-            and self.http_user_agent_row.get_selected() != Gtk.INVALID_LIST_POSITION
-        ):
-            selected_item_obj = self.http_user_agent_row.get_selected_item()
-            if isinstance(selected_item_obj, Gtk.StringObject):
-                current_selection_text = selected_item_obj.get_string()
+        # if (
+        #     self.http_user_agent_row.get_model()
+        #     and self.http_user_agent_row.get_selected() != Gtk.INVALID_LIST_POSITION
+        # ):
+        #     selected_item_obj = self.http_user_agent_row.get_selected_item()
+        #     if isinstance(selected_item_obj, Gtk.StringObject):
+        #         current_selection_text = selected_item_obj.get_string()
 
         display_titles: list[str] = []
 
@@ -995,66 +970,39 @@ class HttpPage(Gtk.Box):
 
         self.http_user_agent_row.set_model(Gtk.StringList.new(display_titles))
 
-        default_ua_title_pref = self.settings.get_string("default-user-agent-title")
+        default_ua_title_from_prefs = self.settings.get_string("default-user-agent-title")
+        title_to_select_in_http_page_dropdown = none_title # Default to "None"
 
-        # Determine the title to select: current, preferred default, or "None"
-        title_to_select = none_title  # Default to "None" (system UA)
-
-        # 1. If there's a current selection in the UI, try to maintain it,
-        #    unless it's no longer a valid choice.
-        if current_selection_text and current_selection_text in display_titles:
-            title_to_select = current_selection_text
-
-        # 2. If `default_ua_title_pref` from GSettings is a non-empty string,
-        #    it means the user has explicitly saved a preference. Try to apply it.
-        #    An empty string `''` for `default_ua_title_pref` means "System Default" (i.e., "None" option).
-        #    The legacy "[System Default]" string is also treated as "System Default".
-        if default_ua_title_pref and default_ua_title_pref != "[System Default]":
-            if default_ua_title_pref in display_titles:
-                title_to_select = default_ua_title_pref
-                logger.info(
-                    f"HTTP Page: Applying preferred default User-Agent from GSettings: '{default_ua_title_pref}'."
-                )
+        if default_ua_title_from_prefs: # If there's a global default set
+            if default_ua_title_from_prefs in display_titles:
+                title_to_select_in_http_page_dropdown = default_ua_title_from_prefs
+                logger.info(f"HTTP Page: Setting User-Agent dropdown to global default: '{default_ua_title_from_prefs}'.")
             else:
-                # The preferred default is not in the current list (e.g., was removed from custom UAs).
-                # Fallback to "None" (system default) in this case.
-                title_to_select = none_title
                 logger.warning(
-                    f"HTTP Page: Preferred default User-Agent title '{default_ua_title_pref}' from GSettings not found in available UAs. Falling back to 'None' (System Default)."
+                    f"HTTP Page: Global default User-Agent '{default_ua_title_from_prefs}' not in available titles. Falling back to 'None'."
                 )
-        elif not default_ua_title_pref or default_ua_title_pref == "[System Default]":
-            # If GSettings stores empty string or the legacy "[System Default]",
-            # ensure "None" (system default) is selected, unless a valid `current_selection_text`
-            # already superseded this (e.g. user just changed it but model is refreshing).
-            # If current_selection_text was valid and different from "None", it takes precedence.
-            if not (
-                current_selection_text
-                and current_selection_text in display_titles
-                and current_selection_text != none_title
-            ):
-                title_to_select = none_title
-            logger.info(
-                f"HTTP Page: User-Agent set to '{title_to_select}' (System Default or retained current selection) as per GSettings preference ('{default_ua_title_pref}')."
-            )
+        else: # Global default is "System Default" (empty string in GSettings)
+            logger.info("HTTP Page: Global default User-Agent is 'System Default'. Setting dropdown to 'None'.")
+            # title_to_select_in_http_page_dropdown is already "None"
 
-        # Select the determined title
-        if title_to_select in display_titles:
+        # Set the selection in the ComboBox
+        if title_to_select_in_http_page_dropdown in display_titles:
             try:
-                idx = display_titles.index(title_to_select)
-                # Block signal handler temporarily if it writes back to GSettings immediately
-                # to prevent loops if _update_user_agent_model is called from GSettings change.
-                # For now, assuming _on_user_agent_changed_visual_feedback doesn't write to GSettings.
-                # _save_selected_user_agent_preference will handle GSettings persistence.
+                idx = display_titles.index(title_to_select_in_http_page_dropdown)
                 self.http_user_agent_row.set_selected(idx)
-            except ValueError:  # Should not happen if title_to_select is in display_titles
-                if display_titles:  # Should not be empty if none_title was added
-                    self.http_user_agent_row.set_selected(0)  # Select "None"
-        elif display_titles:  # Fallback if something went wrong
-            self.http_user_agent_row.set_selected(
-                display_titles.index(none_title) if none_title in display_titles else 0
-            )
-        else:  # Should not happen as "None" is always added
-            self.http_user_agent_row.set_selected(Gtk.INVALID_LIST_POSITION)
+            except ValueError: # Should not happen if logic is correct
+                logger.error(f"HTTP Page: Title '{title_to_select_in_http_page_dropdown}' not found in display_titles for indexing, though it should be. Selecting first item as fallback.")
+                if display_titles:
+                    self.http_user_agent_row.set_selected(0)
+                else: # Should not happen
+                    self.http_user_agent_row.set_selected(Gtk.INVALID_LIST_POSITION)
+        else: # Should only happen if display_titles is empty, which means "None" wasn't added.
+            logger.error(f"HTTP Page: Critical - '{title_to_select_in_http_page_dropdown}' (or even 'None') not in display_titles. ListBox might be empty.")
+            if display_titles: # Should not be empty
+                 self.http_user_agent_row.set_selected(0)
+            else:
+                 self.http_user_agent_row.set_selected(Gtk.INVALID_LIST_POSITION)
+
 
         # Update visual feedback based on the final selection
         self._on_user_agent_changed_visual_feedback(self.http_user_agent_row, None)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -35,8 +35,9 @@ class Preferences(Adw.PreferencesWindow):
     Adw.PreferencesWindow subclass for managing application settings.
 
     This class defines the structure and behavior of the preferences dialog,
-    allowing users to customize various aspects of the application.
-    It binds UI elements to GSettings for persistence.
+    organized into pages (e.g., Appearance, Behavior), allowing users to
+    customize various aspects of the application. It binds UI elements
+    to GSettings for persistence.
 
     :ivar font_scale_combo_row: :class:`Adw.ComboRow` for font scaling.
     :vartype font_scale_combo_row: Adw.ComboRow
@@ -102,14 +103,6 @@ class Preferences(Adw.PreferencesWindow):
 
     # Global Font Preference UI Element
     global_output_font_button: Gtk.FontButton = Gtk.Template.Child("global_output_font_button")  # type: ignore
-
-    # HTTP Header Preferences UI Elements
-    default_http_header_combo_row: Adw.ComboRow = Gtk.Template.Child("default_http_header_combo_row")  # type: ignore
-    new_custom_http_header_title_entry: Gtk.Entry = Gtk.Template.Child("new_custom_http_header_title_entry")  # type: ignore
-    new_custom_http_header_name_entry: Gtk.Entry = Gtk.Template.Child("new_custom_http_header_name_entry")  # type: ignore
-    new_custom_http_header_value_entry: Gtk.Entry = Gtk.Template.Child("new_custom_http_header_value_entry")  # type: ignore
-    add_custom_http_header_button: Gtk.Button = Gtk.Template.Child("add_custom_http_header_button")  # type: ignore
-    custom_http_header_list_container: Gtk.Box = Gtk.Template.Child("custom_http_header_list_container")  # type: ignore
 
     def __init__(self, main_window: Optional[Gtk.Window] = None):
         """
@@ -212,18 +205,6 @@ class Preferences(Adw.PreferencesWindow):
             self.user_agent_combo_row.connect("notify::selected-item", self._on_default_user_agent_changed)
 
         # Custom HTTP Header Signals
-        if self.add_custom_http_header_button:
-            self.add_custom_http_header_button.connect("clicked", self._on_add_custom_http_header_clicked)
-        if self.new_custom_http_header_title_entry:
-            self.new_custom_http_header_title_entry.connect("entry-activated", self._on_add_custom_http_header_clicked)
-        if self.new_custom_http_header_name_entry:
-            self.new_custom_http_header_name_entry.connect("entry-activated", self._on_add_custom_http_header_clicked)
-        if self.new_custom_http_header_value_entry:
-            self.new_custom_http_header_value_entry.connect("entry-activated", self._on_add_custom_http_header_clicked)
-
-        self.settings.connect("changed::custom-http-headers", lambda _s, _k: self._render_custom_http_header_list())
-        if self.default_http_header_combo_row:
-            self.default_http_header_combo_row.connect("notify::selected-item", self._on_default_http_header_changed)
 
 
     def on_global_font_setting_changed(self, font_button: Gtk.FontButton):
@@ -655,27 +636,6 @@ class Preferences(Adw.PreferencesWindow):
                 logging.warning(f"GSettings 'output-font' was empty, set to default: {default_font}")
 
         # HTTP Headers
-        self._render_custom_http_header_list() # This also calls _populate_default_http_header_combo_row
-
-        default_http_header_title_gsettings = self.settings.get_string("default-http-header-title")
-        if default_http_header_title_gsettings == "": # User explicitly wants no default header
-            if not self._select_combo_row_item(self.default_http_header_combo_row, NONE_OPTION_TITLE):
-                logging.error(f"'{NONE_OPTION_TITLE}' not found in default_http_header_combo_row.")
-                if self.default_http_header_combo_row.get_model() and self.default_http_header_combo_row.get_model().get_n_items() > 0:
-                     self.default_http_header_combo_row.set_selected(0)
-        elif default_http_header_title_gsettings: # A specific header title is saved
-            if not self._select_combo_row_item(self.default_http_header_combo_row, default_http_header_title_gsettings):
-                logging.warning(
-                    f"Saved default HTTP header title '{default_http_header_title_gsettings}' not found in combo. "
-                    f"Falling back to '{NONE_OPTION_TITLE}'."
-                )
-                self.settings.set_string("default-http-header-title", "") # Clear invalid GSetting
-                if not self._select_combo_row_item(self.default_http_header_combo_row, NONE_OPTION_TITLE):
-                    logging.error(f"Fallback '{NONE_OPTION_TITLE}' not found for HTTP headers. Critical error.")
-        else: # GSetting is empty, but not explicitly "" (initial state or cleared by other means)
-            if not self._select_combo_row_item(self.default_http_header_combo_row, NONE_OPTION_TITLE):
-                logging.error(f"'{NONE_OPTION_TITLE}' not found for HTTP headers during initial load. Critical error.")
-            self.settings.set_string("default-http-header-title", "")
 
 
     def _populate_user_agent_combo_row(self):
@@ -779,278 +739,5 @@ class Preferences(Adw.PreferencesWindow):
                 if current_gsettings_val != "": # Only update if it's not already empty
                     self.settings.set_string("default-user-agent-title", "")
                     logging.debug("Default user agent selection cleared as list is empty or selection is invalid.")
-
-    # --- HTTP Header Management ---
-
-    def _render_custom_http_header_list(self):
-        """
-        Clear and repopulate the list of custom HTTP Headers in the UI.
-        Retrieves header triples (title, name, value) from GSettings,
-        creates an :class:`Adw.ActionRow` for each, and adds them to the
-        ``custom_http_header_list_container``. Each row includes a remove button.
-        This method also triggers a refresh of the default HTTP header combo box.
-        """
-        if not self.custom_http_header_list_container:
-            logging.warning("custom_http_header_list_container not found, cannot render list.")
-            return
-
-        child = self.custom_http_header_list_container.get_first_child()
-        while child:
-            self.custom_http_header_list_container.remove(child)
-            child = self.custom_http_header_list_container.get_first_child()
-
-        variant = self.settings.get_value("custom-http-headers")
-        custom_headers_triples: list[tuple[str, str, str]] = list(
-            variant.unpack() if variant and variant.get_type_string() == "a(sss)" else []
-        )
-
-        for title, name, value in custom_headers_triples:
-            row = Adw.ActionRow(title=title, subtitle=f"{name}: {value}")
-            row.set_activatable(False)
-            remove_button = Gtk.Button(icon_name="edit-delete-symbolic", valign=Gtk.Align.CENTER)
-            remove_button.add_css_class("flat")
-            remove_button.set_tooltip_text(f"Remove '{title}'")
-            remove_button.connect("clicked", lambda _btn, t=title: self._on_remove_custom_http_header_clicked(t))
-            row.add_suffix(remove_button)
-            row.set_activatable_widget(remove_button)
-            self.custom_http_header_list_container.append(row)
-
-        self._populate_default_http_header_combo_row() # Keep dropdown in sync
-
-    def _is_http_header_title_unique(self, title_text: str) -> bool:
-        """
-        Check if a given title is unique among default and custom HTTP headers.
-
-        Compares against titles in `constants.DEFAULT_HTTP_HEADERS` and
-        titles of existing custom HTTP headers stored in GSettings.
-
-        :param title_text: The title string to check for uniqueness.
-        :type title_text: str
-        :return: ``True`` if the title is unique, ``False`` otherwise.
-        :rtype: bool
-        """
-        # Check against default headers from constants.py
-        for header_dict in DEFAULT_HTTP_HEADERS:
-            if header_dict['title'] == title_text:
-                return False
-
-        # Check against custom headers from GSettings
-        variant = self.settings.get_value("custom-http-headers")
-        current_headers_triples: list[tuple[str, str, str]] = list(
-            variant.unpack() if variant and variant.get_type_string() == "a(sss)" else []
-        )
-        for triple in current_headers_triples:
-            if triple[0] == title_text:
-                return False
-        return True
-
-    def _on_add_custom_http_header_clicked(self, _widget: Gtk.Widget) -> None:
-        """
-        Handle the 'Add Custom HTTP Header' button click or :class:`Gtk.Entry` activation.
-
-        Retrieves text from the title, name, and value entry fields.
-        If all are non-empty and the title is unique (checked by
-        :meth:`._is_http_header_title_unique`), adds the new header triple
-        (title, name, value) to the ``custom-http-headers`` GSettings list.
-        Clears input fields on success. Provides visual error feedback on entries
-        if validation fails.
-
-        :param _widget: The :class:`Gtk.Widget` that triggered the signal (unused).
-        :type _widget: Gtk.Widget
-        """
-        if not self.new_custom_http_header_title_entry or \
-           not self.new_custom_http_header_name_entry or \
-           not self.new_custom_http_header_value_entry:
-            logging.error("One or more custom HTTP header entry fields are not available.")
-            return
-
-        title_text = self.new_custom_http_header_title_entry.get_text().strip()
-        name_text = self.new_custom_http_header_name_entry.get_text().strip()
-        value_text = self.new_custom_http_header_value_entry.get_text().strip()
-
-        # Basic validation for empty fields
-        has_error = False
-        if not title_text:
-            self.new_custom_http_header_title_entry.add_css_class("error")
-            has_error = True
-        else:
-            self.new_custom_http_header_title_entry.remove_css_class("error")
-
-        if not name_text:
-            self.new_custom_http_header_name_entry.add_css_class("error")
-            has_error = True
-        else:
-            self.new_custom_http_header_name_entry.remove_css_class("error")
-
-        if not value_text: # Value can technically be empty, but let's enforce for usability here.
-                           # User can create a header with empty value if they really want via other means or edit.
-            self.new_custom_http_header_value_entry.add_css_class("error")
-            has_error = True
-        else:
-            self.new_custom_http_header_value_entry.remove_css_class("error")
-
-        if has_error:
-            logging.info("Attempted to add custom HTTP header with one or more empty fields.")
-            return
-
-        # Check for duplicate titles
-        if not self._is_http_header_title_unique(title_text):
-            logging.info(f"Custom HTTP header title '{title_text}' already exists or conflicts with a default header.")
-            self.new_custom_http_header_title_entry.add_css_class("error")
-            # Optionally show a banner or toast here
-            return
-        else:
-            self.new_custom_http_header_title_entry.remove_css_class("error")
-
-        variant = self.settings.get_value("custom-http-headers")
-        current_headers_triples: list[tuple[str, str, str]] = list(
-            variant.unpack() if variant and variant.get_type_string() == "a(sss)" else []
-        )
-
-        current_headers_triples.append((title_text, name_text, value_text))
-        new_variant = GLib.Variant("a(sss)", current_headers_triples)
-
-        if self.settings.set_value("custom-http-headers", new_variant):
-            logging.info(f"Added custom HTTP Header: '{title_text}' -> '{name_text}: {value_text}'")
-            self.new_custom_http_header_title_entry.set_text("")
-            self.new_custom_http_header_name_entry.set_text("")
-            self.new_custom_http_header_value_entry.set_text("")
-            # _render_custom_http_header_list is called by GSettings "changed::custom-http-headers" signal
-        else:
-            logging.error(f"Failed to save custom HTTP header list to GSettings with new header: {title_text}")
-
-    def _on_remove_custom_http_header_clicked(self, title_to_remove: str) -> None:
-        """
-        Handle the click of a 'remove' button for a custom HTTP Header.
-
-        Removes the HTTP header triple identified by ``title_to_remove`` from
-        the ``custom-http-headers`` GSettings list. The UI list is updated
-        automatically via the GSettings "changed" signal connection to
-        :meth:`._render_custom_http_header_list`.
-
-        :param title_to_remove: The title of the custom HTTP header to remove.
-        :type title_to_remove: str
-        """
-        variant = self.settings.get_value("custom-http-headers")
-        current_headers_triples: list[tuple[str, str, str]] = list(
-            variant.unpack() if variant and variant.get_type_string() == "a(sss)" else []
-        )
-
-        original_length = len(current_headers_triples)
-        updated_headers_triples = [triple for triple in current_headers_triples if triple[0] != title_to_remove]
-
-        if len(updated_headers_triples) < original_length:
-            new_variant = GLib.Variant("a(sss)", updated_headers_triples)
-            if self.settings.set_value("custom-http-headers", new_variant):
-                logging.info(f"Removed custom HTTP Header with title: {title_to_remove}")
-                # _render_custom_http_header_list is called by GSettings "changed::custom-http-headers" signal
-            else:
-                logging.error(f"Failed to save custom HTTP header list after removing title: {title_to_remove}")
-        else:
-            logging.warning(f"Attempted to remove non-existent custom HTTP Header with title: {title_to_remove}")
-
-    def _populate_default_http_header_combo_row(self):
-        """
-        Populate the ``default_http_header_combo_row`` with available HTTP header choices.
-
-        The choices include a "None" option, predefined headers from
-        `constants.DEFAULT_HTTP_HEADERS`, and user-defined custom headers
-        from GSettings. It attempts to preserve the currently selected item.
-        """
-        if not self.default_http_header_combo_row:
-            logging.warning("default_http_header_combo_row not found, cannot populate.")
-            return
-
-        current_selection_title = None
-        selected_item = self.default_http_header_combo_row.get_selected_item()
-        if selected_item:
-            if isinstance(selected_item, Gtk.StringObject):
-                current_selection_title = selected_item.get_string()
-
-        all_header_titles = []
-
-        # 1. Add "None" option (No default header)
-        all_header_titles.append(NONE_OPTION_TITLE) # Re-use NONE_OPTION_TITLE for consistency
-
-        # 2. Add default headers from constants.py
-        for header_dict in DEFAULT_HTTP_HEADERS:
-            title = header_dict['title']
-            if title not in all_header_titles:
-                all_header_titles.append(title)
-            else:
-                logging.warning(f"Default HTTP Header title '{title}' conflicts with '{NONE_OPTION_TITLE}' or another default header. Skipping.")
-
-        # 3. Add custom HTTP headers from GSettings
-        variant = self.settings.get_value("custom-http-headers")
-        custom_headers_triples: list[tuple[str, str, str]] = list(
-            variant.unpack() if variant and variant.get_type_string() == "a(sss)" else []
-        )
-
-        for title, _name, _value in custom_headers_triples:
-            if title not in all_header_titles:
-                all_header_titles.append(title)
-            else:
-                logging.warning(
-                    f"Custom HTTP Header title '{title}' conflicts with a default or another custom header title. Skipping."
-                )
-
-        model = Gtk.StringList.new(all_header_titles)
-        self.default_http_header_combo_row.set_model(model)
-
-        if current_selection_title and current_selection_title in all_header_titles:
-            idx_to_select = all_header_titles.index(current_selection_title)
-            self.default_http_header_combo_row.set_selected(idx_to_select)
-        elif model.get_n_items() > 0:
-            self.default_http_header_combo_row.set_selected(0) # Select NONE_OPTION_TITLE
-        else:
-            self.default_http_header_combo_row.set_selected(Gtk.INVALID_LIST_POSITION)
-            logging.warning("Populate HTTP Header: No headers available to select, even NONE_OPTION_TITLE is missing.")
-
-        selected_idx = self.default_http_header_combo_row.get_selected()
-        if selected_idx != Gtk.INVALID_LIST_POSITION and self.default_http_header_combo_row.get_model():
-            selected_title_after_set = self.default_http_header_combo_row.get_model().get_string(selected_idx)
-            logging.debug(f"HTTP Header ComboBox selection after populate: Index {selected_idx}, Title '{selected_title_after_set}'")
-        else:
-            logging.debug(f"HTTP Header ComboBox no selection or invalid index after populate: {selected_idx}")
-
-
-    def _on_default_http_header_changed(self, combo_row: Adw.ComboRow, _gparam: GObject.ParamSpec):
-        """
-        Handle changes in the default HTTP header selection from the :class:`Adw.ComboRow`.
-
-        Saves the selected header's title to the ``default-http-header-title``
-        GSettings key. If "None" (represented by `NONE_OPTION_TITLE`) is selected,
-        an empty string is saved to GSettings, indicating no default header override.
-
-        :param combo_row: The :class:`Adw.ComboRow` whose selection changed.
-        :type combo_row: Adw.ComboRow
-        :param _gparam: The :class:`GObject.ParamSpec` of the property that changed (unused).
-        :type _gparam: GObject.ParamSpec
-        """
-        selected_item_obj = combo_row.get_selected_item()
-        if isinstance(selected_item_obj, Gtk.StringObject):
-            selected_header_title = selected_item_obj.get_string()
-            if selected_header_title:
-                current_gsettings_val = self.settings.get_string("default-http-header-title")
-                gsetting_to_save = "" # Assume NONE_OPTION_TITLE / No default
-                if selected_header_title != NONE_OPTION_TITLE:
-                    gsetting_to_save = selected_header_title
-
-                if gsetting_to_save != current_gsettings_val:
-                    self.settings.set_string("default-http-header-title", gsetting_to_save)
-                    logging.debug(
-                        f"Default HTTP header title selection '{selected_header_title}' saved to GSettings as '{gsetting_to_save}'."
-                    )
-            else: # Should not happen with valid titles
-                logging.warning("Selected HTTP Header title is None or empty, setting GSettings to empty (no default).")
-                self.settings.set_string("default-http-header-title", "")
-
-        elif selected_item_obj is None:
-            model = combo_row.get_model()
-            if model is None or model.get_n_items() == 0:
-                current_gsettings_val = self.settings.get_string("default-http-header-title")
-                if current_gsettings_val != "":
-                    self.settings.set_string("default-http-header-title", "")
-                    logging.debug("Default HTTP header selection cleared as list is empty or selection invalid.")
 
     # --- End HTTP Header Management ---


### PR DESCRIPTION
This commit implements significant changes based on your feedback:

1.  **Removed Incorrect HTTP Header Preference:**
    *   Fully removed the previously implemented "Default HTTP Header"
        and "Custom HTTP Headers" feature. This involved deleting
        related UI elements from `src/gtk/preferences.ui`, logic and
        GSettings key usage from `src/preferences.py`, schema
        definitions from `data/com.github.mclellac.woes.gschema.xml`,
        constants from `src/constants.py`, and parameter handling
        from `src/http_page.py` and `src/http_client.py`.

2.  **Refactored Preferences Window:**
    *   The Preferences window (`src/gtk/preferences.ui`) has been
        restructured into a paged layout using `Adw.PreferencesPage`.
    *   Settings are now organized into two pages:
        *   **Appearance Page:** Contains Theme, Font Scaling,
            Global Output Font, and HTTP Output Color settings.
        *   **Behavior Page:** Contains Custom DNS Server (Tool Settings)
            and User-Agent configuration (default selection and
            custom UA management).
    *   `src/preferences.py` was confirmed to be compatible with this
        new UI structure due to preserved widget IDs.

3.  **Corrected Default User-Agent Logic for HTTP Page:**
    *   Modified `src/http_page.py` (`_update_user_agent_model`) so
        that the User-Agent dropdown on the HTTP Page now correctly
        initializes its selection based on the `default-user-agent-title`
        GSettings value. If no default is set in Preferences, or the
        saved default is not found, the dropdown defaults to "None".
    *   The selection made in the HTTP Page's User-Agent dropdown is
        now session-specific and does *not* modify the global
        `default-user-agent-title` GSettings preference. This was
        achieved by commenting out the GSettings write operation in
        `HttpPage._save_selected_user_agent_preference`.

4.  **Docstrings Updated:**
    *   Docstrings across `src/preferences.py`, `src/http_page.py`,
        and other affected files have been updated to reflect these
        changes and remove any references to the deleted HTTP Header
        feature.