### PR TITLE
Fix: Resolve SyntaxError in nmap_page.py

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -258,7 +258,8 @@ class NmapPage(Gtk.Box):
             task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.SCAN_FAILED.value, f"Nmap scan error: {e}")
         except Exception as e:
             logger.exception("Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__)
-            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, f"Scan failed unexpectedly: {e}")
+            error_msg_details = f"Scan failed unexpectedly: {e}"
+            task.return_new_error_literal(GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, error_msg_details)
         finally:
             logger.info("Nmap scan thread finished for %s.", target)
 


### PR DESCRIPTION
Refactors the `except Exception as e:` block within the `_run_nmap_scan_thread_func` method in `src/nmap_page.py`.

The original code had an f-string directly as an argument in the `task.return_new_error_literal` call. This change assigns the f-string to a local variable `error_msg_details` first and then passes this variable to the function.

This modification is intended to mitigate a `SyntaxError` that was occurring on the `finally:` line immediately following this `except` block, potentially due to subtle parsing issues with the complex inline f-string in that context with Python 3.13.