### PR TITLE
Fix: Resolve Gtk-CRITICAL 'Invalid object type' error for page widgets.

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -21,6 +21,10 @@ from .constants import (
     TEXT_SCALING_FACTOR_KEY,
 )
 from .style_utils import apply_font_size, apply_theme
+from .http_page import HttpPage
+from .nmap_page import NmapPage
+from .dns_page import DNSPage
+from .webscan_page import WebScanPage
 
 
 gi.require_version("Adw", "1")


### PR DESCRIPTION
I added missing imports for HttpPage, NmapPage, DNSPage, and WebScanPage to `src/window.py`. These imports ensure that the custom page widget types are known to the GObject type system before the WoesWindow UI template is processed, resolving the "Invalid object type" error that occurred during template building.