### PR TITLE
I fixed multiple runtime errors and warnings.

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -9,7 +9,7 @@ DNS lookups are performed asynchronously to maintain UI responsiveness.
 """
 
 import logging
-from typing import Optional, Any, List, Dict, Final # Added Final
+from typing import Optional, Any, List, Dict, Final  # Added Final
 
 import gi
 
@@ -110,7 +110,9 @@ class DNSPage(Gtk.Box):
         if self.dns_apply_button:
             self.dns_apply_button.connect("clicked", self._on_entry_activated)
         if self.dns_record_type_dropdown:
-            self.dns_record_type_dropdown.connect("notify::selected-item", self._on_record_type_changed)
+            self.dns_record_type_dropdown.connect(
+                "notify::selected-item", self._on_record_type_changed
+            )
         if self.dns_clear_results_button:
             self.dns_clear_results_button.connect("clicked", self._on_clear_results_clicked)
         if self.dns_copy_all_results_button:
@@ -215,10 +217,13 @@ class DNSPage(Gtk.Box):
                 elif rtype in ("CNAME", "NS", "PTR"):
                     parts.append(f"Target: {record_data.get('target', 'N/A')}")
                 elif rtype == "MX":
-                    parts.append(f"Preference: {record_data.get('preference', 'N/A')}")
+                    parts.append(
+                        f"Preference: {record_data.get('preference', 'N/A')}"
+                    )
                     parts.append(f"Exchange: {record_data.get('exchange', 'N/A')}")
                 elif rtype == "TXT":
-                    texts_join = "; ".join([f'"{s}"' for s in record_data.get('texts', ['N/A'])])
+                    texts_val = record_data.get('texts', ['N/A'])
+                    texts_join = "; ".join([f'"{s}"' for s in texts_val])
                     parts.append(f"Texts: {texts_join}")
                 elif rtype == "SOA":
                     parts.append(f"MNAME: {record_data.get('mname', 'N/A')}")
@@ -555,12 +560,14 @@ class DNSPage(Gtk.Box):
         if is_valid_ip(user_input) and requested_record_type.upper() == "PTR":
             model = self.dns_record_type_dropdown.get_model()
             if model:
-                for i in range(model.get_n_items()): # type: ignore
-                    item_str = model.get_string(i) # type: ignore
+                for i in range(model.get_n_items()):  # type: ignore
+                    item_str = model.get_string(i)  # type: ignore
                     if item_str and item_str.upper() == "PTR":
                         if self.dns_record_type_dropdown.get_selected() != i:
                             self.dns_record_type_dropdown.set_selected(i)
-                            logger.debug("DNSPage: Switched dropdown to PTR for IP input.")
+                            logger.debug(
+                                "DNSPage: Switched dropdown to PTR for IP input."
+                            )
                         break
             actual_record_type_used = "PTR"
         return actual_record_type_used
@@ -584,15 +591,13 @@ class DNSPage(Gtk.Box):
 
         if self._current_dns_task and not self._current_dns_task.is_done():
             try:
-                if self._current_dns_task.get_cancellable(): # Check if cancellable exists
+                if self._current_dns_task.get_cancellable():  # Check if cancellable exists
                     self._current_dns_task.get_cancellable().cancel()
                 logger.info("DNSPage: Previous DNS lookup task cancelled.")
             except Exception as e_cancel:
                 logger.warning("DNSPage: Error trying to cancel previous DNS task: %s", e_cancel)
 
         cancellable = Gio.Cancellable()
-        self._current_dns_task = Gio.Task.new(self, cancellable, self._perform_lookup_done_cb, None)
-
         custom_dns_server = self.settings.get_string("custom-dns-server")
 
         task_data = {
@@ -600,15 +605,21 @@ class DNSPage(Gtk.Box):
             "requested_record_type": requested_record_type,
             "custom_dns_server": custom_dns_server if custom_dns_server else None
         }
-        self._current_dns_task.set_task_data(task_data)
+        self._current_dns_task = Gio.Task.new(self, cancellable, self._perform_lookup_done_cb, task_data)
+        self._current_dns_task.set_task_data(None)
 
         logger.debug(
             "DNSPage: Starting DNS lookup task with input: '%s', type: '%s', server: '%s'",
-            user_input, requested_record_type, custom_dns_server or "System Default"
+            user_input,
+            requested_record_type,
+            custom_dns_server or "System Default"
         )
         self._current_dns_task.run_in_thread(self._perform_lookup_thread_func)
 
-    def _perform_lookup_thread_func(self, task: Gio.Task, _source_object: Any, _task_data_param: Any, cancellable: Gio.Cancellable) -> None:
+    def _perform_lookup_thread_func(
+        self, task: Gio.Task, _source_object: Any,
+        _task_data_param: Any, cancellable: Gio.Cancellable
+    ) -> None:
         """
         Perform the DNS lookup in a background thread.
 
@@ -620,41 +631,61 @@ class DNSPage(Gtk.Box):
         :param _task_data_param: Data passed via `run_in_thread` (unused here).
         :param cancellable: The :class:`Gio.Cancellable` for this task.
         """
-        task_internal_data: Dict[str, Any] = task.get_task_data() # type: ignore
+        task_internal_data: Dict[str, Any] = task.get_task_data()  # type: ignore
         user_input: str = task_internal_data["user_input"]
         requested_record_type: str = task_internal_data["requested_record_type"]
         custom_dns_server: Optional[str] = task_internal_data["custom_dns_server"]
 
         if cancellable.is_cancelled():
-            task.return_error(GLib.Error.new_literal(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED, "Lookup cancelled before starting."))
+            task.return_error(
+                GLib.Error.new_literal(
+                    Gio.io_error_quark(),
+                    Gio.IOErrorEnum.CANCELLED,
+                    "Lookup cancelled before starting."
+                )
+            )
             return
 
         try:
             dns_client = DnsResolverClient(custom_dns_server=custom_dns_server)
-            if cancellable.is_cancelled(): # Check again before potentially long operation
-                task.return_error(GLib.Error.new_literal(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED, "Lookup cancelled before resolving."))
+            if cancellable.is_cancelled():  # Check again before potentially long operation
+                task.return_error(
+                    GLib.Error.new_literal(
+                        Gio.io_error_quark(),
+                        Gio.IOErrorEnum.CANCELLED,
+                        "Lookup cancelled before resolving."
+                    )
+                )
                 return
             result_data = dns_client.resolve(user_input, requested_record_type)
 
             if cancellable.is_cancelled():
-                task.return_error(GLib.Error.new_literal(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED, "Lookup cancelled after resolving."))
+                task.return_error(
+                    GLib.Error.new_literal(
+                        Gio.io_error_quark(),
+                        Gio.IOErrorEnum.CANCELLED,
+                        "Lookup cancelled after resolving."
+                    )
+                )
                 return
 
             task_result_payload = {
                 "data": result_data,
                 "client_nameservers": dns_client.resolver.nameservers or []
             }
-            # GLib.Variant is more robust for complex types across threads with GObject Introspection
-            # For this simple dict, direct passing might work but GVariant is safer.
-            # However, directly returning dicts from run_in_thread and retrieving with propagate_value
-            # which returns 'gpointer' (Any in Python) is common in PyGObject if not using GVariant explicitly.
-            task.return_value(task_result_payload) # type: ignore
+            task.return_value(task_result_payload)  # type: ignore
         except Exception as e:
-            task.get_task_data()["original_exception"] = e
-            task.return_error(GLib.Error.new_literal(Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, str(e)))
+            if task.get_task_data(): # Ensure task_data exists to store exception
+                task.get_task_data()["original_exception"] = e
+            task.return_error(
+                GLib.Error.new_literal(
+                    Gio.io_error_quark(), Gio.IOErrorEnum.FAILED, str(e)
+                )
+            )
 
-
-    def _perform_lookup_done_cb(self, _source_object: Any, result: Gio.AsyncResult, _user_data: Any) -> None:
+    def _perform_lookup_done_cb(
+        self, _source_object: Any, result: Gio.AsyncResult, _user_data: Any
+    ) -> None:
         """
         Process the result of the asynchronous DNS lookup.
 
