### PR TITLE
Fix ImportError in nmap_scanner.py and verify codebase

### DIFF
--- a/src/nmap_scanner.py
+++ b/src/nmap_scanner.py
@@ -15,7 +15,7 @@ import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Any, dict, list, Optional, TypedDict, Union
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 try:
     from gi.repository import Gio


### PR DESCRIPTION
Changed the import statement in `src/nmap_scanner.py` from `from typing import Any, dict, list, Optional, TypedDict, Union` to `from typing import Any, Dict, List, Optional, TypedDict, Union`.

This corrects the `ImportError: cannot import name 'dict' from 'typing'`. Additionally, verified with grep that no other instances of incorrect `typing.dict` or `typing.list` imports exist in the codebase.

This completes the fixes for this type of ImportError across the project.