### PR TITLE
Fix Gtk-CRITICAL: Invalid object type in window.ui

### DIFF
--- a/src/gtk/window.ui
+++ b/src/gtk/window.ui
@@ -58,12 +58,7 @@
                         <property name="unit">px</property>
                         <property name="vexpand">True</property>
                         <child>
-                          <object class="GtkBox" id="HttpPage">
-                            <child>
-                              <object class="HttpPage">
-                              </object>
-                            </child>
-                          </object>
+                          <object class="HttpPage" id="http_page_content"/>
                         </child>
                       </object>
                     </child>
@@ -91,16 +86,10 @@
                         <property name="unit">px</property>
                         <property name="vexpand">True</property>
                         <child>
-                          <object class="GtkBox" id="NmapPage">
+                          <object class="NmapPage" id="nmap_page_content">
                             <property name="hexpand">true</property>
                             <property name="hexpand-set">true</property>
-                            <child>
-                              <object class="NmapPage">
-                                <property name="hexpand">true</property>
-                                <property name="hexpand-set">true</property>
-                                <property name="vexpand">true</property>
-                              </object>
-                            </child>
+                            <property name="vexpand">true</property>
                           </object>
                         </child>
                       </object>
@@ -130,11 +119,7 @@
                         <property name="unit">px</property>
                         <property name="vexpand">True</property>
                         <child>
-                          <object class="GtkBox" id="DnsPageBox">
-                            <child>
-                              <object class="DNSPage" id="DNSPage"/>
-                            </child>
-                          </object>
+                          <object class="DNSPage" id="dns_page_content"/>
                         </child>
                       </object>
                     </child>
@@ -162,14 +147,9 @@
                         <property name="unit">px</property>
                         <property name="vexpand">True</property>
                         <child>
-                          <object class="GtkBox" id="webscan_box">
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="WebScanPage">
-                                <property name="hexpand">true</property>
-                                <property name="vexpand">true</property>
-                              </object>
-                            </child>
+                          <object class="WebScanPage" id="webscan_page_content">
+                            <property name="hexpand">true</property>
+                            <property name="vexpand">true</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
Correctly instantiates custom page widgets (HttpPage, NmapPage, DNSPage, WebScanPage) directly in src/gtk/window.ui instead of nesting them within an unnecessary GtkBox.

This resolves the Gtk-CRITICAL error "Invalid object type 'HttpPage'" and the subsequent WARNING "switcher_title or stack not found during setup_ui."