### PR TITLE
Fix: Improve Nmap results display and use standard Adwaita colors

### DIFF
--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -710,8 +710,8 @@ class NmapPage(Gtk.Box):
         :type host_key: str
         :rtype: None
         """
-        expander = Adw.ExpanderRow(title=f"Text Scan Summary - {host_key}")
-        expander.set_expanded(True)
+        expander = Adw.ExpanderRow(title=f"Scripts & Host Summary - {host_key}")
+        expander.set_expanded(False)
         human_readable_summary = self._generate_human_readable_host_summary(host_data_dict)
 
         # Ensure the textview's buffer is cleared and new text is set
@@ -867,7 +867,7 @@ class NmapPage(Gtk.Box):
         if not osmatch_data:
             return
         expander = Adw.ExpanderRow(title=f"Operating System Detection - {host_key}")
-        expander.set_expanded(True)
+        expander.set_expanded(False)
         os_details_added = False
         for match in osmatch_data:
             name = match.get("name", "N/A")
@@ -957,7 +957,7 @@ class NmapPage(Gtk.Box):
         :rtype: None
         """
         self.status_row.set_subtitle(message)
-        status_css_classes = ["success-color", "warning-color", "error-color", "accent-color"]
+        status_css_classes = ["success", "warning", "error", "accent"]
         style_context = self.status_row.get_style_context()
         for css_class in status_css_classes:
             style_context.remove_class(css_class)
@@ -965,7 +965,7 @@ class NmapPage(Gtk.Box):
             self.scan_spinner.set_visible(True)
             self.scan_spinner.start()
             self.status_row.set_title("Scanning...")
-            style_context.add_class("accent-color")
+            style_context.add_class("accent")
             if self.nmap_apply_button:
                 self.nmap_apply_button.set_sensitive(False)
             if hasattr(self, "nmap_cancel_scan_button") and self.nmap_cancel_scan_button:
@@ -982,10 +982,10 @@ class NmapPage(Gtk.Box):
 
             if status_type == ScanStatus.COMPLETE:
                 self.status_row.set_title("Scan Complete")
-                style_context.add_class("success-color")
+                style_context.add_class("success")
             elif status_type == ScanStatus.FAILED:
                 self.status_row.set_title("Scan Failed")
-                style_context.add_class("error-color")
+                style_context.add_class("error")
             elif status_type == ScanStatus.IDLE:
                 self.status_row.set_title("Idle")
             else:
@@ -1110,57 +1110,9 @@ class NmapPage(Gtk.Box):
                     formatted_output = "\n".join([f"    {line.strip()}" for line in script_output.strip().split("\n")])
                     summary_lines.append(f"  Script: {script_id}\n{formatted_output}")
 
-        ports_data = []
-        for proto in ["tcp", "udp", "sctp", "ip"]:
-            if proto_data := host_data_dict.get(proto):
-                if isinstance(proto_data, dict):
-                    for port_id, port_info in proto_data.items():
-                        p_state = port_info.get("state", "N/A")
-                        if p_state not in ["closed", "filtered out"]:
-                            p_name, p_product, p_version, p_reason = (
-                                port_info.get(k, "") for k in ["name", "product", "version", "reason"]
-                            )
-                            port_str = f"{port_id}/{proto.upper():<4} {p_state:<10} {p_name}"
-                            if p_product:
-                                port_str += f" {p_product}"
-                            if p_version:
-                                port_str += f" {p_version}"
-                            if p_reason:
-                                port_str += f" (reason: {p_reason})"
-                            ports_data.append(port_str)
-                        if port_scripts := port_info.get("script"):
-                            if isinstance(port_scripts, dict):
-                                for script_id, script_output in port_scripts.items():
-                                    if script_output and isinstance(script_output, str):
-                                        formatted_script_output = "\n".join(
-                                            [
-                                                f"  |_{script_id}: {line.strip()}" if i == 0 else f"  | {line.strip()}"
-                                                for i, line in enumerate(script_output.strip().split("\n"))
-                                            ]
-                                        )
-                                        ports_data.append(formatted_script_output)
-        if ports_data:
-            summary_lines.append("\nPORT      STATE SERVICE      VERSION")
-            summary_lines.extend(ports_data)
-        else:
-            summary_lines.append("No open ports reported or port data available.")
+        summary_lines.append("\nDetailed port information is available in the 'Network Ports' section.")
+        summary_lines.append("Operating system details are available in the 'Operating System Detection' section (if OS scan was enabled).")
 
-        osmatch_data = host_data_dict.get("osmatch", [])
-        if osmatch_data:
-            summary_lines.append("\nOS details:")
-            for match in osmatch_data:
-                summary_lines.append(f"  Name: {match.get('name', 'N/A')}")
-                summary_lines.append(f"  Accuracy: {match.get('accuracy', 'N/A')}%")
-                if "osclass" in match:
-                    osclasses = match["osclass"] if isinstance(match["osclass"], list) else [match["osclass"]]
-                    for os_class in osclasses:
-                        if isinstance(os_class, dict):
-                            summary_lines.append("  OS Class:")
-                            summary_lines.append(
-                                f"    Type: {os_class.get('type', 'N/A')}, Vendor: {os_class.get('vendor', 'N/A')}, Family: {os_class.get('osfamily', 'N/A')}, Gen: {os_class.get('osgen', 'N/A')}"
-                            )
-        else:
-            summary_lines.append("No OS data available.")
         return "\n".join(summary_lines)
 
     def trigger_scan(self) -> None:

