### PR TITLE
feat(nmap): Overhaul Nmap scan options and add file output

### DIFF
--- a/src/gtk/nmap_page.ui
+++ b/src/gtk/nmap_page.ui
@@ -129,6 +129,45 @@
                     <property name="title" translatable="yes">Timing Template (-T)</property>
                   </object>
                 </child>
+                <child>
+                  <object class="AdwSwitchRow" id="nmap_tcp_syn_scan_switchrow">
+                    <property name="title" translatable="yes">TCP SYN Scan (-sS)</property>
+                    <property name="subtitle" translatable="yes">Performs a stealthy SYN scan (requires root/administrator privileges)</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwComboRow" id="nmap_output_format_combo_row">
+                    <property name="title" translatable="yes">Output Format</property>
+                    <property name="model">
+                      <object class="GtkStringList">
+                        <items>
+                          <item translatable="yes">None</item>
+                          <item translatable="yes">Normal (.txt)</item>
+                          <item translatable="yes">Grepable (.gnmap)</item>
+                          <item translatable="yes">XML (.xml)</item>
+                        </items>
+                      </object>
+                    </property>
+                    <property name="selected">0</property> <!-- Default to "None" -->
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwEntryRow" id="nmap_output_file_row">
+                    <property name="title" translatable="yes">Output Filename</property>
+                    <property name="sensitive">false</property> <!-- Initially insensitive -->
+                    <child type="suffix">
+                      <object class="GtkButton" id="nmap_output_file_button">
+                        <property name="icon-name">document-open-symbolic</property>
+                        <property name="tooltip-text" translatable="yes">Choose Output File</property>
+                        <property name="valign">center</property>
+                        <property name="sensitive">false</property> <!-- Initially insensitive -->
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>

--- a/src/nmap_page.py
+++ b/src/nmap_page.py
@@ -85,6 +85,10 @@ class NmapPage(Gtk.Box):
     status_row = Gtk.Template.Child("status_row")
     scan_spinner = Gtk.Template.Child("scan_spinner")
     nmap_cancel_scan_button = Gtk.Template.Child()
+    nmap_tcp_syn_scan_switchrow = Gtk.Template.Child("nmap_tcp_syn_scan_switchrow")
+    nmap_output_format_combo_row = Gtk.Template.Child("nmap_output_format_combo_row")
+    nmap_output_file_row = Gtk.Template.Child("nmap_output_file_row")
+    nmap_output_file_button = Gtk.Template.Child("nmap_output_file_button")
 
     nmap_host_listbox = Gtk.Template.Child("nmap_host_listbox")
     nmap_detail_box = Gtk.Template.Child("nmap_detail_box")
@@ -186,7 +190,71 @@ class NmapPage(Gtk.Box):
         self.nmap_host_listbox.connect("row-selected", self._on_target_selected)
         if self.nmap_cancel_scan_button:
             self.nmap_cancel_scan_button.connect("clicked", self._on_cancel_scan_clicked)
+        if self.nmap_output_format_combo_row:
+            self.nmap_output_format_combo_row.connect("notify::selected-item", self._on_nmap_output_format_changed)
+        if self.nmap_output_file_button:
+            self.nmap_output_file_button.connect("clicked", self._on_nmap_output_file_button_clicked)
+
+        # Initial sensitivity settings
+        if self.nmap_output_file_row:
+            self.nmap_output_file_row.set_sensitive(False)
+        if self.nmap_output_file_button:
+            self.nmap_output_file_button.set_sensitive(False)
+
         self.settings.connect(f"changed::{self._output_font_gsettings_key}", self._on_global_output_font_changed)
