### PR TITLE
Fix ImportError in http_client.py for typing.Dict and typing.List

### DIFF
--- a/src/http_client.py
+++ b/src/http_client.py
@@ -1,7 +1,7 @@
 """Module for fetching HTTP headers and processing responses."""
 
 import logging
-from typing import Optional, dict, list, Any
+from typing import Optional, Dict, List, Any
 
 import requests
 import requests.utils  # For urlparse, urlunparse


### PR DESCRIPTION
Changed the import statement in `src/http_client.py` from `from typing import Optional, dict, list, Any` to
`from typing import Optional, Dict, List, Any`.

This corrects the `ImportError: cannot import name 'dict' from 'typing'` that occurred due to using lowercase 'dict' and 'list' which are not the correct type names in the `typing` module. This is a follow-up to a similar fix in `http_page.py`.