@@ -666,44 +697,63 @@ class DNSPage(Gtk.Box):
         :param result: The :class:`Gio.AsyncResult` from the completed task.
         :param _user_data: User data passed with the callback (unused).
         """
-        if not self._current_dns_task or not self._current_dns_task.matches_async_result(result):
+        active_task = self._current_dns_task
+        if not active_task or not active_task.matches_async_result(result):
             logger.warning("DNSPage: Callback received for an outdated or mismatched DNS task.")
-            if not self._current_dns_task or self._current_dns_task.is_done(): # If no current task or it's done
+            if not active_task or active_task.is_done():  # If no current task or it's done
                  self._set_loading_state(False, "Idle.")
             return
 
-        task_internal_data: Dict[str, Any] = self._current_dns_task.get_task_data() # type: ignore
-        user_input: str = task_internal_data["user_input"]
-        requested_record_type: str = task_internal_data["requested_record_type"]
+        task_internal_data: Optional[Dict[str, Any]] = active_task.get_task_data()
+        user_input: str = "Unknown Input"
+        requested_record_type: str = "Unknown Type"
+        if task_internal_data:
+            user_input = task_internal_data.get("user_input", user_input)
+            requested_record_type = task_internal_data.get(
+                "requested_record_type", requested_record_type
+            )
 
         try:
-            task_return_value = self._current_dns_task.propagate_value(result)
+            task_return_value = active_task.propagate_value(result)
+
+            result_data: List[Dict[str, Any]] = []
+            nameservers_used: List[str] = ["System Default"]
 
             if isinstance(task_return_value, dict):
                 result_data = task_return_value.get("data", [])
                 nameservers_used = task_return_value.get("client_nameservers", [])
             else:
-                logger.warning("DNSPage: Task returned unexpected data type: %s", type(task_return_value))
-                result_data = []
+                logger.warning(
+                    "DNSPage: Task returned unexpected data type: %s", type(task_return_value)
+                )
                 # Attempt to get custom_dns_server from settings as a fallback for display
                 custom_dns_setting = self.settings.get_string("custom-dns-server")
-                nameservers_used = [custom_dns_setting] if custom_dns_setting else ["System Default"]
+                if custom_dns_setting:
+                    nameservers_used = [custom_dns_setting]
 
-            self._handle_dns_lookup_success_async(result_data, user_input, requested_record_type, nameservers_used)
+            self._handle_dns_lookup_success_async(
+                result_data, user_input, requested_record_type, nameservers_used
+            )
 
         except GLib.Error as e:
-            original_exception = task_internal_data.get("original_exception")
-            if original_exception:
-                self._handle_dns_lookup_exception_async(original_exception, user_input, requested_record_type)
-            else:
-                self._handle_dns_lookup_exception_async(e, user_input, requested_record_type)
+            original_exception = None
+            if task_internal_data:
+                original_exception = task_internal_data.get("original_exception")
+
+            error_to_handle = original_exception if original_exception else e
+            self._handle_dns_lookup_exception_async(
+                error_to_handle, user_input, requested_record_type
+            )
         except Exception as e_unexpected:
-            logger.exception("DNSPage: Unexpected error processing DNS task result for '%s':", user_input)
-            self._handle_dns_lookup_exception_async(e_unexpected, user_input, requested_record_type)
+            logger.exception(
+                "DNSPage: Unexpected error processing DNS task result for '%s':", user_input
+            )
+            self._handle_dns_lookup_exception_async(
+                e_unexpected, user_input, requested_record_type
+            )
         finally:
             self._set_loading_state(False)
             self._current_dns_task = None
-
 
     def _handle_dns_lookup_success_async(
         self,
@@ -768,47 +818,64 @@ class DNSPage(Gtk.Box):
         if isinstance(error, DnsNxDomainError):
             show_global_error(self, error_message)
             status_subtitle = f"NXDOMAIN: Domain '{user_input}' not found."
-            self._current_result_records = None
-            self._display_result([], user_input, requested_record_type, current_dns_for_display)
+            self._current_result_records = None # Clear previous results on NXDOMAIN
+            self._display_result(
+                [], user_input, requested_record_type, current_dns_for_display
+            )
         elif isinstance(error, DnsNoAnswerError):
-            logger.info("DNSPage: %s", error_message)
-            self._current_result_records = []
+            logger.info("DNSPage: %s", error_message) # Log full error
+            self._current_result_records = [] # No records found
             self._current_user_input = user_input
             self._current_requested_record_type = requested_record_type
             self._current_dns_servers = current_dns_for_display
-            self._display_result([], user_input, requested_record_type, current_dns_for_display)
-            status_subtitle = f"No {requested_record_type} records found for '{user_input}' (No Answer)."
+            self._display_result(
+                [], user_input, requested_record_type, current_dns_for_display
+            )
+            status_subtitle = (
+                f"No {requested_record_type} records found for '{user_input}' (No Answer)."
+            )
         elif isinstance(error, DnsResolutionTimeoutError):
-            show_global_error(self, error_message)
-            status_subtitle = f"Timeout resolving '{user_input}' for {requested_record_type} records."
-            self._current_result_records = None
-            self._display_result([], user_input, requested_record_type, current_dns_for_display)
-        elif isinstance(error, DnsGenericError) or isinstance(error, DnsClientError):
+            show_global_error(self, error_message) # Show full error to user
+            status_subtitle = (
+                f"Timeout resolving '{user_input}' for {requested_record_type} records."
+            )
+            self._current_result_records = None # Clear results on timeout
+            self._display_result(
+                [], user_input, requested_record_type, current_dns_for_display
+            )
+        elif isinstance(error, (DnsGenericError, DnsClientError)):
             logger.warning(
                 "DNSPage: DNS lookup failed for '%s', type '%s' (%s): %s",
                 user_input, requested_record_type, type(error).__name__, error_message
             )
-            show_global_error(self, error_message)
+            show_global_error(self, error_message) # Show full error
             status_subtitle = f"DNS Error: {error_message.splitlines()[0]}"
-            self._current_result_records = None
-            self._display_result([], user_input, requested_record_type, current_dns_for_display)
-        elif isinstance(error, GLib.Error) and error.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
+            self._current_result_records = None # Clear results on generic DNS error
+            self._display_result(
+                [], user_input, requested_record_type, current_dns_for_display
+            )
+        elif isinstance(error, GLib.Error) and \
+             error.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
             status_subtitle = "Lookup cancelled."
             show_global_toast(self, status_subtitle)
             # Do not clear results on user cancellation, previous results might still be relevant
-        else:
+        else: # Unexpected errors
             logger.exception(
-                "DNSPage: Unexpected error/task error during DNS lookup for '%s', type '%s':", user_input, requested_record_type
+                "DNSPage: Unexpected error during DNS lookup for '%s', type '%s':",
+                user_input, requested_record_type
             )
-            error_message_short = f"An unexpected error occurred: {error_message.splitlines()[0]}"
+            error_message_short = (
+                f"An unexpected error occurred: {error_message.splitlines()[0]}"
+            )
             show_global_error(self, error_message_short)
             status_subtitle = error_message_short
-            self._current_result_records = None
-            self._display_result([], user_input, requested_record_type, current_dns_for_display)
+            self._current_result_records = None # Clear results on unexpected error
+            self._display_result(
+                [], user_input, requested_record_type, current_dns_for_display
+            )
 
         if self.dns_status_row:
             self.dns_status_row.set_subtitle(status_subtitle)
-
 
     def _get_selected_record_type(self) -> str:
         """
@@ -819,14 +886,15 @@ class DNSPage(Gtk.Box):
         if self.dns_record_type_dropdown:
             model = self.dns_record_type_dropdown.get_model()
             selected_index = self.dns_record_type_dropdown.get_selected()
-            if model and selected_index < model.get_n_items(): # type: ignore[union-attr]
-                item_obj = model.get_item(selected_index) # Gtk.StringObject
+            # Ensure model and selected_index are valid before accessing item
+            if model and selected_index >= 0 and selected_index < model.get_n_items():  # type: ignore[union-attr]
+                item_obj = model.get_item(selected_index)  # Gtk.StringObject
                 if isinstance(item_obj, Gtk.StringObject):
                     return item_obj.get_string()
-                elif item_obj is not None: # Should be StringObject, but defensive
+                elif item_obj is not None:  # Should be StringObject, but defensive
                      return str(item_obj)
 
-        logger.warning("DNSPage: Could not get selected record type, defaulting to 'A'.")
+        logger.warning("DNSPage: Could not get selected record type from dropdown, defaulting to 'A'.")
         return "A"
 
     def _clear_error(self) -> None:
@@ -836,7 +904,7 @@ class DNSPage(Gtk.Box):
 
         main_window = self.get_native()
         if main_window and hasattr(main_window, "hide_error") and callable(main_window.hide_error):
-            main_window.hide_error() # type: ignore
+            main_window.hide_error()  # type: ignore
         else:
             logger.debug("DNSPage: Main window or hide_error method not found/callable.")
 
@@ -885,27 +953,39 @@ class DNSPage(Gtk.Box):
         servers_info_row.set_selectable(False)
         self.dns_results_box_container.append(servers_info_row)
 
-        self.dns_results_box_container.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL, margin_top=6, margin_bottom=6))
+        self.dns_results_box_container.append(
+            Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL, margin_top=6, margin_bottom=6)
+        )
 
-        if not result_records and not (isinstance(self._current_dns_task, Gio.Task) and self._current_dns_task.get_cancellable().is_cancelled()): # Only show "no records" if not cancelled
+        # Check if the task was cancelled before deciding to show "no records"
+        task_was_cancelled = False
+        if isinstance(self._current_dns_task, Gio.Task):
+            cancellable = self._current_dns_task.get_cancellable()
+            if cancellable and cancellable.is_cancelled():
+                task_was_cancelled = True
+
+        if not result_records and not task_was_cancelled:
             no_records_message = f"No {record_type.upper()} records found for '{domain_or_ip}'."
-            if record_type.upper() == "PTR" and is_valid_ip(domain_or_ip): # More specific for PTR
-                no_records_message = f"No PTR records found for IP address '{domain_or_ip}'."
-
+            # More specific for PTR
+            if record_type.upper() == "PTR" and is_valid_ip(domain_or_ip):
+                no_records_message = (
+                    f"No PTR records found for IP address '{domain_or_ip}'."
+                )
             no_records_row = Adw.ActionRow(title=no_records_message, selectable=False)
             self.dns_results_box_container.append(no_records_row)
