### PR TITLE
Fix ImportError in http_page.py for typing.Dict and typing.List

### DIFF
--- a/src/http_page.py
+++ b/src/http_page.py
@@ -9,7 +9,7 @@ and uses a background thread for network operations to keep the UI responsive.
 
 import logging
 from enum import Enum
-from typing import Any, dict, list, Optional
+from typing import Any, Dict, List, Optional
 
 import gi
 


### PR DESCRIPTION
Changed the import statement in `src/http_page.py` from `from typing import Any, dict, list, Optional` to
`from typing import Any, Dict, List, Optional`.

This corrects the `ImportError: cannot import name 'dict' from 'typing'` that occurred due to using lowercase 'dict' and 'list' which are not the correct type names in the `typing` module.