### PR TITLE
Fix NameError in dns_page.py and improve imports/dependencies

### DIFF
--- a/src/dns_page.py
+++ b/src/dns_page.py
@@ -9,6 +9,7 @@ DNS lookups are performed asynchronously to maintain UI responsiveness.
 """
 
 import logging
+from enum import Enum # Add missing import
 from typing import Optional, Any, List, Dict, Final  # Added Final
 
 import gi

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -27,7 +27,7 @@ import nmap
 from nmap import PortScannerError
 import yaml
 
-from .utils import is_valid_ip, is_valid_domain
+from utils import is_valid_ip, is_valid_domain # Changed from relative to direct
 
 
 class ScanOptions(Enum):


### PR DESCRIPTION
This commit addresses the following issues:

- NameError: I fixed a NameError in src/dns_page.py by adding the missing 'from enum import Enum' statement. The DnsLookupErrorType class requires this import.

- ImportError: I corrected an import statement in src/nmap_scanner.py. I changed a potentially problematic relative import to a direct one to resolve an ImportError during testing.

- Dependencies: Implicitly, this round of fixes highlighted missing dependencies (dnspython, python-nmap, PyYAML) which I handled. While not a code change in this commit, their resolution is part of this correction cycle.

I performed a general syntax check and an import test on key modules to improve confidence in stability.