### PR TITLE
Fix: Attempt to resolve SyntaxError in nmap_page.py

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -323,11 +323,7 @@ class NmapPage(Gtk.Box):
                 "Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__
             )
             error_msg_details = f"Scan failed unexpectedly: {e}"
-            task.return_new_error_literal(
-                NMAP_SCAN_ERROR_DOMAIN_QUARK,
-                NmapScanErrorType.UNEXPECTED.value,
-                error_msg_details
-            )
+            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN_QUARK, NmapScanErrorType.UNEXPECTED.value, error_msg_details)
         finally:
             logger.info("Nmap scan thread finished for %s.", target)
 


### PR DESCRIPTION
The traceback indicated a `SyntaxError: invalid syntax` on the `finally:` line within the `_run_nmap_scan_thread_func` method in `src/nmap_page.py`.

A visual inspection of the code did not reveal an obvious syntax error. This commit reformats the multi-line `task.return_new_error_literal()` call within the preceding `except Exception as e:` block to be a single line.

This is a speculative fix, based on the possibility that the Python parser in the specific execution environment might have issues with the multi-line formatting of that particular call in that context, leading to the `finally` keyword being misinterpreted.