--- a/src/webscan_page.py
+++ b/src/webscan_page.py
@@ -49,6 +49,8 @@ class WebScanPage(Gtk.Box):
     # New UI elements for Nikto options
     nikto_format_combo_row: Adw.ComboRow = Gtk.Template.Child()
     nikto_output_file_row: Adw.EntryRow = Gtk.Template.Child()
+
+    STATUS_STYLE_CLASSES = ["success", "warning", "error", "accent"]
     nikto_output_file_button: Gtk.Button = Gtk.Template.Child()
     no404_switch: Adw.SwitchRow = Gtk.Template.Child()
     auth_bypass_switch: Adw.SwitchRow = Gtk.Template.Child()
@@ -388,6 +390,10 @@ class WebScanPage(Gtk.Box):
         self.scan_button.set_sensitive(False)
 
         if self.webscan_status_action_row:
+            style_context = self.webscan_status_action_row.get_style_context()
+            for css_class in WebScanPage.STATUS_STYLE_CLASSES:
+                style_context.remove_class(css_class)
+            style_context.add_class("accent")
             self.webscan_status_action_row.set_subtitle("Scanning...")
         if self.webscan_status_spinner:
             self.webscan_status_spinner.set_visible(True)
@@ -797,6 +803,11 @@ class WebScanPage(Gtk.Box):
 
         logger.info(f"Nikto scan task done for {target_url}.")
 
+        if self.webscan_status_action_row:
+            style_context = self.webscan_status_action_row.get_style_context()
+            for css_class in WebScanPage.STATUS_STYLE_CLASSES:
+                style_context.remove_class(css_class)
+
         try:
             returned_data = result.propagate_value()
 
@@ -851,12 +862,17 @@ class WebScanPage(Gtk.Box):
                     self.webscan_status_action_row.set_subtitle("Scan complete. See results below.")
                 else:
                     self.webscan_status_action_row.set_subtitle("Scan complete. No output received.")
+                self.webscan_status_action_row.get_style_context().add_class("success")
             elif s_out is None and s_err is None and not (isinstance(returned_data, tuple) and len(returned_data) == 2):
-                if self.webscan_status_action_row and self.webscan_status_action_row.get_subtitle() == "Scanning...":
-                    self.webscan_status_action_row.set_subtitle("Error: Unexpected scan result format.")
-            else:
+                if self.webscan_status_action_row:
+                     if self.webscan_status_action_row.get_subtitle() == "Scanning...":
+                        self.webscan_status_action_row.set_subtitle("Error: Unexpected scan result format.")
+                     self.webscan_status_action_row.get_style_context().add_class("error") # Treat as error
+            else: # No output but propagation was fine
                 if self.webscan_status_action_row:
                     self.webscan_status_action_row.set_subtitle("Scan complete. No output received.")
+                    self.webscan_status_action_row.get_style_context().add_class("success")
+
 
         except GLib.Error as e:
             logger.error(
@@ -890,6 +906,7 @@ class WebScanPage(Gtk.Box):
 
             if self.webscan_status_action_row:
                 self.webscan_status_action_row.set_subtitle(brief_user_message)
+                self.webscan_status_action_row.get_style_context().add_class("error")
             show_global_error(self, brief_user_message)
 
             if (
@@ -915,6 +932,7 @@ class WebScanPage(Gtk.Box):
 
             if self.webscan_status_action_row:
                 self.webscan_status_action_row.set_subtitle(user_message)
+                self.webscan_status_action_row.get_style_context().add_class("error")
             show_global_error(self, user_message + " Check logs for details.")
             self._update_textview(None, detailed_error_msg_for_textview, is_error_message=True)
         finally:


### PR DESCRIPTION
This commit addresses your feedback regarding UI clarity and styling:

1.  NmapPage Results Display:
    *   The "Text Scan Summary" expander has been renamed to "Scripts & Host Summary".
    *   Redundant port and OS details have been removed from this summary, as they are already present in their dedicated expanders. Placeholder text now guides you to the correct sections.
    *   The "Scripts & Host Summary" and "Operating System Detection" expanders are now collapsed by default to reduce initial information overload.

2.  Libadwaita Named Colors:
    *   Updated NmapPage (`_update_status_ui`) to use standard Libadwaita style classes (`.accent`, `.success`, `.error`, `.warning`) for its status row, replacing the previous custom (and unstyled) `-color` suffixed classes.
    *   Updated WebScanPage (`on_scan_button_clicked`, `_on_scan_task_done`) to also use these standard Libadwaita style classes for its `webscan_status_action_row`, ensuring consistent visual feedback for scan statuses (scanning, success, error).

These changes enhance UI clarity, improve consistency with the GNOME HIG, and correctly utilize Libadwaita's semantic color system.