### PR TITLE
I've commented out a problematic `finally` block in `nmap_page.py` to…

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -323,9 +323,13 @@ class NmapPage(Gtk.Box):
                 "Unexpected exception in Nmap scan task for %s (%s):", target, type(e).__name__
             )
             error_msg_details = f"Scan failed unexpectedly: {e}"
-            task.return_new_error_literal(NMAP_SCAN_ERROR_DOMAIN_QUARK, NmapScanErrorType.UNEXPECTED.value, error_msg_details)
-        finally:
-            logger.info("Nmap scan thread finished for %s.", target)
+            task.return_new_error_literal(
+                NMAP_SCAN_ERROR_DOMAIN_QUARK,
+                NmapScanErrorType.UNEXPECTED.value,
+                error_msg_details
+            )
+        # finally:
+            # logger.info("Nmap scan thread finished for %s.", target)
 
     def _nmap_scan_task_done_cb(
         self, _source_object: GObject.Object, result: Gio.AsyncResult, _user_data: Optional[Any]


### PR DESCRIPTION
… help identify the source of a persistent `SyntaxError`. The error originally occurred on the `finally:` line in the `_run_nmap_scan_thread_func` method in `src/nmap_page.py`.

In this change, the `finally:` keyword and its content have been commented out. I'm doing this to observe how the error message and its location change. This will help determine if the issue is with the `finally` clause itself or the preceding `try`/`except` block.