### PR TITLE
Fix: Resolve Gtk-CRITICAL error for HttpPage type

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -20,6 +20,7 @@ from .constants import (
     TEXT_SCALING_FACTOR_KEY,
 )
 from .style_utils import apply_font_size, apply_theme
+from .http_page import HttpPage
 
 
 gi.require_version("Adw", "1")


### PR DESCRIPTION
The application was failing to launch due to a Gtk-CRITICAL error: "Error building template class 'WoesWindow' for an instance of type 'WoesWindow': .:0:0 Invalid object type 'HttpPage'"

This occurred because the `HttpPage` custom widget was used in the `WoesWindow` UI template (`window.ui`) without being imported in the `WoesWindow` Python module (`window.py`). GTK requires custom widget types to be known before parsing templates that use them.

This commit resolves the issue by adding `from .http_page import HttpPage` to `src/window.py`.

This change is also expected to resolve a secondary warning: `WARNING:root:switcher_title or stack not found during setup_ui.` which was likely a symptom of the main template loading failure.

Direct testing of the application launch was hindered by environment issues (PyGObject import errors and GTK version incompatibilities).