-        else:
-            for record_data in result_records:
-                row = self._create_record_row(record_data)
+        elif result_records: # Only iterate if there are records
+            for record_data_item in result_records:
+                row = self._create_record_row(record_data_item)
                 if row:
                     self.dns_results_box_container.append(row)
+        # If task_was_cancelled and no results, we don't add a "no records" message.
 
-        has_content_to_manage = bool(domain_or_ip) # Enable clear/copy if a query was made, even if no results
+        # Enable clear/copy if a query was made, even if no results or cancelled
+        has_content_to_manage = bool(domain_or_ip)
         if self.dns_clear_results_button:
-            self.dns_clear_results_button.set_sensitive(True)
+            self.dns_clear_results_button.set_sensitive(True) # Always allow clear after a query
         if self.dns_copy_all_results_button:
             self.dns_copy_all_results_button.set_sensitive(has_content_to_manage)
-
 
     def _create_record_row(self, record_data: Dict[str, Any]) -> Optional[Gtk.Widget]:
         """
@@ -923,8 +1003,8 @@ class DNSPage(Gtk.Box):
         """
         record_type_val = record_data.get("type", "").upper()
         name = record_data.get("name", "N/A")
-        ttl = record_data.get("ttl", "N/A") # TTL can sometimes be missing or not applicable
-        rd_class_str = record_data.get("class", "N/A") # Class can sometimes be missing
+        ttl = record_data.get("ttl", "N/A")  # TTL can sometimes be missing or not applicable
+        rd_class_str = record_data.get("class", "N/A")  # Class can sometimes be missing
         base_subtitle = f"Class: {rd_class_str}, TTL: {ttl}"
 
         if record_type_val in ("A", "AAAA"):
@@ -945,8 +1025,12 @@ class DNSPage(Gtk.Box):
                 record_data,
                 record_type_val,
             )
-            unsupported_row = Adw.ActionRow(title=name, subtitle=f"Type: {record_type_val} (Unsupported detailed view)")
-            unsupported_row.set_tooltip_text(f"Raw data: {str(record_data)}") # Show raw data in tooltip
+            unsupported_row = Adw.ActionRow(
+                title=name,
+                subtitle=f"Type: {record_type_val} (Unsupported detailed view)"
+            )
+            # Show raw data in tooltip
+            unsupported_row.set_tooltip_text(f"Raw data: {str(record_data)}")
             return unsupported_row
 
     def trigger_lookup(self) -> None:

--- a/src/http_page.py
+++ b/src/http_page.py
@@ -55,7 +55,7 @@ class HttpErrorType(int, Enum):
     TIMEOUT = 0
     HTTP_ERROR = 1  # Typically for 4xx/5xx status codes
     CONNECTION_ERROR = 2
-    REQUEST_EXCEPTION = 3 # Other requests.RequestException
+    REQUEST_EXCEPTION = 3  # Other requests.RequestException
     GENERIC_UNEXPECTED = 4
     CANCELLED = 5
 
@@ -202,7 +202,7 @@ class HttpPage(Gtk.Box):
         self.header_list_store = Gio.ListStore.new(item_type=HeaderItem)
         selection_model = Gtk.MultiSelection.new(self.header_list_store)
         self.http_column_view.set_model(selection_model)
-        if not self.http_column_view.get_columns(): # Ensure columns are added only once
+        if not self.http_column_view.get_columns():  # Ensure columns are added only once
             header_name_factory = self._create_factory("key")
             header_value_factory = self._create_factory("value", wrap_text=True)
             col_name = Gtk.ColumnViewColumn.new("Header", header_name_factory)
@@ -226,16 +226,18 @@ class HttpPage(Gtk.Box):
             self.clear_results_button.get_style_context().add_class("destructive-action")
         if self.copy_results_button:
             self.copy_results_button.get_style_context().add_class("flat")
-        if self.http_host_header_row: # Ensure it exists before connecting
-            self._on_host_header_changed(self.http_host_header_row) # Initial visual state
-        if self.http_user_agent_row: # Ensure it exists
-            self._on_user_agent_changed_visual_feedback(self.http_user_agent_row, None) # Initial visual state
+        if self.http_host_header_row:  # Ensure it exists before connecting
+            self._on_host_header_changed(self.http_host_header_row)  # Initial visual state
+        if self.http_user_agent_row:  # Ensure it exists
+            self._on_user_agent_changed_visual_feedback(self.http_user_agent_row, None)  # Initial visual state
 
         # Initialize the ColumnView context menu helper
-        if self.http_column_view and self.get_native(): # Ensure ColumnView and window exist
-            self.column_view_helper = Helper(widget=self.http_column_view, parent_window=self.get_native())
+        if self.http_column_view and self.get_native():  # Ensure ColumnView and window exist
+            self.column_view_helper = Helper(
+                widget=self.http_column_view, parent_window=self.get_native()
+            )
 
-        self._hide_results() # Initially no results to show
+        self._hide_results()  # Initially no results to show
 
     def _connect_signals(self) -> None:
         """Connect signals for UI elements to their respective handlers."""
@@ -287,7 +289,7 @@ class HttpPage(Gtk.Box):
                 combo_row.remove_css_class("active-override")
             else:
                 combo_row.add_css_class("active-override")
-        elif selected_item_obj is None and not self._ua_title_to_value_map: # Handle empty model case
+        elif selected_item_obj is None and not self._ua_title_to_value_map:  # Handle empty model case
             combo_row.remove_css_class("active-override")
 
     def _on_copy_results_clicked(self, _button: Gtk.Button) -> None:
@@ -320,7 +322,7 @@ class HttpPage(Gtk.Box):
                     if item.key:
                         lines.append(f"{item.key}: {item.value}")
                     else:
-                        lines.append(f"  {item.value}") # Indent continuation lines for readability
+                        lines.append(f"  {item.value}")  # Indent continuation lines for readability
 
         if not lines:
             show_global_toast(self, "No content formatted for copying.")
@@ -330,7 +332,7 @@ class HttpPage(Gtk.Box):
         try:
             clipboard = Gdk.Display.get_default().get_clipboard()
             if clipboard:
-                clipboard.set_text(text_to_copy) # Using set_text for simplicity
+                clipboard.set_text(text_to_copy)  # Using set_text for simplicity
                 logger.info("Headers copied to clipboard successfully.")
                 show_global_toast(self, "Headers copied to clipboard.")
             else:
@@ -358,12 +360,16 @@ class HttpPage(Gtk.Box):
         url_to_fetch = self._ensure_scheme(original_url)
 
         if not is_valid_url(url_to_fetch):
-            logger.warning("HTTP Page: Invalid URL provided: %s (processed as: %s)", original_url, url_to_fetch)
-            toast_message = "Invalid URL format. Please enter a valid URL (e.g., https://example.com)."
-            show_global_error(self, toast_message) # More prominent for invalid URL
+            logger.warning(
+                "HTTP Page: Invalid URL provided: %s (processed as: %s)", original_url, url_to_fetch
+            )
+            toast_message = (
+                "Invalid URL format. Please enter a valid URL (e.g., https://example.com)."
+            )
+            show_global_error(self, toast_message)  # More prominent for invalid URL
             if self.http_entry_row:
                 self.http_entry_row.add_css_class("error")
-            self._update_column_view_model(None) # Clear previous results
+            self._update_column_view_model(None)  # Clear previous results
             self._set_loading_state(False, "Idle - Invalid URL.")
             return
 
@@ -379,26 +385,31 @@ class HttpPage(Gtk.Box):
             if isinstance(selected_item_obj, Gtk.StringObject):
                 selected_ua_title_in_dropdown = selected_item_obj.get_string()
 
-        if selected_ua_title_in_dropdown and selected_ua_title_in_dropdown != self.SYSTEM_DEFAULT_UA_TITLE:
+        if selected_ua_title_in_dropdown and \
+           selected_ua_title_in_dropdown != self.SYSTEM_DEFAULT_UA_TITLE:
             user_agent_to_send = self._ua_title_to_value_map.get(selected_ua_title_in_dropdown)
             log_msg = f"HTTP Page: Using User-Agent from dropdown: '{selected_ua_title_in_dropdown}'"
-            if user_agent_to_send is None: # Should not happen if map is correct
+            if user_agent_to_send is None:  # Should not happen if map is correct
                  log_msg += " (Warning: value not found in map, sending None)."
             logger.info(log_msg)
         else:
             logger.info("HTTP Page: Using system default User-Agent (requests library default).")
-            user_agent_to_send = None # Explicitly None for requests default
+            user_agent_to_send = None  # Explicitly None for requests default
 
         custom_dns_server = self.settings.get_string("custom-dns-server")
 
         self._http_task_data_for_thread = {
             "url": url_to_fetch,
-            "use_akamai_pragma": self.http_pragma_switch_row.get_active() if self.http_pragma_switch_row else False,
+            "use_akamai_pragma": (
+                self.http_pragma_switch_row.get_active() if self.http_pragma_switch_row else False
+            ),
             "host_header": host_header if host_header else None,
             "user_agent": user_agent_to_send,
             "custom_dns_server": custom_dns_server if custom_dns_server else None,
         }
-        logger.debug("HttpPage: Starting header fetch task with data: %s", self._http_task_data_for_thread)
+        logger.debug(
+            "HttpPage: Starting header fetch task with data: %s", self._http_task_data_for_thread
+        )
 
         if self.current_http_task and not self.current_http_task.is_done():
             try:
