### PR TITLE
Fix ImportError for DEFAULT_HTTP_HEADERS in preferences.

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -349,10 +349,8 @@ class HttpPage(Gtk.Box):
         Handle activation of the URL entry row or click of the 'Fetch' button.
 
         Validates the URL, gathers request parameters (including Host header,
-        User-Agent, custom DNS, Akamai Pragma state, and the selected default
-        HTTP header from GSettings), and starts the background task to fetch
-        HTTP headers. The resolved default HTTP header is passed as
-        ``additional_headers`` to the :class:`.http_client.HttpFetcher`.
+        User-Agent, custom DNS, and Akamai Pragma state), and starts the
+        background task to fetch HTTP headers.
 
         :param _widget: The :class:`Gtk.Widget` that triggered the activation (unused).
         :type _widget: Gtk.Widget
@@ -483,10 +481,9 @@ class HttpPage(Gtk.Box):
         Background thread function for fetching HTTP headers.
 
         This function is executed by :meth:`Gio.Task.run_in_thread`.
-        It instantiates :class:`.http_client.HttpFetcher` with all necessary
-        parameters, including any resolved ``additional_headers`` (like a
-        default HTTP header), and calls its main fetching method. Results or
-        exceptions are then reported back to the main thread via the :class:`Gio.Task`.
+        It instantiates :class:`.http_client.HttpFetcher` with necessary parameters
+        and calls its main fetching method. Results or exceptions are reported
+        back to the main thread via the :class:`Gio.Task`.
 
         :param task: The :class:`Gio.Task` associated with this operation.
         :type task: Gio.Task

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -18,7 +18,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, Gio, Gtk, GLib, GObject, Gdk
 
 # Local application imports
-from .constants import APP_ID, RESOURCE_PREFIX, USER_AGENTS, DEFAULT_HTTP_HEADERS
+from .constants import APP_ID, RESOURCE_PREFIX, USER_AGENTS
 
 # Conditional import for dnspython
 try:
@@ -67,18 +67,6 @@ class Preferences(Adw.PreferencesWindow):
     :vartype user_agent_combo_row: Adw.ComboRow
     :ivar global_output_font_button: :class:`Gtk.FontButton` for global output font.
     :vartype global_output_font_button: Gtk.FontButton
-    :ivar default_http_header_combo_row: :class:`Adw.ComboRow` for default HTTP header selection.
-    :vartype default_http_header_combo_row: Adw.ComboRow
-    :ivar new_custom_http_header_title_entry: :class:`Gtk.Entry` for new custom HTTP header display title.
-    :vartype new_custom_http_header_title_entry: Gtk.Entry
-    :ivar new_custom_http_header_name_entry: :class:`Gtk.Entry` for new custom HTTP header name.
-    :vartype new_custom_http_header_name_entry: Gtk.Entry
-    :ivar new_custom_http_header_value_entry: :class:`Gtk.Entry` for new custom HTTP header value.
-    :vartype new_custom_http_header_value_entry: Gtk.Entry
-    :ivar add_custom_http_header_button: :class:`Gtk.Button` to add a new custom HTTP header.
-    :vartype add_custom_http_header_button: Gtk.Button
-    :ivar custom_http_header_list_container: :class:`Gtk.Box` for displaying the list of custom HTTP headers.
-    :vartype custom_http_header_list_container: Gtk.Box
     """
 
     __gtype_name__ = "Preferences"


### PR DESCRIPTION
I corrected an `ImportError` in `src/preferences.py` where it was still attempting to import `DEFAULT_HTTP_HEADERS` from `woes.constants`. This name was removed as part of the cleanup of the erroneous HTTP Header feature in a previous commit.

The import statement in `src/preferences.py` has been updated to only import existing names: `APP_ID`, `RESOURCE_PREFIX`, and `USER_AGENTS`.

This fixes a startup crash caused by the missing import.