### PR TITLE
I made some changes to fix Gtk template loading errors for pages.

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -22,6 +22,9 @@ from .constants import (
 )
 from .style_utils import apply_font_size, apply_theme
 from .http_page import HttpPage
+from .nmap_page import NmapPage
+from .dns_page import DNSPage
+from .webscan_page import WebScanPage
 
 
 gi.require_version("Adw", "1")


### PR DESCRIPTION
I added missing imports for NmapPage, DNSPage, and WebScanPage to `src/window.py`. This is intended to resolve the "Invalid object type" Gtk-CRITICAL errors that were occurring during application startup when the UI template was being parsed.

These errors were preventing the full initialization of the WoesWindow, also leading to "switcher_title or stack not found" warnings.

Note: I couldn't fully verify these fixes due to a persistent "ModuleNotFoundError: No module named 'gi'" in the execution environment.