### PR TITLE
Fix ImportError in nmap_scanner.py

### DIFF
--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -27,7 +27,7 @@ import nmap
 from nmap import PortScannerError
 import yaml
 
-from utils import is_valid_ip, is_valid_domain # Changed from relative to direct
+from .utils import is_valid_ip, is_valid_domain # Changed back to relative import
 
 
 class ScanOptions(Enum):


### PR DESCRIPTION
I reverted an incorrect import statement in src/woes/nmap_scanner.py. The import for 'is_valid_ip' and 'is_valid_domain' from the local utils module was changed from 'from utils import ...' back to the correct relative import 'from .utils import ...'.

This ensures that nmap_scanner.py correctly imports your application's own 'utils.py' module from within the 'woes' package, rather than attempting to import a potentially conflicting system-level 'utils' package. This resolves the ImportError that was causing your application to fail at startup.