### PR TITLE
Fix IndentationError in dns_page.py and verify syntax

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -721,7 +721,7 @@ class DNSPage(Gtk.Box):
         if not active_task or not active_task.matches_async_result(result):
             logger.warning("DNSPage: Callback received for an outdated or mismatched DNS task.")
             if not active_task or active_task.is_done():  # If no current task or it's done
-            self._set_loading_state(False, "Idle.")
+                self._set_loading_state(False, "Idle.")
             return
 
         # Retrieve operational data from instance variable


### PR DESCRIPTION
This commit addresses an IndentationError found in src/dns_page.py in the _perform_lookup_done_cb method. A line of code was not correctly indented under an 'if' statement.

The indentation has been corrected.

Additionally, a syntax check was performed on the following files to ensure no further syntax errors were present after recent modifications:
- src/http_page.py
- src/dns_page.py
- src/nmap_page.py
- src/webscan_page.py
- src/utils.py
- src/window.py
- src/main.py All checked files compiled successfully.