### PR TITLE
Fix Gtk-CRITICAL by importing page modules

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -25,6 +25,10 @@ from .style_utils import apply_font_size, apply_theme
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 
+from . import http_page
+from . import nmap_page
+from . import dns_page
+from . import webscan_page
 
 # Imports for custom page widgets
 


### PR DESCRIPTION
Imports http_page, nmap_page, dns_page, and webscan_page modules in src/window.py before the WoesWindow class definition.

This ensures that the custom widget types (HttpPage, NmapPage, etc.) are registered with the GObject type system before GtkBuilder parses the WoesWindow UI template (window.ui), which uses these types.

This should resolve the Gtk-CRITICAL error "Invalid object type 'HttpPage'" and the subsequent WARNING "switcher_title or stack not found during setup_ui."