@@ -409,8 +420,10 @@ class HttpPage(Gtk.Box):
                 logger.warning("HttpPage: Error cancelling previous HTTP task: %s", e_cancel)
 
         cancellable = Gio.Cancellable()
-        self.current_http_task = Gio.Task.new(self, cancellable, self._fetch_headers_task_done_cb, None)
-        self.current_http_task.set_task_data(self._http_task_data_for_thread) # Store data with the task
+        self.current_http_task = Gio.Task.new(
+            self, cancellable, self._fetch_headers_task_done_cb, self._http_task_data_for_thread
+        )
+        self.current_http_task.set_task_data(None)  # Store data with the task
         self.current_http_task.run_in_thread(self._fetch_headers_task_thread_func)
 
     def _fetch_headers_task_thread_func(
@@ -431,12 +444,18 @@ class HttpPage(Gtk.Box):
         :param cancellable: The :class:`Gio.Cancellable` for this task.
         :type cancellable: Gio.Cancellable
         """
-        # task_data is already set on the task object by the caller
+        # task_data is the data passed to Gio.Task.new(), retrieved by task.get_task_data()
         current_task_data: Dict[str, Any] = task.get_task_data()
         url_to_fetch: str = current_task_data["url"]
 
         if cancellable.is_cancelled():
-            task.return_error(GLib.Error.new_literal(WOES_HTTP_ERROR_DOMAIN, HttpErrorType.CANCELLED.value, "Task cancelled before fetching."))
+            task.return_error(
+                GLib.Error.new_literal(
+                    WOES_HTTP_ERROR_DOMAIN,
+                    HttpErrorType.CANCELLED.value,
+                    "Task cancelled before fetching."
+                )
+            )
             return
 
         fetcher = HttpFetcher(
@@ -445,17 +464,25 @@ class HttpPage(Gtk.Box):
             host_header=current_task_data.get("host_header"),
             user_agent=current_task_data.get("user_agent"),
             custom_dns_server=current_task_data.get("custom_dns_server"),
-            cancellable=cancellable, # Pass cancellable to HttpFetcher
+            cancellable=cancellable,  # Pass cancellable to HttpFetcher
         )
         try:
             processed_data: List[Dict[str, Any]] = fetcher.fetch_headers()
-            if cancellable.is_cancelled(): # Check again after fetch_headers returns
-                task.return_error(GLib.Error.new_literal(WOES_HTTP_ERROR_DOMAIN, HttpErrorType.CANCELLED.value, "Task cancelled after fetching."))
+            if cancellable.is_cancelled():  # Check again after fetch_headers returns
+                task.return_error(
+                    GLib.Error.new_literal(
+                        WOES_HTTP_ERROR_DOMAIN,
+                        HttpErrorType.CANCELLED.value,
+                        "Task cancelled after fetching."
+                    )
+                )
             else:
                 task.return_value(processed_data)
-        except HttpClientError as e: # Catch custom exceptions from HttpFetcher
-            task.get_task_data()["original_exception"] = e
-            task.get_task_data()["original_exception_type_name"] = type(e).__name__
+        except HttpClientError as e:  # Catch custom exceptions from HttpFetcher
+            # Store original exception info for more detailed error handling in the callback
+            if task.get_task_data(): # Ensure task_data exists
+                task.get_task_data()["original_exception"] = e
+                task.get_task_data()["original_exception_type_name"] = type(e).__name__
 
             error_type_map = {
                 HttpRequestTimeoutError: HttpErrorType.TIMEOUT,
@@ -464,17 +491,27 @@ class HttpPage(Gtk.Box):
                 HttpGenericRequestError: HttpErrorType.REQUEST_EXCEPTION,
             }
             glib_error_code = error_type_map.get(type(e), HttpErrorType.GENERIC_UNEXPECTED).value
-            if "cancelled" in str(e).lower(): # Override if cancellation specific message in HttpClientError
+            # Override if cancellation specific message in HttpClientError
+            if "cancelled" in str(e).lower():
                  glib_error_code = HttpErrorType.CANCELLED.value
             task.return_error(GLib.Error.new_literal(WOES_HTTP_ERROR_DOMAIN, glib_error_code, str(e)))
-        except Exception as e: # Catch any other unexpected errors from fetcher
-            logger.exception("HttpPage Task: Unexpected error from HttpFetcher for URL '%s':", url_to_fetch)
-            task.get_task_data()["original_exception"] = e
-            task.get_task_data()["original_exception_type_name"] = type(e).__name__
-            task.return_error(GLib.Error.new_literal(WOES_HTTP_ERROR_DOMAIN, HttpErrorType.GENERIC_UNEXPECTED.value, f"Unexpected internal error: {e}"))
+        except Exception as e:  # Catch any other unexpected errors from fetcher
+            logger.exception(
+                "HttpPage Task: Unexpected error from HttpFetcher for URL '%s':", url_to_fetch
+            )
+            if task.get_task_data(): # Ensure task_data exists
+                task.get_task_data()["original_exception"] = e
+                task.get_task_data()["original_exception_type_name"] = type(e).__name__
+            task.return_error(
+                GLib.Error.new_literal(
+                    WOES_HTTP_ERROR_DOMAIN,
+                    HttpErrorType.GENERIC_UNEXPECTED.value,
+                    f"Unexpected internal error: {e}"
+                )
+            )
 
     def _fetch_headers_task_done_cb(
-        self, source_object: GObject.Object, result: Gio.AsyncResult, user_data: Any = None
+        self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Any = None
     ) -> None:
         """
         Handle completion of the asynchronous HTTP header fetch task.
@@ -491,34 +528,37 @@ class HttpPage(Gtk.Box):
         :type user_data: Any
         """
         # Ensure this callback is for the current task.
-        if not self.current_http_task or not self.current_http_task.matches_async_result(result):
+        # Note: source_object and user_data are GObject/Gio convention, often unused if data is on task.
+        active_task = self.current_http_task
+        if not active_task or not active_task.matches_async_result(result):
             logger.warning("HttpPage: Callback received for an outdated or mismatched HTTP task.")
-            if not self.current_http_task or self.current_http_task.is_done():
+            # If there's no active task or the current one (if any) is done, ensure UI is idle.
+            if not active_task or active_task.is_done():
                 self._set_loading_state(False, "Idle.")
             return
 
-        task_data_from_task_obj: Dict[str, Any] = self.current_http_task.get_task_data()
-        original_url_for_log = task_data_from_task_obj.get("url", "unknown URL")
+        task_data_from_task_obj: Optional[Dict[str, Any]] = active_task.get_task_data()
+        original_url_for_log = "unknown URL"
+        if task_data_from_task_obj:
+            original_url_for_log = task_data_from_task_obj.get("url", original_url_for_log)
 
         try:
-            returned_value = self.current_http_task.propagate_value(result) # This will raise GLib.Error if task failed
+            # This will raise GLib.Error if task failed (e.g., task.return_error was called)
+            returned_value = active_task.propagate_value(result)
 
-            # If propagate_value didn't raise, task was successful.
-            # returned_value should be List[Dict] from thread_func
+            data: Optional[List[Dict[str, Any]]] = None
+            error_msg: Optional[str] = None
+
             if isinstance(returned_value, list):
-                data: List[Dict[str, Any]] = returned_value
-                error_msg = None
-            else: # Should not happen if thread_func returns correctly
+                data = returned_value
+            else:  # Should not happen if thread_func returns correctly (List[Dict])
                 logger.error(
-                    "HttpPage: Unexpected data type '%s' from successful task for URL '%s'.",
-                    type(returned_value),
-                    original_url_for_log
+                    "HttpPage: Unexpected data type '%s' from successful task for URL '%s'. Expected list.",
+                    type(returned_value), original_url_for_log
                 )
-                data = None
                 error_msg = "Received unexpected data format from background task."
 
-            if error_msg:
-                # This block would typically be hit if process_task_result was used and it returned an error string
+            if error_msg: # Error identified from type check
                 show_global_error(self, error_msg)
                 if self.http_entry_row:
                     self.http_entry_row.add_css_class("error")
@@ -534,16 +574,16 @@ class HttpPage(Gtk.Box):
                     if not isinstance(response_data_dict_item, dict):
                         continue
 
-                    url_display = f"URL: {response_data_dict_item.get('url', 'N/A')}" # pyright: ignore[reportUnknownMemberType]
-                    status_code = response_data_dict_item.get("status_code", "N/A") # pyright: ignore[reportUnknownMemberType]
-                    response_type = response_data_dict_item.get("type", "unknown") # pyright: ignore[reportUnknownMemberType] # 'redirect' or 'final'
+                    url_display = f"URL: {response_data_dict_item.get('url', 'N/A')}"
+                    status_code = response_data_dict_item.get('status_code', 'N/A')
+                    response_type = response_data_dict_item.get('type', 'unknown') # 'redirect' or 'final'
                     status_display = f"Status: {status_code} ({str(response_type).capitalize()})"
-                    # For special rows, key is main info, value is parenthesized status
+
                     processed_headers_for_store.append(
                         HeaderItem(key=url_display, value=status_display, is_special_row=True)
                     )
 
-                    headers_for_this_response = response_data_dict_item.get("headers", {}) # pyright: ignore[reportUnknownMemberType]
+                    headers_for_this_response = response_data_dict_item.get("headers", {})
                     if isinstance(headers_for_this_response, dict):
                         for key, value in headers_for_this_response.items():
                             original_value_str = str(value)
@@ -557,27 +597,33 @@ class HttpPage(Gtk.Box):
                                 while True:
                                     idx = current_value_segment.find(";")
                                     if idx != -1:
-                                        part = current_value_segment[:idx+1].strip()
+                                        part = current_value_segment[:idx + 1].strip()
                                         if part:
                                             display_parts.append(part)
-                                        current_value_segment = current_value_segment[idx+1:]
+                                        current_value_segment = current_value_segment[idx + 1:]
                                     else:
                                         part = current_value_segment.strip()
                                         if part:
                                             display_parts.append(part)
                                         break
                             first_part_processed = False
-                            if not display_parts: # If original_value_str was empty or only ";"
-                                processed_headers_for_store.append(HeaderItem(key=str(key), value="", is_special_row=False))
+                            if not display_parts:  # If original_value_str was empty or only ";"
+                                processed_headers_for_store.append(
+                                    HeaderItem(key=str(key), value="", is_special_row=False)
+                                )
                             else:
                                 for part_content in display_parts:
                                     if not first_part_processed:
-                                        processed_headers_for_store.append(HeaderItem(key=str(key), value=part_content, is_special_row=False))
+                                        processed_headers_for_store.append(
+                                            HeaderItem(key=str(key), value=part_content, is_special_row=False)
+                                        )
                                         first_part_processed = True
-                                    else: # Continuation line for a multi-part header
-                                        processed_headers_for_store.append(HeaderItem(key="", value=part_content, is_special_row=False))
+                                    else:  # Continuation line for a multi-part header
+                                        processed_headers_for_store.append(
+                                            HeaderItem(key="", value=part_content, is_special_row=False)
+                                        )
 
-                    if response_type == "redirect" and i < len(data) - 1 : # If redirect and not last item
+                    if response_type == "redirect" and i < len(data) - 1:  # If redirect and not last item
                         processed_headers_for_store.append(
                             HeaderItem(key="--- Redirected To ---", value="", is_special_row=True)
                         )
@@ -588,58 +634,72 @@ class HttpPage(Gtk.Box):
                     self.http_entry_row.remove_css_class("error")
                 self._set_loading_state(False, "Headers loaded successfully.")
             else:
-                # This case (data is None, error_msg is None) should ideally be handled by process_task_result returning an error_msg
-                show_global_error(self, "Failed to process data from background task (data is None).")
+            # This case (data is None, error_msg is None) implies successful task completion
+            # but the thread function returned None, which is unexpected for this specific task.
+            # Or, propagate_value itself returned None without raising GLib.Error.
+            show_global_error(self, "Failed to process data: background task returned None.")
                 if self.http_entry_row:
                     self.http_entry_row.add_css_class("error")
                 self._update_column_view_model(None)
-                self._set_loading_state(False, "Error: Failed to process data.")
+            self._set_loading_state(False, "Error: Failed to process data (task returned None).")
 
-        except GLib.Error as e: # Catch errors propagated by Gio.Task.propagate_value()
-            original_py_exception = task_data_from_task_obj.get("original_exception")
+        except GLib.Error as e:  # Catch errors propagated by Gio.Task.propagate_value()
+            original_py_exception = None
+            if task_data_from_task_obj: # Check if task_data_from_task_obj is not None
+                original_py_exception = task_data_from_task_obj.get("original_exception")
+
             error_to_handle = original_py_exception if original_py_exception else e
-
             error_message = str(error_to_handle)
-            user_facing_error_message = error_message # Default to full message
-            status_subtitle = f"Error: {error_message.splitlines()[0]}"
+            user_facing_error_message = error_message  # Default to full message
+            status_subtitle_main_part = error_message.splitlines()[0]
+            status_subtitle = f"Error: {status_subtitle_main_part}"
 
             if isinstance(error_to_handle, HttpRequestTimeoutError):
-                user_facing_error_message = f"Request timed out for {original_url_for_log}."
+                user_facing_error_message = (
+                    f"Request timed out for {original_url_for_log}."
+                )
                 status_subtitle = "Error: Request Timeout."
             elif isinstance(error_to_handle, HttpConnectionError):
-                # _get_detailed_connection_error_message was part of HttpFetcher,
-                # we use the message from the exception directly.
-                user_facing_error_message = error_message
-                status_subtitle = f"Error: Connection Failed for {original_url_for_log}."
+                user_facing_error_message = error_message  # Already detailed
+                status_subtitle = (
+                    f"Error: Connection Failed for {original_url_for_log}."
+                )
             elif isinstance(error_to_handle, HttpProcessingError):
-                user_facing_error_message = error_message # Already formatted by HttpFetcher
-                url_in_error = error_to_handle.url or original_url_for_log # pyright: ignore[reportUnknownMemberType]
-                status_subtitle = f"Error: HTTP {error_to_handle.status_code} for {url_in_error}" # pyright: ignore[reportUnknownMemberType]
+                user_facing_error_message = error_message  # Already formatted by HttpFetcher
+                url_in_error = getattr(error_to_handle, 'url', None) or original_url_for_log
+                status_code = getattr(error_to_handle, 'status_code', 'Unknown')
+                status_subtitle = f"Error: HTTP {status_code} for {url_in_error}"
             elif isinstance(error_to_handle, HttpGenericRequestError):
                 user_facing_error_message = (
                     f"Request failed for {original_url_for_log}: {error_message}"
                 )
-                status_subtitle = f"Error: Request Failed for {original_url_for_log}"
+                status_subtitle = (
+                    f"Error: Request Failed for {original_url_for_log}"
+                )
             elif isinstance(error_to_handle, HttpClientError) and \
-                 "cancelled" in error_message.lower(): # From HttpFetcher's own cancellation checks
-                 user_facing_error_message = f"Request cancelled for {original_url_for_log}."
+                 "cancelled" in error_message.lower():  # From HttpFetcher's cancellation
+                 user_facing_error_message = (
+                     f"Request cancelled for {original_url_for_log}."
+                 )
                  status_subtitle = "Request Cancelled."
-                 show_global_toast(self, status_subtitle) # Toast for cancellation
-            elif e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED): # Gio cancellation
-                user_facing_error_message = f"Lookup for {original_url_for_log} was cancelled."
-                status_subtitle = "Lookup Cancelled."
-                show_global_toast(self, status_subtitle) # Toast for cancellation
-            else: # Other GLib.Error or unexpected Python exceptions from thread
+                 show_global_toast(self, status_subtitle)  # Toast for cancellation
+            elif e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):  # Gio cancellation
+                user_facing_error_message = (
+                    f"Operation for {original_url_for_log} was cancelled."
+                )
+                status_subtitle = "Operation Cancelled."
+                show_global_toast(self, status_subtitle)  # Toast for cancellation
+            else:  # Other GLib.Error or unexpected Python exceptions from thread
                 logger.exception(
                     "HttpPage: Error processing task result for URL '%s': %s",
                     original_url_for_log, e
                 )
                 user_facing_error_message = (
-                    f"An unexpected error occurred: {str(e).splitlines()[0]}"
+                    f"An unexpected error occurred: {status_subtitle_main_part}"
                 )
                 status_subtitle = "Error: Unexpected."
 
-            # Show error unless it's a cancellation type already handled by a toast
+            # Show error dialog unless it's a cancellation type already handled by a toast
             is_cancellation_by_http_client = (
                 isinstance(error_to_handle, HttpClientError) and
                 "cancelled" in str(error_to_handle).lower()
@@ -976,18 +1036,13 @@ class HttpPage(Gtk.Box):
             self.settings.disconnect(self._gsettings_ua_changed_handler_id)
             self._gsettings_ua_changed_handler_id = 0
 
-        # For other handlers connected with self.settings.connect("changed::key", self.callback_method)
-        # GObject's automatic signal disconnection on dispose should handle them,
-        # but explicit disconnection is safer if IDs were stored.
-        # Example for other direct connections (if they existed and were stored):
-        # self.settings.disconnect_by_func(self._on_color_setting_changed)
-        # self.settings.disconnect_by_func(self._on_global_output_font_changed)
-        # self.settings.disconnect_by_func(self._update_user_agent_model) # For the lambda
-        # Since we don't store all handler IDs, we rely on GObject's cleanup.
-        # Or, more robustly, use self.settings.disconnect_by_func for each.
-        # For now, only the stored ID is explicitly disconnected.
+            # For other handlers connected with self.settings.connect("changed::key", self.callback_method),
+            # GObject's automatic signal disconnection on dispose should handle them.
+            # Explicit disconnection by function (e.g., self.settings.disconnect_by_func(self._on_color_setting_changed))
+            # could be used if handler IDs were not stored, but typically not required if objects are disposed correctly.
+            # Relying on GObject's cleanup for these direct connections.
 
-        super().do_dispose() # Call parent class's dispose method
+        super().do_dispose()  # Call parent class's dispose method
 
     def _create_factory(self, attr_name: str, wrap_text: bool = False) -> Gtk.SignalListItemFactory:
         """
@@ -1011,7 +1066,7 @@ class HttpPage(Gtk.Box):
             if wrap_text:
                 label.set_wrap(True)
                 label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
-                label.set_max_width_chars(80) # Sensible default for wrapped value col
+                label.set_max_width_chars(80)  # Sensible default for wrapped value col
             list_item.set_child(label)
 
         def bind_func_internal(_factory: Gtk.SignalListItemFactory, list_item: Gtk.ListItem) -> None:
@@ -1019,15 +1074,20 @@ class HttpPage(Gtk.Box):
             label_widget = list_item.get_child()
             item_obj = list_item.get_item()
 
-            if not isinstance(label_widget, Gtk.Label): # Should always be a Gtk.Label from setup
-                logger.error("HttpPage _create_factory: Expected Gtk.Label, got %s", type(label_widget))
+            if not isinstance(label_widget, Gtk.Label):  # Should always be a Gtk.Label from setup
+                logger.error(
+                    "HttpPage _create_factory: Expected Gtk.Label, got %s", type(label_widget)
+                )
                 return
-            if not isinstance(item_obj, HeaderItem): # Item in store should be HeaderItem
-                logger.error("HttpPage _create_factory: Expected HeaderItem, got %s", type(item_obj))
-                label_widget.set_text("Error: Invalid item type in model.")
+            if not isinstance(item_obj, HeaderItem):  # Item in store should be HeaderItem
+                logger.error(
+                    "HttpPage _create_factory: Expected HeaderItem, got %s", type(item_obj)
+                )
+                if isinstance(label_widget, Gtk.Label): # Check again to satisfy type checker
+                    label_widget.set_text("Error: Invalid item type in model.")
                 return
 
-            text_to_display = getattr(item_obj, attr_name, "") # Get 'key' or 'value'
+            text_to_display = getattr(item_obj, attr_name, "")  # Get 'key' or 'value'
 
             # Font settings from Pango.FontDescription
             font_family_name = self._output_font_desc.get_family()
@@ -1041,22 +1101,22 @@ class HttpPage(Gtk.Box):
             is_bold: bool = False
             if item_obj.is_special_row:
                 color_to_use = self._special_row_color
-                is_bold = True # Make special rows bold
+                is_bold = True  # Make special rows bold
             elif attr_name == "key":
                 color_to_use = self._header_key_color
-            else: # attr_name == "value"
+            else:  # attr_name == "value"
                 color_to_use = self._header_value_color
 
             escaped_text = GLib.markup_escape_text(str(text_to_display))
 
             # Construct Pango markup string for styling
-            # Breaking down the f-string for readability and to avoid E501
+            # Breaking down the f-string for readability
             markup_font_family = f"font_family='{current_font_family}'"
             markup_size = f"size='{pango_font_size}'"
             markup_foreground = f"foreground='{color_to_use}'"
 
             markup_parts = [
-                f"<span {markup_font_family} {markup_size} {markup_foreground}>"
+                f"<span {markup_font_family} {markup_size} {markup_foreground}>",
             ]
             if is_bold:
                 markup_parts.append("<b>")
@@ -1080,6 +1140,6 @@ class HttpPage(Gtk.Box):
         """
         logger.debug("HTTP fetch triggered by shortcut.")
         if self.http_apply_button and self.http_apply_button.get_sensitive():
-            self.http_apply_button.activate() # This will call _on_entry_row_activated
+            self.http_apply_button.activate()  # This will call _on_entry_row_activated
         else:
             logger.warning("HTTP fetch button not available or not sensitive, cannot trigger fetch.")

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -24,6 +24,7 @@ from .nmap_scanner import NmapScanner, ScanStatus, ScanCancelledError
 from .utils import show_global_error, show_global_toast, process_task_result  # Import new utility
 from .gtk_utils import create_copy_button, create_detail_action_row, create_expander_row
 
+NMAP_SCAN_ERROR_DOMAIN_QUARK = GLib.quark_from_string("nmap-scan-error-domain")
 
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
@@ -159,9 +160,8 @@ class NmapPage(Gtk.Box):
             logger.info("NmapPage disposed, ongoing scan cancelled.")
         if hasattr(self, "scanner") and self.scanner:
             self.scanner.shutdown(wait=False)
-        # GObject.Object.do_dispose(self) # Call parent's dispose if it's a GObject, not needed for Gtk.Widget
+        # GObject.Object.do_dispose(self)  # Call parent's dispose if it's a GObject, not needed for Gtk.Widget
         super().do_dispose()
-
 
     def _init_page_ui(self):
         self.nmap_host_listbox.bind_model(self.nmap_target_listbox_store, self._create_target_listbox_row)
@@ -280,7 +280,7 @@ class NmapPage(Gtk.Box):
         if not params:
             logger.error("NmapPage: _run_nmap_scan_thread_func: _current_nmap_scan_params is None.")
             task.return_new_error_literal(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN),
+                NMAP_SCAN_ERROR_DOMAIN_QUARK,
                 NmapScanErrorType.UNEXPECTED.value,
                 "Internal error: Scan parameters not found.",
             )
@@ -288,7 +288,7 @@ class NmapPage(Gtk.Box):
         target = params["target"]
         if cancellable and cancellable.is_cancelled():
             task.return_new_error_literal(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN),
+                NMAP_SCAN_ERROR_DOMAIN_QUARK,
                 NmapScanErrorType.CANCELLED.value,
                 "Scan cancelled before start.",
             )
@@ -297,29 +297,36 @@ class NmapPage(Gtk.Box):
             nm = self.scanner.run_nmap_scan(params, cancellable=cancellable)
             if cancellable and cancellable.is_cancelled():
                 task.return_new_error_literal(
-                    GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN),
+                    NMAP_SCAN_ERROR_DOMAIN_QUARK,
                     NmapScanErrorType.CANCELLED.value,
                     "Scan cancelled during operation.",
                 )
             else:
-                task.return_value(nm)
+                # nm is nmap.PortScanner object
+                results_map = page_instance.scanner.convert_results_to_yaml(nm)
+                all_hosts_list = nm.all_hosts()
+                task.return_value({"results_map": results_map, "all_hosts": all_hosts_list})
         except ScanCancelledError as e:
             logger.info("Nmap scan for %s was cancelled: %s", target, e)
             task.return_new_error_literal(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.CANCELLED.value, str(e)
+                NMAP_SCAN_ERROR_DOMAIN_QUARK, NmapScanErrorType.CANCELLED.value, str(e)
             )
         except nmap.PortScannerError as e:
             logger.exception("Nmap PortScannerError for %s:", target)
             task.return_new_error_literal(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN),
+                NMAP_SCAN_ERROR_DOMAIN_QUARK,
                 NmapScanErrorType.SCAN_FAILED.value,
                 f"Nmap scan error: {e}",
             )
         except Exception as e:
-            logger.exception("Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__)
+            logger.exception(
+                "Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__
+            )
             error_msg_details = f"Scan failed unexpectedly: {e}"
             task.return_new_error_literal(
-                GLib.quark_from_string(NMAP_SCAN_ERROR_DOMAIN), NmapScanErrorType.UNEXPECTED.value, error_msg_details
+                NMAP_SCAN_ERROR_DOMAIN_QUARK,
+                NmapScanErrorType.UNEXPECTED.value,
+                error_msg_details
             )
         finally:
             logger.info("Nmap scan thread finished for %s.", target)
@@ -341,31 +348,38 @@ class NmapPage(Gtk.Box):
             if error_msg:
                 # Specific NmapPage handling for "cancelled" if desired for UI
                 if "cancel" in error_msg.lower():  # Basic check
-                    self._set_scan_status(ScanStatus.IDLE, f"Scan for {original_target} cancelled.")
+                    self._set_scan_status(
+                        ScanStatus.IDLE, f"Scan for {original_target} cancelled."
+                    )
                     self._clear_results()  # Clear results on cancel for NmapPage
                 else:
                     self._handle_scan_error(original_target, error_msg)
-            elif data is not None:
-                nm_results_final: Optional[nmap.PortScanner] = None
-                if isinstance(data, nmap.PortScanner):
-                    nm_results_final = data
-                elif hasattr(data, "value") and isinstance(
-                    data.value, nmap.PortScanner
-                ):  # Handle GObject.Value wrapping
-                    nm_results_final = data.value
+            elif data is not None:  # data is the result from propagate_value
+                if isinstance(data, dict) and "results_map" in data and "all_hosts" in data:
+                    results_map_final = data["results_map"]
+                    all_hosts_final = data["all_hosts"]
+                    GLib.idle_add(self._update_results_view, all_hosts_final, results_map_final)
+                    self._set_scan_status(
+                        ScanStatus.COMPLETE,
+                        f"Scan complete for {original_target}. {len(all_hosts_final)} host(s) found."
+                    )
                 else:
-                    logger.error(f"NmapPage: Unexpected data type from process_task_result: {type(data)}")
-                    self._handle_scan_error(original_target, "Scan returned an unexpected data type.")
-
-            if nm_results_final:
-                self._process_scan_results(nm_results_final, original_target)
-            # This else corresponds to 'elif data is not None', so it means data is None.
-            # The case where error_msg is None AND data is None.
-            else:  # No error, but data is None
-                logger.error(
-                    f"NmapPage: Scan for {original_target} resulted in no data and no error_msg from process_task_result."
+                    logger.error(
+                        f"NmapPage: Unexpected data type from process_task_result: {type(data)}, "
+                        f"expected dict with results_map and all_hosts."
+                    )
+                    self._handle_scan_error(
+                        original_target, "Scan returned an unexpected data type."
+                    )
+            elif not error_msg:  # data is None and no error_msg
+                 logger.error(
+                    f"NmapPage: Scan for {original_target} resulted in no data and "
+                    f"no error_msg from process_task_result."
                 )
-                self._handle_scan_error(original_target, "Scan completed with no data and no error.")
+                 self._handle_scan_error(
+                     original_target, "Scan completed with no data and no error."
+                 )
+            # error_msg case is already handled by the existing if/else after process_task_result
         finally:
             # Ensure task references are cleared and UI is reset regardless of success or failure.
             self.current_nmap_task = None  # Already cleared, but good for safety.
@@ -377,26 +391,6 @@ class NmapPage(Gtk.Box):
             if hasattr(self, "nmap_cancel_scan_button") and self.nmap_cancel_scan_button:
                 self.nmap_cancel_scan_button.set_sensitive(False)
                 self.nmap_cancel_scan_button.set_visible(False)
-
-    def _process_scan_results(self, nm: nmap.PortScanner, original_target: str) -> None:
-        hosts_found = nm.all_hosts()
-        if not hosts_found:
-            logger.warning("No hosts found in Nmap results for target %s.", original_target)
-            self._set_scan_status(
-                ScanStatus.COMPLETE, f"Scan complete for {original_target}. No hosts found or responsive."
-            )
-            self._clear_dynamic_details()
-            self.nmap_detail_placeholder.set_title("No Responsive Hosts")
-            self.nmap_detail_placeholder.set_description(
-                (f"The Nmap scan for '{original_target}' did not find any responsive hosts.")
-            )
-            self.nmap_detail_placeholder.set_visible(True)
-            return
-        results_yaml_map: dict[str, str] = self.scanner.convert_results_to_yaml(nm)
-        GLib.idle_add(self._update_results_view, hosts_found, results_yaml_map)
-        self._set_scan_status(
-            ScanStatus.COMPLETE, f"Scan complete for {original_target}. {len(hosts_found)} host(s) found."
-        )
 
     def _handle_scan_error(self, target: str, error_message: str) -> None:
         show_global_error(self, f"Error scanning {target}: {error_message}")
@@ -456,23 +450,26 @@ class NmapPage(Gtk.Box):
             if hasattr(current_parent, "remove"):
                 current_parent.remove(self.nmap_output_scrolled_window)
             elif (
-                hasattr(current_parent, "set_child") and current_parent.get_child() == self.nmap_output_scrolled_window
+                hasattr(current_parent, "set_child") and
+                current_parent.get_child() == self.nmap_output_scrolled_window
             ):
                 current_parent.set_child(None)
         expander.add_row(self.nmap_output_scrolled_window)
         self.nmap_detail_box.append(expander)
 
-    def _on_copy_host_summary_clicked(self, summary_text: str):  # This is now directly connected by create_copy_button
-        # The actual copy logic is handled by gtk_utils._copy_to_clipboard via create_copy_button
+    def _on_copy_host_summary_clicked(self, summary_text: str):  # This is now directly connected
+        # The actual copy logic is handled by gtk_utils._copy_to_clipboard via create_copy_button.
         # This method can be removed if no other logic is needed here.
-        # For now, keeping it to show it's acknowledged, but it's effectively bypassed.
         if not summary_text:
             show_global_toast(self, "No summary text available to copy.")
             return
-        show_global_toast(self, "Host summary copied to clipboard.")  # Feedback, actual copy done by util
+        # Feedback, actual copy done by util
+        show_global_toast(self, "Host summary copied to clipboard.")
 
     def _add_host_details_expander(self, host_data: Dict[str, Any], host_key: str):
-        expander = create_expander_row(title=f"Host Information - {host_key}", initially_expanded=True)
+        expander = create_expander_row(
+            title=f"Host Information - {host_key}", initially_expanded=True
+        )
         status_info = host_data.get("status", {})
         status_value = f"{status_info.get('state', 'N/A')} (Reason: {status_info.get('reason', 'N/A')})"
         expander.add_row(
@@ -627,7 +624,7 @@ class NmapPage(Gtk.Box):
             self.results_by_host[host_key] = yaml_data
         if self.nmap_target_listbox_store.get_n_items() > 0:
             self.nmap_host_listbox.select_row(self.nmap_host_listbox.get_row_at_index(0))
-        else:  # Should not happen if hosts list is not empty
+        else:  # Should not happen if hosts list is not empty / results_map has items
             self._clear_dynamic_details()
             self.nmap_detail_placeholder.set_title("No Hosts Available")
             self.nmap_detail_placeholder.set_description("No host data to display.")
@@ -821,8 +818,8 @@ class NmapPage(Gtk.Box):
             logger.warning("Nmap scan button not available or not sensitive, cannot trigger scan.")
 
 
-NMAP_SCAN_ERROR_DOMAIN = "nmap-scan-error-domain"
-
+# NMAP_SCAN_ERROR_DOMAIN is defined by its quark NMAP_SCAN_ERROR_DOMAIN_QUARK
+# No separate string constant needed if only quark is used.
 
 class NmapScanErrorType(int, Enum):
     """

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -20,6 +20,8 @@ from gi.repository import Gtk, Adw, Gio, GLib, GObject, Gdk, Pango
 from .constants import RESOURCE_PREFIX, APP_ID
 from .utils import show_global_error, show_global_toast, is_valid_url, process_task_result
 
+WEB_SCAN_ERROR_DOMAIN_QUARK = GLib.quark_from_string("web-scan-error-domain")
+
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
@@ -127,7 +129,7 @@ class WebScanPage(Gtk.Box):
         self.current_web_scan_task: Optional[Gio.Task] = None
         self.current_web_scan_cancellable: Optional[Gio.Cancellable] = None
         self.current_nikto_process: Optional[subprocess.Popen[str]] = None
-        self._current_webscan_params: Optional[WebScanParameters] = None # Use TypedDict
+        self._current_webscan_params: Optional[WebScanParameters] = None  # Use TypedDict
         self.settings: Gio.Settings = Gio.Settings.new(APP_ID)
         self.style_manager: Adw.StyleManager = Adw.StyleManager.get_default()
 
@@ -214,11 +216,19 @@ class WebScanPage(Gtk.Box):
             size_in_points = size_in_pango_units / Pango.SCALE
         else:  # Default to a reasonable size if Pango size is 0 or invalid
             size_in_points = 10.0
-            logger.warning(f"WebScanPage: Pango font size was {size_in_pango_units}, defaulting to {size_in_points}pt.")
+            logger.warning(
+                f"WebScanPage: Pango font size was {size_in_pango_units}, "
+                f"defaulting to {size_in_points}pt."
+            )
 
         effective_font_family = font_family if font_family else "Monospace"
 
-        css = f"textview#webscan-output-textview {{ font-family: '{effective_font_family}'; font-size: {size_in_points:.1f}pt; }}"
+        css = (
+            f"textview#webscan-output-textview {{ "
+            f"font-family: '{effective_font_family}'; "
+            f"font-size: {size_in_points:.1f}pt; "
+            f"}}"
+        )
         try:
             self.font_css_provider.load_from_string(css)
         except GLib.Error as e:  # Catch potential errors from load_from_string
@@ -427,10 +437,12 @@ class WebScanPage(Gtk.Box):
                 self.current_web_scan_cancellable.cancel()
 
         self.current_web_scan_cancellable = Gio.Cancellable()
-        task = Gio.Task.new(self, self.current_web_scan_cancellable, self._on_scan_task_done, None)
+        task = Gio.Task.new(
+            self, self.current_web_scan_cancellable, self._on_scan_task_done, None
+        )
         self.current_web_scan_task = task
 
-        task_data_for_thread: WebScanParameters = { # Use TypedDict
+        task_data_for_thread: WebScanParameters = {  # Use TypedDict
             "target_url": target_url,
             "force_ssl": self.force_ssl_switch.get_state(),
             "cgi_vulns": self.cgi_vulns_switch.get_state(),
@@ -469,9 +481,11 @@ class WebScanPage(Gtk.Box):
         scan_params = page_instance._current_webscan_params
 
         if not scan_params:
-            logger.error("WebScanPage: _run_scan_task_thread_func: _current_webscan_params is None.")
+            logger.error(
+                "WebScanPage: _run_scan_task_thread_func: _current_webscan_params is None."
+            )
             task.return_new_error_literal(
-                GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                WEB_SCAN_ERROR_DOMAIN_QUARK,
                 WebScanErrorType.GENERIC.value,
                 "Missing scan parameters in thread.",
             )
@@ -517,9 +531,12 @@ class WebScanPage(Gtk.Box):
 
         if is_file_required:
             if not output_filename:
-                logger.error("A Nikto output format requiring a filename was selected, but no filename was provided.")
+                logger.error(
+                    "A Nikto output format requiring a filename was selected, "
+                    "but no filename was provided."
+                )
                 task.return_new_error_literal(
-                    GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                    WEB_SCAN_ERROR_DOMAIN_QUARK,
                     WebScanErrorType.GENERIC.value,
                     "Output format requires a filename, but none was provided.",
                 )
@@ -574,7 +591,7 @@ class WebScanPage(Gtk.Box):
         try:
             if cancellable.is_cancelled():
                 task.return_new_error_literal(
-                    GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                    WEB_SCAN_ERROR_DOMAIN_QUARK,
                     WebScanErrorType.CANCELLED.value,
                     "Scan cancelled before Nikto process start.",
                 )
@@ -600,7 +617,7 @@ class WebScanPage(Gtk.Box):
                         except Exception as e_term:
                             logger.error(f"Error terminating Nikto process: {e_term}")
                     task.return_new_error_literal(
-                        GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                        WEB_SCAN_ERROR_DOMAIN_QUARK,
                         WebScanErrorType.CANCELLED.value,
                         "Scan cancelled by user.",
                     )
@@ -729,12 +746,14 @@ class WebScanPage(Gtk.Box):
             if process.returncode not in [0, 1]:
                 error_output_detail = main_report_content if main_report_content else (aux_output or "")
                 logger.error(
-                    f"Nikto process finished with an unexpected error code {process.returncode}. Output/Stderr: {error_output_detail[:500]}..."
+                    f"Nikto process finished with an unexpected error code {process.returncode}. "
+                    f"Output/Stderr: {error_output_detail[:500]}..."
                 )
                 task.return_new_error_literal(
-                    GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                    WEB_SCAN_ERROR_DOMAIN_QUARK,
                     WebScanErrorType.GENERIC.value,
-                    f"Nikto execution error (code {process.returncode}). Output (if any):\n{error_output_detail}",
+                    f"Nikto execution error (code {process.returncode}). "
+                    f"Output (if any):\n{error_output_detail}",
                 )
                 return
 
@@ -770,23 +789,21 @@ class WebScanPage(Gtk.Box):
                     aux_output = instructional_message.strip()
                 logger.info("Appended RFIURL instructional message to aux_output.")
 
-            task.return_value(
-                (
-                    str(main_report_content) if main_report_content is not None else "",
-                    str(aux_output) if aux_output is not None else None,
-                )
-            )
+            task.return_value({
+                "stdout": str(main_report_content) if main_report_content is not None else "",
+                "stderr": str(aux_output) if aux_output is not None else None
+            })
         except FileNotFoundError:
             logger.error("Nikto command not found. Ensure it's in PATH.")
             task.return_new_error_literal(
-                GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN),
+                WEB_SCAN_ERROR_DOMAIN_QUARK,
                 WebScanErrorType.NIKTO_NOT_FOUND.value,
                 "Nikto command not found. Please ensure it is installed and in your system's PATH.",
             )
         except Exception as e:
             logger.exception(f"An unexpected error occurred during Nikto scan task: {e}")
             task.return_new_error_literal(
-                GLib.quark_from_string(WEB_SCAN_ERROR_DOMAIN), WebScanErrorType.GENERIC.value, str(e)
+                WEB_SCAN_ERROR_DOMAIN_QUARK, WebScanErrorType.GENERIC.value, str(e)
             )
         finally:
             self.current_nikto_process = None
@@ -829,58 +846,53 @@ class WebScanPage(Gtk.Box):
                 self._update_textview(None, f"Error: {error_msg}", is_error_message=True)
 
             elif returned_data is not None:
-                s_out, s_err = None, None # Initialize
-                if isinstance(returned_data, tuple) and len(returned_data) == 2:
-                    s_out, s_err = returned_data
-                elif (
-                    hasattr(returned_data, "value")
-                    and isinstance(returned_data.value, tuple)
-                    and len(returned_data.value) == 2
-                ):
-                    s_out, s_err = returned_data.value
+                final_stdout: Optional[str] = None
+                final_stderr: Optional[str] = None
+                if isinstance(returned_data, dict):
+                    s_out = returned_data.get("stdout")
+                    s_err = returned_data.get("stderr")
+
+                    final_stdout = str(s_out) if s_out is not None else ""
+                    # Newlines should already be actual \n from the thread function
+                    # final_stdout = final_stdout.replace("\\n", "\n") # Already done in thread if necessary
+
+                    final_stderr = str(s_err) if s_err is not None else None # Keep None if it was None
+                    # Newlines should already be actual \n from the thread function
+                    # if final_stderr:
+                    #    final_stderr = final_stderr.replace("\\n", "\n") # Already done in thread if necessary
                 else:
                     logger.error(
-                        f"Nikto scan for {target_url} returned unexpected data format from process_task_result: {type(returned_data)}"
+                        f"Nikto scan for {target_url} returned unexpected data format from process_task_result: {type(returned_data)}, expected dict."
                     )
                     show_global_error(self, "Scan returned unexpected data format.")
                     self._update_textview(None, "Error: Scan returned unexpected data format.", is_error_message=True)
-                    # s_out, s_err remain None
-
-                final_stdout: Optional[str] = None
-                if s_out is None:
-                    final_stdout = ""
-                elif not isinstance(s_out, str):
-                    final_stdout = str(s_out)
-                else:
-                    final_stdout = s_out
-                if final_stdout:
-                    final_stdout = final_stdout.replace("\\n", "\n")
-
-                final_stderr: Optional[str] = None
-                if s_err is not None:
-                    if not isinstance(s_err, str):
-                        final_stderr = str(s_err)
-                    else:
-                        final_stderr = s_err
-                    if final_stderr:
-                        final_stderr = final_stderr.replace("\\n", "\n")
+                    # final_stdout, final_stderr remain None
 
                 self._update_textview(final_stdout, final_stderr, is_error_message=False)
 
                 if self.webscan_status_action_row:
-                    if final_stdout or final_stderr:
-                        self.webscan_status_action_row.set_subtitle("Scan complete. See results below.")
-                    else:
-                        self.webscan_status_action_row.set_subtitle("Scan complete. No output received.")
-            else:  # Handles (no error_msg, no returned_data)
-                logger.error(f"Nikto scan for {target_url} resulted in no data and no error_msg from process_task_result.")
+                    if final_stdout or final_stderr:  # Check if there's any content at all
+                        self.webscan_status_action_row.set_subtitle(
+                            "Scan complete. See results below."
+                        )
+                    else:  # Both are None or empty string
+                        self.webscan_status_action_row.set_subtitle(
+                            "Scan complete. No output received."
+                        )
+            elif not error_msg:  # returned_data is None and no error_msg
+                logger.error(
+                    f"Nikto scan for {target_url} resulted in no data and no error_msg from "
+                    f"process_task_result."
+                )
                 show_global_error(self, "Scan completed with no data and no error.")
                 self._update_textview(None, "Error: Scan completed with no data.", is_error_message=True)
                 if self.webscan_status_action_row:
                     self.webscan_status_action_row.set_subtitle("Scan finished with no data.")
-        except Exception as e: # Catch-all for unexpected issues in result processing
+        except Exception as e:  # Catch-all for unexpected issues in result processing
             logger.exception(f"Unexpected error processing scan results for {target_url}: {e}")
-            show_global_error(self, f"Unexpected error processing results: {str(e).splitlines()[0]}")
+            show_global_error(
+                self, f"Unexpected error processing results: {str(e).splitlines()[0]}"
+            )
             if self.webscan_status_action_row:
                 self.webscan_status_action_row.set_subtitle("Error processing results.")
         finally:
@@ -894,7 +906,7 @@ class WebScanPage(Gtk.Box):
 
             if self.webscan_status_action_row:
                 current_subtitle = self.webscan_status_action_row.get_subtitle()
-                if current_subtitle == "Scanning...": # Only override if it was "Scanning..."
+                if current_subtitle == "Scanning...":  # Only override if it was "Scanning..."
                     self.webscan_status_action_row.set_subtitle("Scan finished.")
 
             self.current_web_scan_task = None
@@ -967,9 +979,8 @@ class WebScanPage(Gtk.Box):
         else:
             logger.warning("Webscan scan button not available or not sensitive, cannot trigger scan.")
 
-
-WEB_SCAN_ERROR_DOMAIN = "web-scan-error-domain"
-
+# WEB_SCAN_ERROR_DOMAIN is defined by its quark WEB_SCAN_ERROR_DOMAIN_QUARK
+# No separate string constant needed if only quark is used.
 
 class WebScanErrorType(int, Enum):
     """


### PR DESCRIPTION
This commit addresses several issues I identified from a debug log:

- HttpPage/DNSPage: I fixed a ValueError when calling Gio.Task.set_task_data() by passing complex data to Gio.Task.new() instead and using None for set_task_data().
- NmapPage/WebScanPage: I fixed a TypeError with Gio.Task.propagate_value() by ensuring data returned from task threads is a simple dictionary, making it GVariant-compatible. This involved changing the return type of _run_nmap_scan_thread_func (nmap_page.py) and _run_scan_task_thread_func (webscan_page.py) to dictionaries and updating the respective task completion callbacks.
- NmapPage: The UnboundLocalError for `nm_results_final` was implicitly resolved by my refactoring of the Nmap result handling.
- Preferences UI: I verified that the unescaped ampersand warning for "Theme & Font Size" in preferences.ui was not applicable as the ampersand was already correctly escaped.
- GtkBox Warnings: I investigated GtkBox property warnings (hadjustment, etc.). These are likely internal to GTK/PyGObject or relate to template processing and were not directly addressable in your application code.
- PEP8 Compliance: I applied various PEP8 fixes (line length, spacing) to the modified Python files (http_page.py, dns_page.py, nmap_page.py, webscan_page.py).