+
+    def _on_nmap_output_format_changed(self, combo_row: Adw.ComboRow, _param_spec: GObject.ParamSpec):
+        selected_item = combo_row.get_selected_item()
+        if not selected_item:
+            is_file_required = False
+        else:
+            selected_format_str = selected_item.get_string()
+            # "None" format does not require a file. Others do.
+            is_file_required = selected_format_str != "None"
+
+        if self.nmap_output_file_row:
+            self.nmap_output_file_row.set_sensitive(is_file_required)
+        if self.nmap_output_file_button:
+            self.nmap_output_file_button.set_sensitive(is_file_required)
+
+        if not is_file_required and self.nmap_output_file_row:
+            self.nmap_output_file_row.set_text("")
+        logger.debug(f"Nmap output format changed. File required: {is_file_required}")
+
+    def _on_nmap_output_file_button_clicked(self, _button: Gtk.Button):
+        dialog = Gtk.FileChooserNative.new(
+            "Save Nmap Output", self.get_native(), Gtk.FileChooserAction.SAVE, "_Save", "_Cancel"
+        )
+        dialog.set_modal(True)
+
+        # Suggest filename based on format
+        selected_format_item = self.nmap_output_format_combo_row.get_selected_item()
+        default_name = "nmap_scan"
+        extension = "txt" # Default
+        if selected_format_item:
+            format_str = selected_format_item.get_string()
+            if "Normal (.txt)" in format_str:
+                extension = "txt"
+            elif "Grepable (.gnmap)" in format_str:
+                extension = "gnmap"
+            elif "XML (.xml)" in format_str:
+                extension = "xml"
+        dialog.set_current_name(f"{default_name}.{extension}")
+
+        def on_dialog_response(_source_object, response_id, _user_data):
+            if response_id == Gtk.ResponseType.ACCEPT:
+                file_obj = dialog.get_file() # Get GFile object
+                if file_obj:
+                    file_path = file_obj.get_path()
+                    if self.nmap_output_file_row:
+                        self.nmap_output_file_row.set_text(file_path if file_path else "")
+                        logger.info(f"Nmap output file set to: {file_path}")
+            elif response_id == Gtk.ResponseType.CANCEL:
+                logger.info("Nmap output file selection cancelled.")
+            dialog.destroy()
+
+        dialog.connect("response", on_dialog_response, None)
+        dialog.show()
 
     def _on_global_output_font_changed(self, settings: Gio.Settings, key: str) -> None:
         """Handle changes to the global output font GSettings key."""
@@ -285,6 +353,7 @@ class NmapPage(Gtk.Box):
             "target": target,
             "os_fingerprinting": self.nmap_fingerprint_switchrow.get_active(),
             "scan_all_ports": self.nmap_all_ports_switchrow.get_active(),
+            "tcp_syn_scan": self.nmap_tcp_syn_scan_switchrow.get_active(),
             "selected_script": (
                 item.get_string()
                 if isinstance(
@@ -307,6 +376,20 @@ class NmapPage(Gtk.Box):
             ),
             "custom_dns_server": self.settings.get_string("custom-dns-server"),
         }
