### PR TITLE
Fix Gtk-WARNINGs and add padding to webscan output

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -53,6 +53,7 @@ class DNSPage(Gtk.Box):
     dns_status_spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: GObject.GObject):
+        """Initialize the DNSPage."""
         logging.debug("DNSPage.__init__ called")
         """
         Initialize the DNSPage.

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -1,9 +1,9 @@
-/* Margin for GtkSourceView widgets */
-.source-view {
-  margin-top: 10;
-  margin-bottom: 10;
-  margin-left: 10;
-  margin-right: 10;
+/* Padding for webscan output GtkTextView */
+textview#webscan-output-textview {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 /* HTTP Page Specific Styles */

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -169,6 +169,7 @@ class HttpPage(Gtk.Box):
     http_status_spinner: Gtk.Spinner = Gtk.Template.Child()
 
     def __init__(self, **kwargs: Any):
+        """Initialize the HttpPage."""
         logging.debug("HttpPage.__init__ called")
         """
         Initialize the HttpPage.

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -91,6 +91,7 @@ class NmapPage(Gtk.Box):
     nmap_detail_placeholder = Gtk.Template.Child("nmap_detail_placeholder")
 
     def __init__(self, **kwargs: Any):
+        """Initialize the NmapPage."""
         logging.debug("NmapPage.__init__ called")
         """
         Initialize the NmapPage.

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -54,6 +54,7 @@ class WebScanPage(Gtk.Box):
     auth_bypass_switch: Adw.SwitchRow = Gtk.Template.Child()
 
     def __init__(self, **kwargs: Any):
+        """Initialize the WebScanPage."""
         logging.debug("WebScanPage.__init__ called")
         """
         Initialize the WebScanPage.

--- a/src/window.py
+++ b/src/window.py
@@ -57,6 +57,7 @@ class WoesWindow(Adw.ApplicationWindow):
     toast_overlay: Adw.ToastOverlay = Gtk.Template.Child("toast_overlay")
 
     def __init__(self, **kwargs: Any):  # GObject.GObject is too restrictive if no args passed
+        """Initialize the WoesWindow."""
         logging.debug("WoesWindow.__init__ called")
         """
         Initialize the WoesWindow.


### PR DESCRIPTION
Resolves Gtk-WARNING theme parser errors in style.css by adding 'px' units to margin properties.

The CSS rule originally for '.source-view' with margins has been updated to target 'textview#webscan-output-textview' and now applies padding. This addresses the issue where GtkSourceView was replaced by GtkTextView for displaying web scan results, and ensures the output area has appropriate padding.

Linters were run and auto-fixes for docstrings were applied.