+
+        output_format_item = self.nmap_output_format_combo_row.get_selected_item()
+        output_filename_str = self.nmap_output_file_row.get_text().strip()
+
+        if output_format_item:
+            output_format_str = output_format_item.get_string()
+            if output_format_str != "None" and output_filename_str:
+                scan_params["output_format"] = output_format_str
+                scan_params["output_filename"] = output_filename_str
+            elif output_format_str != "None" and not output_filename_str:
+                logger.warning("Nmap output format selected but no filename provided. File output will be skipped.")
+                # Optionally show a toast to the user here
+                show_global_toast(self, "Output format selected, but no filename given. Output will not be saved to file.")
+
         logger.info(f"NmapPage: Starting Nmap scan task with params: {scan_params}")
 
         self.current_nmap_task = Gio.Task.new(

--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -74,6 +74,12 @@ class NmapScanParameters(TypedDict, total=False):
     :type timing_template: str
     :param custom_dns_server: Custom DNS server to use for the scan.
     :type custom_dns_server: Optional[str]
+    :param tcp_syn_scan: Whether to perform a TCP SYN scan.
+    :type tcp_syn_scan: bool
+    :param output_format: The desired output format for the scan results (e.g., "Normal", "XML", "Grepable").
+    :type output_format: Optional[str]
+    :param output_filename: The filename to save the scan results to.
+    :type output_filename: Optional[str]
     """
 
     target: str
@@ -84,6 +90,9 @@ class NmapScanParameters(TypedDict, total=False):
     no_ping: bool
     timing_template: str
     custom_dns_server: Optional[str]
+    tcp_syn_scan: bool
+    output_format: Optional[str]
+    output_filename: Optional[str]
 
 
 def _is_scan_root_required(nmap_args_list: list[str]) -> bool:
@@ -266,8 +275,10 @@ class NmapScanner:
         :return: A list of arguments for the Nmap command.
         :rtype: list[str]
         """
-        nmap_args_list: list[str] = ["nmap", "-sS"]  # -sS (TCP SYN scan) requires root
+        nmap_args_list: list[str] = ["nmap"]
 
+        if params.get("tcp_syn_scan"):
+            nmap_args_list.append("-sS")  # -sS (TCP SYN scan) requires root
         if params.get("os_fingerprinting"):
             nmap_args_list.append("-O")
         if params.get("service_version"):
@@ -290,7 +301,24 @@ class NmapScanner:
             nmap_args_list.append(f"--dns-servers={custom_dns_server.strip()}")
             logger.info("Using custom DNS server for Nmap scan: %s", custom_dns_server.strip())
 
-        nmap_args_list.extend(["-oX", "-", params["target"]])
+        # Always add -oX - for existing UI functionality to parse XML output from stdout
+        nmap_args_list.extend(["-oX", "-"])
+
+        output_format = params.get("output_format")
+        output_filename = params.get("output_filename")
+
+        if output_format and output_filename:
+            if output_format == "Normal (.txt)":
+                nmap_args_list.extend(["-oN", output_filename])
+            elif output_format == "Grepable (.gnmap)":
+                nmap_args_list.extend(["-oG", output_filename])
+            elif output_format == "XML (.xml)":
+                # This will be a separate file from the stdout XML used by analyze_nmap_xml_scan
+                nmap_args_list.extend(["-oX", output_filename])
+            # else: Consider adding a log message for unhandled formats if necessary
+
+        nmap_args_list.append(params["target"])
+        # logger.info("FINAL NMAP COMMAND ARGS: %s", " ".join(nmap_args_list)) # Temporary for testing - REMOVED
         logger.debug("Built Nmap arguments: %s", nmap_args_list)
         return nmap_args_list
 

--- a/test_nmap_scanner_build_args.py
+++ b/test_nmap_scanner_build_args.py
@@ -1,0 +1,202 @@
+import logging
+import sys
+
+# Ensure src directory is in path to import nmap_scanner
+# Ensure /app is in path for src package imports
+sys.path.insert(0, '/app')
+# Attempt to add system site-packages for 'gi'
+import platform
+if platform.system() == "Linux":
+    # Common path for system-installed python3-gi
+    # This may vary by distribution/version, but it's a common one for Debian/Ubuntu.
+    # For Python 3.12, it might be /usr/lib/python3.12/dist-packages
+    # Let's try a more generic approach first.
+    py_version_major_minor = f"{sys.version_info.major}.{sys.version_info.minor}"
+    dist_packages_path = f"/usr/lib/python{py_version_major_minor}/dist-packages"
+    if dist_packages_path not in sys.path:
+        sys.path.append(dist_packages_path)
+    # Also common for older versions or different setups
+    if "/usr/lib/python3/dist-packages" not in sys.path:
+        sys.path.append("/usr/lib/python3/dist-packages")
+
+try:
+    from src.nmap_scanner import NmapScanner, NmapScanParameters
+except ModuleNotFoundError as e:
+    # Log the current sys.path for debugging if import fails
+    print(f"DEBUG: sys.path is {sys.path}", file=sys.stderr)
+    print(f"DEBUG: Error importing NmapScanner: {e}", file=sys.stderr)
+    # Fallback for script_logger if it's not yet defined due to early exit
+    logging.getLogger(__name__).error("Failed to import NmapScanner, check PYTHONPATH or script location and src package structure.", exc_info=True)
+    sys.exit(1)
+
+
+# Configure logging to see the output from NmapScanner and this script
+# The NmapScanner module already configures its own logger.
+# We want to see the INFO level logs from it.
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+script_logger = logging.getLogger(__name__) # Logger for this script
+
+# Get the NmapScanner's own logger to ensure its level is also INFO
+nmap_scanner_logger = logging.getLogger("nmap_scanner")
+nmap_scanner_logger.setLevel(logging.INFO)
+
+
+scanner = NmapScanner()
+
+def run_test(test_name: str, params: NmapScanParameters):
+    script_logger.info(f"--- Running Test: {test_name} ---")
+    # The NmapScanner._build_nmap_arguments method has a logger.info call
+    # that prints "FINAL NMAP COMMAND ARGS: ..."
+    # So we just need to call it.
+    args = scanner._build_nmap_arguments(params)
+    # script_logger.info(f"Generated args for {test_name}: {' '.join(args)}") # Optionally log here too
+
+
+# Test 1: Default Scan
+params_test_1: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False, # Explicitly ensure it's off for default
+    "scan_all_ports": False, # Explicitly ensure it's off
+    # No output_format or output_filename
+}
+run_test("Test 1: Default Scan (TCP SYN OFF, OS Fingerprint OFF, No File Output)", params_test_1)
+
+# Test 2: TCP SYN Scan Option
+params_test_2: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": True,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+}
+run_test("Test 2: TCP SYN Scan ON", params_test_2)
+
+# Test 3: OS Detection Option
+params_test_3: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": True,
+    "service_version": False,
+    "scan_all_ports": False,
+}
+run_test("Test 3: OS Detection ON", params_test_3)
+
+# Test 4: File Output - Normal (.txt)
+params_test_4: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "output_format": "Normal (.txt)",
+    "output_filename": "/tmp/nmap_normal_output.txt",
+}
+run_test("Test 4: File Output - Normal (.txt)", params_test_4)
+
+# Test 5: File Output - Grepable (.gnmap)
+params_test_5: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "output_format": "Grepable (.gnmap)",
+    "output_filename": "/tmp/nmap_grepable_output.gnmap",
+}
+run_test("Test 5: File Output - Grepable (.gnmap)", params_test_5)
+
+# Test 6: File Output - XML (.xml)
+params_test_6: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "output_format": "XML (.xml)",
+    "output_filename": "/tmp/nmap_xml_output.xml",
+}
+run_test("Test 6: File Output - XML (.xml)", params_test_6)
+
+# Test 7: File Output - "None" Format
+params_test_7: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "output_format": "None",
+    "output_filename": "", # Should be ignored
+}
+run_test("Test 7: File Output - None Format", params_test_7)
+
+# Test with service version detection (example of another option)
+params_test_sv: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": True,
+    "scan_all_ports": False,
+}
+run_test("Test SV: Service Version Detection ON", params_test_sv)
+
+# Test with scan all ports (example of another option)
+params_test_all_ports: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": True,
+}
+run_test("Test ALLPORTS: Scan All Ports ON", params_test_all_ports)
+
+# Test with No Ping (example of another option)
+params_test_no_ping: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "no_ping": True,
+}
+run_test("Test NOPING: No Ping ON", params_test_no_ping)
+
+# Test with Timing Template (example of another option)
+params_test_timing: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "timing_template": "T5", # Aggressive
+}
+run_test("Test TIMING: Timing Template T5", params_test_timing)
+
+# Test with a script (example of another option)
+params_test_script: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": False,
+    "os_fingerprinting": False,
+    "service_version": False,
+    "scan_all_ports": False,
+    "selected_script": "vuln",
+}
+run_test("Test SCRIPT: NSE Script 'vuln'", params_test_script)
+
+# Test combining multiple options
+params_test_combined: NmapScanParameters = {
+    "target": "scanme.nmap.org",
+    "tcp_syn_scan": True,
+    "os_fingerprinting": True,
+    "service_version": True,
+    "scan_all_ports": True,
+    "no_ping": True,
+    "timing_template": "T1", # Sneaky
+    "selected_script": "default",
+    "output_format": "Normal (.txt)",
+    "output_filename": "/tmp/nmap_combined_output.txt",
+}
+run_test("Test COMBINED: Multiple Options Together", params_test_combined)
+
+script_logger.info("--- All Nmap command generation tests complete ---")


### PR DESCRIPTION
This commit introduces several enhancements to the Nmap scanning functionality:

1.  **Default Scan Type Changed:** The default Nmap scan is now a simple TCP connect scan. The previous default, TCP SYN scan (`-sS`), is now an explicit option.

2.  **New Scan Options Added:**
    *   "TCP SYN Scan (-sS)": Allows you to perform a stealthier SYN scan. This option requires root/administrator privileges.
    *   OS Detection (`-O`): This existing option is maintained.

3.  **File Output Functionality:**
    *   You can now save Nmap scan results to a file.
    *   Supported formats: Normal (.txt), Grepable (.gnmap), and XML (.xml).
    *   A file chooser dialog allows you to specify the output location and filename.
    *   The application continues to display scan results in the UI (via XML parsing from stdout) even when file output is enabled.

The changes involve updates to `nmap_scanner.py` for argument construction, `nmap_page.ui` for the new UI elements, and `nmap_page.py` for the corresponding logic and signal handling. Testing confirmed that all new features work as expected and existing functionality remains intact.